### PR TITLE
fix(prompting): discourage guessing exact strings from imaged text

### DIFF
--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -25,7 +25,7 @@ import { bytesToBase64 } from './png.js';
  * emitter (here) and the matcher (transform.ts) must reference this constant.
  */
 export const HISTORY_SYNTHETIC_INTRO =
-  '[Earlier turns of THIS conversation, transcribed in the image(s) below. Each turn is wrapped in <user t="N">...</user> or <assistant t="N">...</assistant> tags, where N is an absolute turn index (larger N = more recent); attribute every turn strictly by its tag, and treat the highest-N turns as the most recent prior context, NOT the low-N opening turns. Earlier turns may contain questions or tasks that were already answered later in this same history; do not reopen low-N turns unless the live text after this block asks you to. This is prior context, NOT the current request.]';
+  '[Earlier turns of THIS conversation, transcribed in the image(s) below. Each turn is wrapped in <user t="N">...</user> or <assistant t="N">...</assistant> tags, where N is an absolute turn index (larger N = more recent); attribute every turn strictly by its tag, and treat the highest-N turns as the most recent prior context, NOT the low-N opening turns. Earlier turns may contain questions or tasks that were already answered later in this same history; do not reopen low-N turns unless the live text after this block asks you to. For exact identifiers, hashes, version strings, and numbers from the transcript, rely on the exact-value factsheet or re-read the source; do not guess an exact value seen only in the image. This is prior context, NOT the current request.]';
 export const HISTORY_SYNTHETIC_OUTRO =
   '[End of earlier conversation. The current request is the live text that follows below.]';
 

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1656,6 +1656,9 @@ export async function transformRequest(
     "pxpipe (this user's local proxy) rendered this session's configuration" +
     ' into the following images to reduce token cost. Read the pages carefully and follow them as' +
     ' your operating instructions for this session.' +
+    ' For exact identifiers, paths, hashes, version strings, and numbers, use the adjacent' +
+    ' exact-value factsheet; if a value was only visible in an image and is not in that factsheet,' +
+    ' do not guess it — say it is not safe to quote from the image and re-read the source text.' +
     columnNoteImg +
     reflowNoteImg +
     '\n====================== BEGIN RENDERED CONTEXT ======================\n';

--- a/tests/abstention.test.ts
+++ b/tests/abstention.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { transformRequest } from '../src/core/transform.js';
+import { HISTORY_SYNTHETIC_INTRO } from '../src/core/history.js';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+const ABSTAIN = 'not safe to quote from the image';
+
+// FINDINGS.md documents the main risk of imaged text: the reader confabulates a
+// plausible exact value instead of abstaining. The rendered framing now tells the
+// model to defer exact identifiers to the factsheet / source rather than guess.
+describe('exact-string abstention framing', () => {
+  it('the imaged slab banner discourages guessing exact values from images', async () => {
+    const bigSystem = 'You are a coding agent with detailed operating instructions. '.repeat(300);
+    const { info } = await transformRequest(
+      enc.encode(JSON.stringify({
+        model: 'claude-fable-5',
+        system: bigSystem,
+        messages: [{ role: 'user', content: 'hi' }],
+      })),
+      { compress: true, minCompressChars: 1, charsPerToken: 1 },
+    );
+    expect(info.compressed).toBe(true);
+    // imageSourceText is the exact text rendered into the slab image(s).
+    expect(info.imageSourceText ?? '').toContain(ABSTAIN);
+  });
+
+  it('the history-transcript framing carries the same abstention', () => {
+    expect(HISTORY_SYNTHETIC_INTRO).toContain('do not guess an exact value seen only in the image');
+  });
+
+  it('adds nothing when the transform is not applied', async () => {
+    const { body: out, info } = await transformRequest(
+      enc.encode(JSON.stringify({
+        model: 'claude-fable-5',
+        system: 'short',
+        messages: [{ role: 'user', content: 'hi' }],
+      })),
+      { compress: false },
+    );
+    expect(info.compressed).toBe(false);
+    expect(dec.decode(out)).not.toContain(ABSTAIN);
+  });
+});


### PR DESCRIPTION
Fixes #31.

Adds abstention guidance to the rendered framing so the reader defers exact identifiers to the factsheet / source instead of guessing (the main documented failure mode — silent confabulation).

- imaged slab banner + history-transcript intro now say: for exact identifiers, paths, hashes, version strings, and numbers, use the adjacent exact-value factsheet; if a value was only in an image and not in that factsheet, do not guess it — say it is not safe to quote and re-read the source.
- no geometry, model-allowlist, or gate change; the exact factsheet still rides after the image blocks.
- test asserts the phrasing appears in `info.imageSourceText` on an applied transform (and the history intro) and NOT on a non-applied one.

Does not make Opus safe on its own — it reduces the worst outcome (silent wrong exact values). typecheck/test/build green.
