### PR TITLE
fix(openai): image array-form Responses system/developer content

### DIFF
--- a/src/core/openai.ts
+++ b/src/core/openai.ts
@@ -805,7 +805,9 @@ export async function transformOpenAIResponses(
     const r = (item as ResponsesInputItem).role;
     if (r !== 'system' && r !== 'developer') continue;
     const content = (item as ResponsesInputItem).content;
-    const text = typeof content === 'string' ? content : '';
+    // content may be a string OR an array of input_text parts (both are valid
+    // Responses shapes for system/developer items) — read either form.
+    const text = responsesContentText(content);
     if (!text) continue;
     authorityDocs.push(`## ${String(r).toUpperCase()} MESSAGE\n${text}`);
     systemTexts.push(text);
@@ -918,14 +920,19 @@ export async function transformOpenAIResponses(
     req.instructions = RESPONSES_POINTER;
   }
 
-  // Replace system/developer input items with pointer.
+  // Replace system/developer input items with a pointer. Mirror the collection
+  // gate above for BOTH content shapes: a string becomes the pointer string; an
+  // input_text part array keeps its array shape with a single pointer part, so a
+  // request the caller sent as parts is not silently reshaped into a string.
   if (!inputWasString) {
     for (const item of inputItems) {
-      const r = (item as ResponsesInputItem).role;
-      if (r !== 'system' && r !== 'developer') continue;
-      const content = (item as ResponsesInputItem).content;
-      if (typeof content === 'string' && content.length > 0) {
-        (item as ResponsesInputItem).content = RESPONSES_POINTER;
+      const it = item as ResponsesInputItem;
+      if (it.role !== 'system' && it.role !== 'developer') continue;
+      const content = it.content;
+      if (typeof content === 'string') {
+        if (content.length > 0) it.content = RESPONSES_POINTER;
+      } else if (Array.isArray(content) && responsesContentText(content).length > 0) {
+        it.content = [{ type: 'input_text', text: RESPONSES_POINTER }];
       }
     }
   }

--- a/tests/openai-gpt5.test.ts
+++ b/tests/openai-gpt5.test.ts
@@ -256,6 +256,35 @@ describe('transformOpenAIResponses (gpt-5.6)', () => {
     expect(tools[0]!.parameters?.properties?.x?.description).toBeUndefined();
   });
 
+  it('images developer/system items whose content is an input_text part array, not just a string', async () => {
+    // Responses allows message content as a string OR an array of parts. The
+    // array form for a developer/system item used to be dropped: not imaged and
+    // not stubbed, so the verbose text rode uncompressed as native input.
+    const body = enc.encode(JSON.stringify({
+      model: 'gpt-5.6',
+      input: [
+        { role: 'developer', content: [{ type: 'input_text', text: BIG_INSTRUCTIONS }] },
+        { role: 'user', content: 'Please do the thing.' },
+      ],
+    }));
+
+    const result = await transformOpenAIResponses(body, { charsPerToken: 1, minCompressChars: 1 });
+    expect(result.info.compressed).toBe(true);
+    expect(result.info.imageCount).toBeGreaterThan(0);
+    // The array-form developer text is now counted as static context.
+    expect(result.info.staticChars).toBeGreaterThanOrEqual(BIG_INSTRUCTIONS.length);
+
+    const out = JSON.parse(dec.decode(result.body)) as { input: Array<{ role: string; content: unknown }> };
+    const dev = out.input.find((i) => i.role === 'developer')!;
+    // Array shape preserved, but the big text is gone — replaced by a pointer part.
+    expect(Array.isArray(dev.content)).toBe(true);
+    const devParts = dev.content as Array<{ type: string; text?: string }>;
+    expect(devParts).toHaveLength(1);
+    expect(devParts[0]!.type).toBe('input_text');
+    expect(devParts[0]!.text).toContain('rendered into image');
+    expect(JSON.stringify(dev.content)).not.toContain('These are detailed');
+  });
+
   it('images GPT Responses tool definitions even when there is no instruction context', async () => {
     const body = enc.encode(JSON.stringify({
       model: 'gpt-5.6',


### PR DESCRIPTION
Fixes #14.

The Responses API allows a message item's `content` to be a string or an array of `input_text` parts. `transformOpenAIResponses` only read the string form (`typeof content === 'string' ? content : ''`), so a developer/system item sent as parts was neither imaged nor stubbed, and the string-only pointer replacement left it in place.

- collect static context via the existing `responsesContentText()` helper (reads both shapes)
- pointer replacement now handles arrays too, preserving the array shape (`[{ type: 'input_text', text: RESPONSES_POINTER }]`) so a parts-form request isn't reshaped into a string
- test: a developer item with array content is imaged (`staticChars` counts it) and its outgoing content is a single pointer part, original text gone

typecheck/test/build green.
