### PR TITLE
fix(factsheet): protect high-risk camelCase identifiers without evicting tier-0

### DIFF
--- a/src/core/factsheet.ts
+++ b/src/core/factsheet.ts
@@ -30,6 +30,12 @@ const PATTERNS: readonly RegExp[] = [
   // Ticket/advisory-style codes: uppercase hyphenated with ≥1 digit (PROJ-1482,
   // CVE-2024-30078, AUDIT-ZX9). Digit lookahead is bounded → no backtracking blowup.
   /\b(?=[A-Z0-9-]{0,119}\d)[A-Z][A-Z0-9]+(?:-[A-Z0-9]+)+\b/g,
+  // camelCase / PascalCase identifiers with ≥2 case humps (tokenLedgerShard,
+  // extractFactSheetTokens). Scoped to multi-hump so ordinary words (getFoo, isX)
+  // are ignored. These land in tier 1 (see priorityTier), so tier-0 tokens
+  // (SHAs/nums/flags/tickets) are never evicted by them — this is the residual
+  // 2/15 miss class flagged in LEGIBILITY-AUDIT, kept below the byte-critical shapes.
+  /\b[A-Za-z][a-z0-9]*(?:[A-Z][a-z0-9]+){2,}\b/g,
 ];
 
 const MIN_LEN = 3;

--- a/tests/factsheet.test.ts
+++ b/tests/factsheet.test.ts
@@ -4,7 +4,40 @@ import {
   extractFactSheetEntries,
   extractFactSheetEntriesAllPages,
   factSheetText,
+  MAX_TOKENS,
 } from '../src/core/factsheet.js';
+
+describe('camelCase identifier protection (LEGIBILITY-AUDIT residual misses)', () => {
+  it('extracts multi-hump camelCase / PascalCase but ignores ordinary words', () => {
+    const toks = extractFactSheetTokens(
+      'call extractFactSheetTokens on tokenLedgerShard and TokenLedgerShard, not getFoo or isReady',
+    );
+    expect(toks).toContain('extractFactSheetTokens');
+    expect(toks).toContain('tokenLedgerShard');
+    expect(toks).toContain('TokenLedgerShard');
+    expect(toks).not.toContain('getFoo'); // single hump — below the ≥2 threshold
+    expect(toks).not.toContain('isReady');
+  });
+
+  it('never lets camelCase (tier 1) evict tier-0 SHAs', () => {
+    // 70 distinct lowercase-hex SHAs (tier 0) — more than the 64 budget on their own.
+    const shas = Array.from({ length: 70 }, (_, i) => `deadbeef${i.toString(16).padStart(4, '0')}`);
+    const camels = Array.from({ length: 70 }, (_, i) => `fooBarBaz${i}`);
+    const kept = extractFactSheetTokens([...shas, ...camels].join(' '));
+    expect(kept.length).toBe(MAX_TOKENS);
+    // The whole budget is tier-0 SHAs; no camelCase displaced one.
+    expect(kept.some((t) => t.startsWith('fooBarBaz'))).toBe(false);
+    expect(kept.every((t) => t.startsWith('deadbeef'))).toBe(true);
+  });
+
+  it('caps and orders camelCase deterministically past the budget', () => {
+    const camels = Array.from({ length: 100 }, (_, i) => `alphaBetaGamma${i}`);
+    const a = extractFactSheetTokens(camels.join(' '));
+    const b = extractFactSheetTokens([...camels].reverse().join(' '));
+    expect(a.length).toBe(MAX_TOKENS);
+    expect(a).toEqual(b); // order is a pure function of the token set, not input order
+  });
+});
 
 describe('factsheet extraction', () => {
   it('captures precision-critical, hard-to-OCR tokens', () => {


### PR DESCRIPTION
Fixes #33.

Adds the residual miss class from `LEGIBILITY-AUDIT-2026-07-01.md` (camelCase code identifiers) to the factsheet, scoped so it can't crowd out byte-critical tokens.

- new extraction pattern for camelCase/PascalCase with ≥2 case humps (so `getFoo`/`isReady` are ignored; `tokenLedgerShard`/`extractFactSheetTokens` are caught)
- they land in tier 1 (priorityTier default) — strictly below tier-0 SHAs/UUIDs/CONST_IDS/tickets/flags/numbers, which are still filled first. `MAX_TOKENS=64` and the URL cap are unchanged.
- tests: multi-hump extraction (single-hump ignored); 70 SHAs + 70 camelCase → the 64-slot budget stays all SHAs (no eviction); 100 camelCase → deterministic order regardless of input order

Helps both Fable and Opus on exact camelCase recall without changing the budget or evicting anything. typecheck/test/build green.
