### PR TITLE
fix(openai): record outgoingTextChars for Responses transforms

### DIFF
--- a/src/core/openai.ts
+++ b/src/core/openai.ts
@@ -418,6 +418,32 @@ function countOutgoingTextChars(req: OpenAIChatRequest): number {
   return n;
 }
 
+/** Outgoing text-char denominator for the GPT Responses regression, mirroring
+ *  countOutgoingTextChars for Chat: instructions + message-item text (string or
+ *  input_text parts) + flat tool name/description/parameters. input_image base64
+ *  is excluded on purpose — it is image cost, not text (responsesContentText
+ *  already drops non-text parts). */
+function countResponsesOutgoingTextChars(req: ResponsesRequest): number {
+  let n = 0;
+  if (typeof req.instructions === 'string') n += req.instructions.length;
+  if (typeof req.input === 'string') {
+    n += req.input.length;
+  } else if (Array.isArray(req.input)) {
+    for (const item of req.input) {
+      n += responsesContentText((item as ResponsesInputItem).content).length;
+    }
+  }
+  if (Array.isArray(req.tools)) {
+    for (const tool of req.tools) {
+      if (!isFlatFunctionTool(tool)) continue;
+      if (typeof tool.name === 'string') n += tool.name.length;
+      if (typeof tool.description === 'string') n += tool.description.length;
+      if (tool.parameters !== undefined) n += safeStringifyLen(tool.parameters);
+    }
+  }
+  return n;
+}
+
 function safeStringifyLen(v: unknown): number {
   try {
     return JSON.stringify(v)?.length ?? 0;
@@ -979,6 +1005,9 @@ export async function transformOpenAIResponses(
 
   if (rewrittenTools !== undefined) req.tools = rewrittenTools;
 
+  // Regression denominator, same as the Chat path — Responses was the only
+  // transform that never recorded it.
+  info.outgoingTextChars = countResponsesOutgoingTextChars(req);
   info.compressed = true;
   return { body: new TextEncoder().encode(JSON.stringify(req)), info };
 }

--- a/tests/openai-gpt5.test.ts
+++ b/tests/openai-gpt5.test.ts
@@ -318,6 +318,19 @@ describe('transformOpenAIResponses (gpt-5.6)', () => {
     expect(textParts.some((p) => p.text?.includes('Do the thing'))).toBe(true);
   });
 
+  it('records outgoingTextChars for compressed Responses requests (denominator parity with Chat)', async () => {
+    const body = enc.encode(JSON.stringify({
+      model: 'gpt-5.6',
+      instructions: BIG_INSTRUCTIONS,
+      input: [{ role: 'user', content: 'Please do the thing.' }],
+    }));
+    const result = await transformOpenAIResponses(body, { charsPerToken: 1, minCompressChars: 1 });
+    expect(result.info.compressed).toBe(true);
+    // Chat set this via countOutgoingTextChars; Responses never recorded it, so
+    // the tokens ≈ α·outgoingTextChars + β·imagePixels denominator was missing.
+    expect(result.info.outgoingTextChars).toBeGreaterThan(0);
+  });
+
   it('returns compressed=false with not_profitable/below_min reason for small input', async () => {
     const body = enc.encode(JSON.stringify({
       model: 'gpt-5.6',

--- a/tests/openai-gpt5.test.ts
+++ b/tests/openai-gpt5.test.ts
@@ -318,17 +318,59 @@ describe('transformOpenAIResponses (gpt-5.6)', () => {
     expect(textParts.some((p) => p.text?.includes('Do the thing'))).toBe(true);
   });
 
-  it('records outgoingTextChars for compressed Responses requests (denominator parity with Chat)', async () => {
+  it('records outgoingTextChars for compressed Responses requests, counting text but not image base64', async () => {
     const body = enc.encode(JSON.stringify({
       model: 'gpt-5.6',
       instructions: BIG_INSTRUCTIONS,
       input: [{ role: 'user', content: 'Please do the thing.' }],
+      tools: [{ type: 'function', name: 'do_thing', description: 'pick a thing', parameters: { type: 'object', properties: {} } }],
     }));
     const result = await transformOpenAIResponses(body, { charsPerToken: 1, minCompressChars: 1 });
     expect(result.info.compressed).toBe(true);
-    // Chat set this via countOutgoingTextChars; Responses never recorded it, so
-    // the tokens ≈ α·outgoingTextChars + β·imagePixels denominator was missing.
-    expect(result.info.outgoingTextChars).toBeGreaterThan(0);
+    const otc = result.info.outgoingTextChars ?? 0;
+    expect(otc).toBeGreaterThan(0);
+
+    const out = JSON.parse(dec.decode(result.body)) as {
+      instructions?: string;
+      input: Array<{ content?: unknown }>;
+      tools?: Array<{ name?: string; description?: string; parameters?: unknown }>;
+    };
+
+    // A real rendered image rode along as input_image base64 (thousands of chars)…
+    let imageChars = 0;
+    for (const item of out.input) {
+      const c = item.content;
+      if (Array.isArray(c)) {
+        for (const p of c as Array<{ type?: string; image_url?: unknown }>) {
+          if (p.type === 'input_image' && typeof p.image_url === 'string') imageChars += p.image_url.length;
+        }
+      }
+    }
+    expect(imageChars).toBeGreaterThan(2000);
+    // …and the denominator must NOT include any of that base64.
+    expect(otc).toBeLessThan(imageChars);
+
+    // It DOES count the instructions pointer + input_text parts + tool fields.
+    let textChars = 0;
+    if (typeof out.instructions === 'string') textChars += out.instructions.length;
+    for (const item of out.input) {
+      const c = item.content;
+      if (typeof c === 'string') textChars += c.length;
+      else if (Array.isArray(c)) {
+        for (const p of c as Array<{ type?: string; text?: string }>) {
+          if (p.type === 'input_text' && typeof p.text === 'string') textChars += p.text.length;
+        }
+      }
+    }
+    for (const t of out.tools ?? []) {
+      if (typeof t.name === 'string') textChars += t.name.length;
+      if (typeof t.description === 'string') textChars += t.description.length;
+      if (t.parameters !== undefined) textChars += JSON.stringify(t.parameters).length;
+    }
+    // otc equals the text sum up to the '\n\n' separators responsesContentText adds
+    // between array parts (a handful of chars) — and is nowhere near the base64.
+    expect(otc).toBeGreaterThanOrEqual(textChars);
+    expect(otc).toBeLessThanOrEqual(textChars + 64);
   });
 
   it('returns compressed=false with not_profitable/below_min reason for small input', async () => {


### PR DESCRIPTION
Fixes #16.

The Chat path set `info.outgoingTextChars = countOutgoingTextChars(req)`; the Responses path didn't set it at all, so compressed Responses rows silently carried no regression denominator.

- add `countResponsesOutgoingTextChars()`: instructions + message-item text (string or `input_text` parts, via `responsesContentText` so `input_image` base64 is excluded) + flat tool name/description/parameters
- set it on the Responses success path, mirroring Chat
- test asserts `outgoingTextChars > 0` for a compressed Responses request

typecheck/test/build green.
