### PR TITLE
fix: bind dashboard to loopback by default (HOST to opt into all-interfaces)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ https://github.com/user-attachments/assets/f4e50137-31b5-426f-a6ed-b83f829b4a2c
 
 ```bash
 npx pxpipe-proxy                                  # proxy on 127.0.0.1:47821
-ANTHROPIC_BASE_URL=http://localhost:47821 claude  # point Claude Code at it
+ANTHROPIC_BASE_URL=http://127.0.0.1:47821 claude  # point Claude Code at it
 ```
 
 Open <http://127.0.0.1:47821/> for a live dashboard: tokens saved, per-session

--- a/src/node.ts
+++ b/src/node.ts
@@ -37,6 +37,11 @@ import {
  *  control. No CLI flags beyond --help/--version. */
 interface RuntimeConfig {
   port: number;
+  /** Interface to bind. Defaults to 127.0.0.1 (loopback only) — the dashboard
+   *  is unauthenticated and serves captured request context, so it must not be
+   *  exposed to the LAN by default. Set HOST=0.0.0.0 to opt into all interfaces
+   *  (e.g. reaching the dashboard from another device / the host of a container). */
+  host: string;
   upstream: string;
   openAIUpstream: string;
   openAIApiKey?: string;
@@ -101,6 +106,8 @@ function parseCli(argv: string[]): RuntimeConfig {
   const sharedUpstream = process.env.PXPIPE_UPSTREAM;
   return {
     port: Number(process.env.PORT ?? 47821),
+    // Loopback by default; opt into all-interfaces exposure explicitly via HOST.
+    host: process.env.HOST?.trim() || '127.0.0.1',
     upstream: process.env.ANTHROPIC_UPSTREAM ?? sharedUpstream ?? 'https://api.anthropic.com',
     openAIUpstream: process.env.OPENAI_UPSTREAM ?? sharedUpstream ?? 'https://api.openai.com',
     openAIApiKey: process.env.OPENAI_API_KEY,
@@ -140,6 +147,9 @@ Flags:
 
 Environment:
   PORT                    listen port (default 47821)
+  HOST                    interface to bind (default 127.0.0.1, loopback only).
+                          Set 0.0.0.0 to expose the dashboard off-host — note it
+                          is unauthenticated and serves captured request context.
   PXPIPE_UPSTREAM         upstream API base for every API family
   ANTHROPIC_UPSTREAM      Anthropic API base; overrides PXPIPE_UPSTREAM
                            (default https://api.anthropic.com)
@@ -1055,8 +1065,19 @@ async function main(): Promise<void> {
       });
   });
 
-  server.listen(opts.port, () => {
-    console.log(`[pxpipe] listening on http://127.0.0.1:${opts.port}`);
+  // IPv6 literals need bracket notation to form a valid URL (http://[::1]:47821).
+  const displayHost = opts.host.includes(':') ? `[${opts.host}]` : opts.host;
+  const isLoopbackHost =
+    opts.host === '127.0.0.1' || opts.host === 'localhost' || opts.host === '::1';
+  server.listen(opts.port, opts.host, () => {
+    console.log(`[pxpipe] listening on http://${displayHost}:${opts.port}`);
+    if (!isLoopbackHost) {
+      console.warn(
+        `[pxpipe] WARNING: bound to ${opts.host} — the unauthenticated dashboard ` +
+          `(captured request context + kill switch) is reachable off-host. ` +
+          `Unset HOST to restrict to loopback.`,
+      );
+    }
     const routes = resolveUpstreams(config);
     console.log(`[pxpipe] anthropic upstream → ${routes.anthropic}`);
     console.log(`[pxpipe] openai upstream → ${routes.openai}`);


### PR DESCRIPTION
## What

The Node proxy binds the dashboard/proxy to **all interfaces** rather than loopback. `src/node.ts` called `server.listen(opts.port, …)` with no host argument, so Node binds `0.0.0.0`/`::` — while the startup log prints `http://127.0.0.1:${port}`, which reads as loopback-only.

This PR binds `127.0.0.1` by default and adds a `HOST` env var to explicitly opt into all-interfaces exposure (container / remote-dashboard use cases), with a startup warning when bound off-loopback.

## Why it matters

The dashboard is unauthenticated and serves sensitive captured content:

- `GET /api/image-source` returns `source_text` — the system prompt / tool docs / file reads / history that were rendered into images, i.e. your actual context.
- `GET /api/sessions`, `/proxy-stats`, `/proxy-recent` return session metadata, all with `access-control-allow-origin: *`.
- `POST /fragments/toggle`, `/api/compression` flip the compression kill switch (CSRF).

With the all-interfaces bind, anyone who can reach the port — another device on the same Wi‑Fi/office LAN, or another container on a shared network — can read that context or disable compression.

Reproduced on a fresh clone (`node dist/node.js`):

```
$ ss -ltn | grep 47821
LISTEN 0  511  *:47821  *:*            # all interfaces, not 127.0.0.1
$ curl http://<host-LAN-IP>:47821/proxy-stats
HTTP 200 + access-control-allow-origin: *   # readable off-host
```

## The fix

- `HOST` defaults to `127.0.0.1` (loopback only).
- `HOST=0.0.0.0` (or `::`) restores the previous all-interfaces behavior for anyone who relied on it (e.g. viewing the dashboard from the host of a container), and prints a warning.
- IPv6-aware: `::1`/`localhost` count as loopback (no warning); the startup URL is bracket-formatted (`http://[::1]:47821`).

Verified on this branch:

```
default (no HOST):  binds 127.0.0.1 only; off-host curl → connection refused
HOST=0.0.0.0:       binds 0.0.0.0; off-host curl → HTTP 200; prints WARNING
HOST=::1:           binds [::1]; valid bracketed URL; no warning
```

`pnpm run typecheck` and `pnpm run build` pass. I also drove a live end-to-end Fable‑5 Claude Code session through the patched build (loopback) — it worked normally and reproduced the expected input‑token savings (~57% end‑to‑end on that session, prompt‑caching intact), so the bind change doesn't affect the proxy path.

### One follow-up left to your call (IPv6-first hosts)

To keep the documented client URL working, I pinned the quickstart example to `127.0.0.1`. The `demo/cost-ab` and `demo/effective-context` scripts still use `http://localhost:4782x`, which on an IPv6-first host (where `localhost` → `::1`) won't reach an IPv4-only loopback bind. Two ways to resolve, your preference — pin those demo URLs to `127.0.0.1` too, or bind both loopback families (`127.0.0.1` + `::1`) by default. I kept this PR to the security fix + primary path; happy to add either.

## Related findings (not addressed here — flagging, happy to follow up)

From the same review; kept out to stay surgical:

1. **Cloudflare Worker as an open key-spending proxy.** `src/worker.ts` injects `env.ANTHROPIC_API_KEY` / `env.OPENAI_API_KEY` upstream with no caller auth. If the Worker is deployed with a key secret set (as `wrangler.toml` documents), anyone who learns the `workers.dev` URL can spend the key. Consider a shared-secret/allowlist check, or a "never deploy with an embedded key unless you gate it" note.
2. **`access-control-allow-origin: *`** on the dashboard JSON endpoints isn't needed for the same-origin htmx UI and widens the exposure above; consider dropping it.
3. **4xx request-body persistence.** Transformed bodies (prompts/code, not the key) are gzipped to `events.jsonl` / `~/.pxpipe/4xx-bodies/`, and on the Worker path to Cloudflare logs by default — worth a note in the README's "honest part."

Found during a security review of the proxy path. Nice project — the `count_tokens` counterfactual measurement is a genuinely clean way to prove the savings.
