### PR TITLE
docs(readme): fix Library use example — package name and renderTextToImages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ sparse prose stays text. Events log to `~/.pxpipe/events.jsonl`.
 ## Library use (no proxy)
 
 ```ts
-import { renderTextToPngs, transformAnthropicMessages } from "pxpipe";
+import { renderTextToImages, transformAnthropicMessages } from "pxpipe-proxy";
 
-const imgs = await renderTextToPngs(toolResultText);            // RenderedImage[]
+const { pages } = await renderTextToImages(toolResultText);     // pages[i].png: Uint8Array
 const { body, applied, info } = await transformAnthropicMessages({
   body: requestBytes,
   model: "claude-fable-5",


### PR DESCRIPTION
Fixes #8.

The `Library use` example imported `renderTextToPngs` from `"pxpipe"`, but the package is `pxpipe-proxy` and the root barrel (`src/core/index.ts`) exports `renderTextToImages`, not `renderTextToPngs` — so the snippet failed on both the specifier and the function name.

- import from `pxpipe-proxy`
- use `renderTextToImages`, and show its real return shape (`const { pages } = ...`, `pages[i].png`)

Docs-only; `pnpm run typecheck && pnpm test && pnpm run build` stay green.
