### PR TITLE
chore(ci): least-privilege permissions and cancel-stale concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege: CI only reads the checkout; it never writes to the repo,
+# creates releases, or comments. Override per-job if a future job needs more.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. a force-push to a PR branch).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #28.

- add top-level `permissions: { contents: read }` — the job only reads the checkout, so scope `GITHUB_TOKEN` down to least privilege
- add a per-ref `concurrency` group with `cancel-in-progress` so a new push to a PR cancels its superseded run

No job/step logic changed; Node stays on 22. YAML validated.
