### PR TITLE
chore(tsconfig): drop stale dashboard build comment and vestigial exclude

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,12 +25,6 @@
   "exclude": [
     "node_modules",
     "dist",
-    "legacy",
-    // src/dashboard/ is the Svelte browser bundle — compiled separately by
-    // scripts/build-dashboard-ui.mjs with the DOM lib + esbuild-svelte. The
-    // root tsconfig targets Node + WebWorker (no `document` / `localStorage`),
-    // so type-checking dashboard sources here would always fail. They're still
-    // covered by `tsconfig.dashboard.json` for editor + CI type-checking.
-    "src/dashboard"
+    "legacy"
   ]
 }


### PR DESCRIPTION
Fixes #22.

The `exclude` comment described `src/dashboard` as a Svelte bundle compiled by `scripts/build-dashboard-ui.mjs` and covered by `tsconfig.dashboard.json` — none of which exist. It's actually server-rendered htmx + Alpine (inlined by `scripts/vendor-ui.mjs`), and CI runs only the root typecheck/test/build.

The exclude was also a no-op: `src/dashboard.ts` imports `./dashboard/fragments.js` and `./dashboard/types.js`, so tsc already type-checks and emits `dist/dashboard/*` transitively. Verified — removing the exclude leaves typecheck green and `dist/dashboard/*` emits identically with or without it — so I dropped both the false comment and the dead entry.

typecheck/test/build green.
