### PR TITLE
feat(mitm): transparent Fable compression for Claude Desktop (CONNECT proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ normally — pxpipe compresses the *request* only, never the model's output.
 Recent turns stay text; the system prompt, tool docs, and older bulk history
 are imaged.
 
+## Claude Desktop (`pxpipe mitm`)
+
+Claude Desktop pins `ANTHROPIC_BASE_URL`, so the base-URL proxy above can't see
+its traffic. `mitm` mode instead runs a local HTTP CONNECT proxy that
+TLS-terminates **only** `api.anthropic.com` (with a CA it generates in
+`~/.pxpipe/mitm/`) and raw-tunnels every other host untouched:
+
+```bash
+pxpipe mitm install     # generate CA, wire ~/.claude/settings.json, add a launchd keepalive
+# fully quit + reopen Claude Desktop, run a Fable task, watch http://127.0.0.1:47821/
+pxpipe mitm uninstall   # revert everything
+```
+
+`install` sets `HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS` in the `env` block of
+`~/.claude/settings.json` (which Desktop leaves free) and removes any
+`ANTHROPIC_BASE_URL` override. Because mitm decrypts `api.anthropic.com`
+locally, your API/OAuth token is visible in plaintext to the proxy (loopback
+only, never written to `events.jsonl`). The CA signs only `api.anthropic.com`.
+`pxpipe mitm doctor` checks the wiring.
+
 ## The honest part
 
 - **It is lossy.** Exact 12-char hex strings in dense imaged content:

--- a/docs/superpowers/specs/2026-07-04-mitm-mode-design.md
+++ b/docs/superpowers/specs/2026-07-04-mitm-mode-design.md
@@ -1,0 +1,200 @@
+# pxpipe `mitm` mode — transparent Fable compression for Claude Desktop
+
+**Date:** 2026-07-04
+**Status:** Approved — implementing (branch `feat/mitm-mode`)
+**Target:** upstream feature in `teamchong/pxpipe` (branch `feat/mitm-mode`)
+
+## Problem
+
+pxpipe intercepts by *swapping the base URL* (`ANTHROPIC_BASE_URL=http://127.0.0.1:47821`).
+That works for the terminal `claude` CLI, but **Claude Desktop's embedded
+claude-code cannot be routed this way**: Desktop injects
+`ANTHROPIC_BASE_URL=https://api.anthropic.com` into the child process it spawns,
+and Claude Code's `settings.json` `env` block only fills *unset* variables — it
+cannot override one Desktop has already set. Users who work exclusively in
+Desktop get no compression today.
+
+## Key insight (measured, not assumed)
+
+Desktop pins `ANTHROPIC_BASE_URL`, but leaves `HTTPS_PROXY`, `HTTP_PROXY`, and
+`NODE_EXTRA_CA_CERTS` **unset**. Claude Code's `settings.json` `env` block *does*
+apply to Desktop's claude-code for vars Desktop doesn't set (verified:
+`ENABLE_TOOL_SEARCH` from that block reaches Desktop sessions). So we can inject
+a proxy + trusted CA that Desktop's Node runtime will honor — without touching
+the base URL.
+
+### De-risk spike (2026-07-04) — the fatal risk is dead
+
+Ran Desktop's exact env (`HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS`) against a
+throwaway `mitmproxy` and drove the standalone CLI through it:
+
+- **HTTPS_PROXY honored** — claude routed all HTTPS through the proxy.
+- **No cert-pinning on `api.anthropic.com`** — mitmproxy decrypted the real
+  inference call `POST https://api.anthropic.com/v1/messages?beta=true` (plus
+  `bootstrap`, `oauth/account/settings`, `v1/mcp_servers`), all in plaintext.
+- **OAuth survives the hop** — `claude -p` returned a real `200`.
+- **Design constraint found for free:** routing *everything* through MITM broke
+  a non-Node client — `api.github.com` failed with `unknown ca` (git/native
+  TLS uses the system trust store, not `NODE_EXTRA_CA_CERTS`). Therefore the
+  proxy **must MITM only `api.anthropic.com` and raw-tunnel every other host.**
+
+## Goals
+
+- Transparent ~60–70% Fable input-token reduction inside Claude Desktop, with
+  no change to how the user uses Desktop.
+- Reuse pxpipe's entire compression engine (transform, gate, cache-alignment,
+  events, dashboard, kill switch) — the only new surface is the interception
+  front-end.
+- Survive Desktop / claude-code version updates (config + local proxy, never
+  binary patching).
+- Global scope: the same injection routes both Desktop **and** the terminal CLI
+  through the MITM proxy.
+
+## Non-goals
+
+- Compressing anything that doesn't reach `api.anthropic.com/v1/messages`
+  (system prompt/tool docs are static + prompt-cached anyway).
+- Intercepting non-Anthropic traffic (explicitly tunneled untouched).
+- Windows support in v1 (macOS/Linux; openssl assumed present).
+- Changing the compression behavior itself (identical to base-URL mode).
+
+## Architecture
+
+pxpipe's core is already runtime-agnostic: `createProxy(config)` returns
+`handle: (Request) => Promise<Response>`, and `src/node.ts` bridges a raw HTTP
+socket to it via `toWebRequest → handle → writeWebResponse`. MITM mode swaps
+*only* the front door — the socket source — and reuses everything behind it.
+
+```
+Desktop claude-code (Fable)
+  │  HTTPS_PROXY → CONNECT <host>:443
+  ▼
+pxpipe mitm listener (127.0.0.1:47821)
+  ├─ host !== api.anthropic.com ──► net.connect + raw pipe  (git/npm/mcp untouched)
+  └─ host === api.anthropic.com:
+        reply "200 Connection Established"
+        wrap client socket in tls.TLSSocket  (our api.anthropic.com leaf,
+                                               ALPN forced to http/1.1)
+        http.Server.emit('connection', tlsSocket)   ← SAME handler as node.ts
+           │  (dashboard routes, then handle(webReq))
+           ▼
+        handle() → transformAnthropicMessages (Fable-only, gated) → forward to
+        real https://api.anthropic.com → stream response back (never modified)
+```
+
+The request the decrypted `http.Server` sees has `Host: api.anthropic.com` and
+`url = /v1/messages?beta=true`; `handle()` forwards to `config.upstream`
+(`https://api.anthropic.com`, unchanged) using that path. Transform touches the
+**request only**; the streamed SSE response is piped through untouched, exactly
+as today.
+
+## Components
+
+### 1. CA manager (`src/core/mitm-ca.ts`, new — small)
+- On first run, generate a local root CA (key + self-signed cert) and an
+  `api.anthropic.com` leaf (SAN `DNS:api.anthropic.com`) signed by it. Store
+  under `~/.pxpipe/mitm/` at `0600`; CA valid ~1 year, leaf regenerated as
+  needed.
+- Generation shells out to `openssl` (already present; MITM mode is inherently
+  Node/local-only, so no new runtime dependency — consistent with pxpipe's
+  "pure-JS runtime, canvas is build-time only" ethos). Fallback: `node-forge`
+  only if openssl is absent.
+- Expose the CA cert path (for `NODE_EXTRA_CA_CERTS` injection) and the leaf
+  cert+key (for the TLS server).
+
+### 2. Selective MITM front-end (`src/core/mitm.ts`, new — the core work)
+- `net.Server` on `host:port`; handle the `connect` event (HTTP CONNECT).
+- `host === 'api.anthropic.com'` → 200, wrap socket in `tls.TLSSocket`
+  (`{ key, cert, ALPNProtocols: ['http/1.1'] }`), hand to the shared
+  `http.Server` via `emit('connection', ...)`.
+- any other host → `net.connect(port, host)` + bidirectional `pipe` (raw
+  tunnel, no interception, no cert needed for those hosts).
+- Also accept plain (non-CONNECT) requests to the port so the dashboard at
+  `http://127.0.0.1:47821/` keeps working unchanged.
+
+### 3. Server-setup reuse (`src/node.ts`, refactor)
+- Extract the tracker + dashboard + `ProxyConfig` + `createServer` request
+  handler from `main()` into a shared `startProxyServer(opts)` so both the
+  default base-URL mode and the new MITM mode use the identical handler,
+  events pipeline, and dashboard. MITM mode calls it to get the request
+  handler, then front-ends it with the CONNECT listener.
+
+### 4. CLI + installer (`bin/cli.js` / `src/node.ts`, follows the `export`
+   subcommand pattern)
+- `pxpipe mitm` — run the proxy in MITM mode (generates CA on first run; prints
+  the CA path and the exact `settings.json` `env` block + launchd snippet to
+  add).
+- `pxpipe mitm install` — idempotent: back up and patch `~/.claude/settings.json`
+  `env` with `HTTPS_PROXY`, `HTTP_PROXY`, `NODE_EXTRA_CA_CERTS`; install a
+  launchd agent (mirrors the user's existing `com.akhilesh.pxpipe.plist`,
+  `KeepAlive`).
+- `pxpipe mitm uninstall` — revert settings.json from backup, remove the agent.
+- `pxpipe mitm doctor` — check proxy up, CA present + injected, port bound.
+
+### 5. Activation (config, global scope)
+`~/.claude/settings.json` `env`:
+```json
+{ "env": {
+    "HTTPS_PROXY": "http://127.0.0.1:47821",
+    "HTTP_PROXY": "http://127.0.0.1:47821",
+    "NODE_EXTRA_CA_CERTS": "/Users/<you>/.pxpipe/mitm/ca.crt"
+} }
+```
+Desktop leaves these unset, so they apply to both Desktop and CLI sessions.
+
+## Security model
+
+- Loopback only (`127.0.0.1`), same as the existing proxy.
+- Our CA signs **one** host (`api.anthropic.com`); no other traffic is
+  decrypted, so a compromise of our CA can only impersonate that one host to
+  *this* machine's Node clients.
+- MITM decrypts the request, so the OAuth bearer token is visible to the proxy
+  in plaintext. It is forwarded as-is and stored nowhere. Document this
+  explicitly; it is the inherent cost of request-body compression.
+- `install` writes the CA into `NODE_EXTRA_CA_CERTS` (Node trust) only — it does
+  **not** add the CA to the system keychain, limiting blast radius.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| claude-code negotiates HTTP/2 to Anthropic | Force `ALPNProtocols: ['http/1.1']` on our TLS server → client downgrades. undici defaults to h1.1 anyway. |
+| Streaming (SSE) responses | Response is piped through untouched; transform only ever touches the request (unchanged from base-URL mode). |
+| Non-Node clients break (git → github) | MITM **only** `api.anthropic.com`; raw-tunnel all other hosts (the spike lesson). |
+| Proxy down → Desktop can't reach the API | launchd `KeepAlive`; `pxpipe mitm doctor`; one-command `uninstall`. |
+| Desktop/claude-code updates | Injection is Claude Code config + a local proxy — independent of Desktop internals; no binary patching. |
+| Upstream cert rotation | We validate the *real* upstream cert with Node's default trust; no pinning on our side. |
+
+## Testing
+
+- **Integration (the gate):** automate the spike — start `pxpipe mitm` on a
+  test port with a temp CA, run `claude -p` (standalone CLI) through it with
+  `HTTPS_PROXY`+`NODE_EXTRA_CA_CERTS`, assert (a) `200`, (b) a compressed
+  `/v1/messages` event in the events log, (c) a non-anthropic host still
+  tunnels (a raw `https` GET to a second host succeeds — proves selective
+  interception).
+- **Unit:** CA/leaf generation (valid chain, correct SAN); CONNECT routing
+  (api.anthropic.com → MITM, other → tunnel); reuse pxpipe's existing transform
+  unit tests unchanged.
+- **Fidelity:** reuse pxpipe's eval harness / dashboard — a Fable Desktop
+  session shows compressed events and correct answers.
+
+## Rollout
+
+1. Ship `pxpipe mitm` + `install`/`uninstall`/`doctor`.
+2. User runs `pxpipe mitm install`, fully restarts Desktop, verifies the
+   dashboard shows compressed Fable events.
+3. Document the OAuth-decryption tradeoff and the uninstall path in the README.
+
+## Resolved decisions
+
+- **Cert generation:** shell out to `openssl` (already present; no new runtime
+  dependency, consistent with pxpipe's pure-JS-runtime ethos). `node-forge`
+  fallback only if openssl is absent.
+- **CLI/Desktop coexistence:** global injection, a **single MITM proxy** for
+  both Desktop and CLI. The old base-URL `com.akhilesh.pxpipe` agent is retired
+  by `pxpipe mitm install` (documented; reversible via `uninstall`).
+- **Activation surface:** `pxpipe mitm` subcommand (matches the existing
+  `export` subcommand), not an env flag.
+- **Requirement:** must work across **all** Claude Desktop app chats (global
+  scope, confirmed by the user).

--- a/eval/glyph-confusability/analyze.mjs
+++ b/eval/glyph-confusability/analyze.mjs
@@ -1,0 +1,137 @@
+/**
+ * Offline glyph-confusability analyzer — the lever-C ("font is a lever") analog
+ * of the opus-density dry-run. NO API KEY NEEDED.
+ *
+ * Decodes the REAL production font (Spleen 5x8, src/core/atlas.ts) and the AA
+ * grayscale atlas (src/core/atlas-gray.ts), simulates the vision encoder's
+ * low-pass (a 3x3 box blur on the 5x8 cell — the encoder sees each tiny glyph
+ * at ~sub-patch resolution), and ranks glyph pairs by post-blur shape distance.
+ *
+ * Purpose: cheaply screen WHICH glyphs a legibility-hardened font must fix
+ * (lever C3), and whether AA (token-free, lever C1) separates confusables
+ * better than the 1-bit atlas. This is a PROXY: pixel distance != VLM confusion.
+ * Ground truth still needs the scored run. Its job is to focus that run.
+ */
+import {
+  ATLAS_PIXELS, ATLAS_OFFSETS, ATLAS_WIDE_FLAGS,
+  ATLAS_CELL_W, ATLAS_CELL_H, atlasRank,
+} from '../../src/core/atlas.js';
+import {
+  ATLAS_GRAY_PIXELS, ATLAS_GRAY_OFFSETS, ATLAS_GRAY_WIDE_FLAGS,
+  ATLAS_GRAY_CELL_W, ATLAS_GRAY_CELL_H, atlasGrayRank,
+} from '../../src/core/atlas-gray.js';
+
+// --- decode a glyph to a Float32 [0..1] cell -------------------------------
+function decode1bit(cp) {
+  const rank = atlasRank(cp);
+  if (rank < 0 || ATLAS_WIDE_FLAGS[rank] === 1) return null;
+  const w = ATLAS_CELL_W, h = ATLAS_CELL_H, off = ATLAS_OFFSETS[rank];
+  const px = new Float32Array(w * h);
+  for (let gy = 0; gy < h; gy++)
+    for (let gx = 0; gx < w; gx++) {
+      const bit = off + gy * w + gx;
+      px[gy * w + gx] = (ATLAS_PIXELS[bit >>> 3] >>> (7 - (bit & 7))) & 1;
+    }
+  return { w, h, px };
+}
+function decodeGray(cp) {
+  const rank = atlasGrayRank(cp);
+  if (rank < 0 || ATLAS_GRAY_WIDE_FLAGS[rank] === 1) return null;
+  const w = ATLAS_GRAY_CELL_W, h = ATLAS_GRAY_CELL_H, off = ATLAS_GRAY_OFFSETS[rank];
+  const px = new Float32Array(w * h);
+  for (let gy = 0; gy < h; gy++)
+    for (let gx = 0; gx < w; gx++)
+      px[gy * w + gx] = ATLAS_GRAY_PIXELS[off + gy * w + gx] / 255;
+  return { w, h, px };
+}
+
+// --- 3x3 box blur (edge-clamped) = cheap vision-encoder low-pass -----------
+function blur({ w, h, px }) {
+  const out = new Float32Array(w * h);
+  for (let y = 0; y < h; y++)
+    for (let x = 0; x < w; x++) {
+      let s = 0, n = 0;
+      for (let dy = -1; dy <= 1; dy++)
+        for (let dx = -1; dx <= 1; dx++) {
+          const yy = y + dy, xx = x + dx;
+          if (yy < 0 || yy >= h || xx < 0 || xx >= w) continue;
+          s += px[yy * w + xx]; n++;
+        }
+      out[y * w + x] = s / n;
+    }
+  return out;
+}
+// cosine distance in [0,2]; 0 = identical shape. Magnitude-independent so
+// sparse (`.`) and dense (`M`) glyphs are compared on shape, not ink amount.
+function cosDist(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  if (na === 0 || nb === 0) return null;
+  return 1 - dot / Math.sqrt(na * nb);
+}
+const disp = (cp) => cp === 0x20 ? "␠" : String.fromCodePoint(cp);
+
+function buildBlurred(decode) {
+  const m = new Map();
+  for (let cp = 0x21; cp <= 0x7e; cp++) { // printable ASCII (skip space)
+    const g = decode(cp);
+    if (!g) continue;
+    const b = blur(g);
+    let ink = 0; for (const v of b) ink += v;
+    if (ink < 1e-6) continue;
+    m.set(cp, b);
+  }
+  return m;
+}
+function allPairs(blurred) {
+  const cps = [...blurred.keys()], pairs = [];
+  for (let i = 0; i < cps.length; i++)
+    for (let j = i + 1; j < cps.length; j++) {
+      const d = cosDist(blurred.get(cps[i]), blurred.get(cps[j]));
+      if (d != null) pairs.push([cps[i], cps[j], d]);
+    }
+  pairs.sort((a, b) => a[2] - b[2]);
+  return pairs;
+}
+
+const oneBit = buildBlurred(decode1bit);
+const gray = buildBlurred(decodeGray);
+const pairs1 = allPairs(oneBit);
+const percentile = (arr, p) => arr[Math.floor((arr.length - 1) * p)][2];
+const p10 = percentile(pairs1, 0.10);
+
+console.log(`\n=== FONT-LEVER SCREEN — Spleen 5x8, ${oneBit.size} ASCII glyphs, ${pairs1.length} pairs ===`);
+console.log(`(post-blur cosine distance; lower = more confusable. proxy, not ground truth)\n`);
+
+console.log(`--- 24 most-confusable glyph pairs (globally, 1-bit prod atlas) ---`);
+for (const [a, b, d] of pairs1.slice(0, 24))
+  console.log(`  '${disp(a)}' ~ '${disp(b)}'   dist=${d.toFixed(4)}`);
+
+// classic OCR confusable classes that matter for exact-string recall
+const CLASSES = [
+  ['0','O'],['0','o'],['0','D'],['0','Q'],['O','o'],['O','Q'],
+  ['1','l'],['1','I'],['1','i'],['l','I'],['l','i'],['I','i'],['1','|'],['l','|'],['I','|'],
+  ['5','S'],['5','s'],['S','s'],['8','B'],['6','G'],['6','b'],['9','g'],['9','q'],['g','q'],
+  ['2','Z'],['2','z'],['Z','z'],['c','e'],['c','o'],['n','h'],['u','v'],['v','y'],
+  [':',';'],['.',','],['`',"'"],["'",'"'],['{','('],['(','['],['-','_'],['/','\\'],
+];
+const distOf = (blurred, a, b) => {
+  const x = blurred.get(a.codePointAt(0)), y = blurred.get(b.codePointAt(0));
+  return x && y ? cosDist(x, y) : null;
+};
+console.log(`\n--- classic confusable classes: 1-bit vs AA-gray (RISK = below 10th pct = ${p10.toFixed(4)}) ---`);
+let sum1 = 0, sumG = 0, nCmp = 0, risk1 = 0, riskG = 0;
+for (const [a, b] of CLASSES) {
+  const d1 = distOf(oneBit, a, b), dg = distOf(gray, a, b);
+  if (d1 == null) continue;
+  const f1 = d1 < p10 ? 'RISK' : 'ok  ';
+  const gStr = dg == null ? '  n/a ' : dg.toFixed(4);
+  const better = dg != null ? (dg > d1 ? '↑AA-safer' : dg < d1 ? '↓AA-worse' : '=') : '';
+  console.log(`  '${a}'~'${b}'  1bit=${d1.toFixed(4)} [${f1}]  aa=${gStr}  ${better}`);
+  sum1 += d1; if (dg != null) { sumG += dg; nCmp++; } if (d1 < p10) risk1++;
+  if (dg != null && dg < p10) riskG++;
+}
+console.log(`\n  mean separation  1-bit=${(sum1 / CLASSES.length).toFixed(4)}  AA-gray=${(sumG / nCmp).toFixed(4)}`);
+console.log(`  classes flagged RISK  1-bit=${risk1}  AA-gray=${riskG}   (higher separation / fewer RISK = better)`);
+console.log(`\nNote: multi-char merges (rn/m, cl/d, vv/w) are invisible to single-glyph`);
+console.log(`distance — those remain for the scored run. This screens single glyphs only.\n`);

--- a/eval/glyph-confusability/harden.mjs
+++ b/eval/glyph-confusability/harden.mjs
@@ -37,29 +37,49 @@ function decode(cp) {
  * touched; every other codepoint in the alphabet is byte-identical to the
  * shipping atlas.
  *
- * VALIDATED (kept) — '2' and '5': each broke an ACCIDENTAL pixel-for-pixel
- * overlap with its confusable partner (2/Z were bit-identical at row 5; 5/S
- * at row 2) by adding a single new pixel at a position the partner does not
- * share. Full-alphabet rescan: target pair improved, zero new worst-24 entrants.
+ * VALIDATED technique: de-collide by RELOCATING or REMOVING a pixel the
+ * confusable partner already shares by coincidence — never by adding mass
+ * ("bolding"). Round 1 confirmed this on '2' (broke a fully shared row 5 with
+ * 'Z') and '5' (fully shared row 2 with 'S'): both improved their target pair
+ * with zero new worst-24 entrants. Round 1 also confirmed the FAILURE mode:
+ * bolding '0'/'B'/'G' (bigger dot / wider bars) pushed each toward a generic
+ * dense blob that OTHER bold capitals also blur into — 'B' got WORSE on its
+ * own target (-0.0026) and crashed B~O into the danger zone; '0' created two
+ * new collisions (0~8, 0~9); 'G' barely moved and converged the same way as B.
  *
- * REVERTED (do not ship) — '0', 'B', 'G': the initial attempt "bolded" the
- * glyph (wider bars, bigger center dot) to differentiate it from its partner.
- * That is the WRONG technique at 5x8 + blur + cosine-distance: adding ink
- * pushes a glyph toward a generic dense-blob shape that OTHER bold capitals
- * also blur into, so it drifts closer to unrelated letters even as the one
- * targeted pair moves. Measured: 'B' (wider bars) made 8~B worse (-0.0026)
- * and crashed B~O to 0.0196 (deep new worst-24 entrant) while drifting
- * closer to ~20 unrelated letters (H, K, N, M, O, G, ...). '0' (bigger dot)
- * improved 0~O only slightly (+0.0043) while creating two new worst-24
- * collisions (0~8, 0~9) — net negative. 'G' (bigger dot) barely moved 6~G
- * and caused the same broad convergence as B.
+ * Round 2 (also REVERTED) — tried the same de-collision technique on '0' and
+ * 'G'. Both failed, for a second, distinct reason:
  *
- * Lesson for any future glyph-hardening attempt: de-collide by RELOCATING or
- * REMOVING a pixel the partner shares (see '2'/'5'), never by adding mass.
+ * '0': removed the 2-pixel diagonal that differed from 'O' (to dodge
+ *   collateral with '8'/'9'/'@') and added back only 1 new pixel elsewhere.
+ *   That's a net REDUCTION in the 0-vs-O distinguishing budget (2 -> 1
+ *   pixels) — an arithmetic error, not a collision issue. Measured: 0~O
+ *   distance nearly HALVED (0.0158 -> 0.0077) and created a new 0~8
+ *   collision. Reverted.
+ *
+ * 'G': reused the exact edit shape that worked for '5' (row "#...." ->
+ *   "##..." at a fully-shared row with '6'), same technique, same row shape.
+ *   It still failed: G~6 got worse (0.0605 -> 0.0481) and G drifted broadly
+ *   closer to a dozen+ unrelated letters (B, E, M, N, P, R, b, f, h, k, l, n,
+ *   p, r, t). Conclusion: the '2'/'5' technique does not mechanically
+ *   generalize — '0' and '6'/'G' sit in a denser neighborhood of similarly-
+ *   shaped glyphs than the more isolated '2'/'Z' and '5'/'S' pairs, so a
+ *   single relocated pixel has broader ripple effects there. Reverted.
+ *
+ * '8'/'B': NO patch attempted. 'B' and '8' have no accidental full-row
+ *   identity to exploit; their only difference (col 0) is already maximal
+ *   within the sole free dimension. No de-collision move is available.
+ *
+ * Net conclusion after 2 rounds: '2' and '5' are the only glyphs where this
+ * technique cleanly worked. '0', '6'/'G', '8'/'B' need either a completely
+ * different technique, a bigger pixel budget (i.e. lever A, not C), or
+ * accepting the risk they carry as-is. Do not attempt a third blind round —
+ * this has now failed twice for the same three glyphs by two different
+ * mechanisms; escalate to real font-design tooling or drop them.
  */
 const PATCHES = {
-  0x35: { name: '5', edits: [[2, 1, 1]] },                 // #.... -> ##...  (flag serif vs S)
-  0x32: { name: '2', edits: [[5, 1, 1]] },                 // #.... -> ##...  (breaks shared px w/ Z)
+  0x35: { name: '5', edits: [[2, 1, 1]] },  // #.... -> ##...  (flag serif vs S)
+  0x32: { name: '2', edits: [[5, 1, 1]] },  // #.... -> ##...  (breaks shared row w/ Z)
 };
 
 function applyPatch(glyph, edits) {
@@ -123,11 +143,11 @@ const pairsAfter = allPairs(after);
 
 console.log(`\n=== LEVER C3 — hardened-glyph rescan (${Object.keys(PATCHES).length} glyphs patched, full ${before.size}-glyph alphabet) ===\n`);
 
-// 1. Target pairs: did they actually improve? Only the validated de-collision
-// patches ('2','5') are applied above; '0'/'B'/'G' are listed for reference —
-// they are UNPATCHED (reverted), so their delta should read ~0 here.
+// 1. Target pairs: did they actually improve? Only '5' and '2' are patched
+// (validated across 2 rounds). '0'/'B'/'G' are reference/reverted — see the
+// PATCHES comment for why 2 different techniques both failed on them.
 const TARGETS = [['5', 'S'], ['2', 'Z'], ['0', 'O'], ['8', 'B'], ['6', 'G']];
-console.log('--- target pairs: before -> after (only 5/S, 2/Z are patched; 0/O, 8/B, 6/G are reference/reverted) ---');
+console.log('--- target pairs: before -> after (only 5/S, 2/Z patched; 0/O, 8/B, 6/G unpatched — no technique found that survives the full rescan) ---');
 for (const [a, b] of TARGETS) {
   const cpa = a.codePointAt(0), cpb = b.codePointAt(0);
   const d0 = cosDist(before.get(cpa), before.get(cpb));

--- a/eval/glyph-confusability/harden.mjs
+++ b/eval/glyph-confusability/harden.mjs
@@ -1,0 +1,187 @@
+/**
+ * Lever C3 prototype: apply minimal, hand-designed pixel patches to the 5
+ * highest-risk digit/letter glyphs (identified by analyze.mjs) and re-run the
+ * SAME offline confusability screen against the FULL ASCII alphabet — not just
+ * the target pairs — to check for (a) improved separation on the fixed pairs
+ * and (b) no NEW collisions introduced elsewhere.
+ *
+ * Design rule: patch only ONE member of each confusable pair, leaving its
+ * counterpart (O, S, Z, 6, 8) byte-identical to production, so nothing else
+ * in the alphabet that already reads correctly can regress.
+ *
+ * This is a proxy screen (pixel/cosine distance after a blur), not ground
+ * truth — it exists to decide whether a real bitmap-font edit + scored eval is
+ * worth doing at all, and to focus that eval on the pairs that matter.
+ */
+import {
+  ATLAS_PIXELS, ATLAS_OFFSETS, ATLAS_WIDE_FLAGS, ATLAS_CELL_W, ATLAS_CELL_H, atlasRank,
+} from '../../src/core/atlas.js';
+
+const W = ATLAS_CELL_W, H = ATLAS_CELL_H; // 5, 8 — production cell, unchanged
+
+function decode(cp) {
+  const rank = atlasRank(cp);
+  if (rank < 0 || ATLAS_WIDE_FLAGS[rank] === 1) return null;
+  const off = ATLAS_OFFSETS[rank];
+  const px = new Float32Array(W * H);
+  for (let gy = 0; gy < H; gy++)
+    for (let gx = 0; gx < W; gx++) {
+      const bit = off + gy * W + gx;
+      px[gy * W + gx] = (ATLAS_PIXELS[bit >>> 3] >>> (7 - (bit & 7))) & 1;
+    }
+  return { w: W, h: H, px };
+}
+
+/**
+ * row,col ink edits: 1 = force filled, 0 = force empty. Only these glyphs are
+ * touched; every other codepoint in the alphabet is byte-identical to the
+ * shipping atlas.
+ *
+ * VALIDATED (kept) — '2' and '5': each broke an ACCIDENTAL pixel-for-pixel
+ * overlap with its confusable partner (2/Z were bit-identical at row 5; 5/S
+ * at row 2) by adding a single new pixel at a position the partner does not
+ * share. Full-alphabet rescan: target pair improved, zero new worst-24 entrants.
+ *
+ * REVERTED (do not ship) — '0', 'B', 'G': the initial attempt "bolded" the
+ * glyph (wider bars, bigger center dot) to differentiate it from its partner.
+ * That is the WRONG technique at 5x8 + blur + cosine-distance: adding ink
+ * pushes a glyph toward a generic dense-blob shape that OTHER bold capitals
+ * also blur into, so it drifts closer to unrelated letters even as the one
+ * targeted pair moves. Measured: 'B' (wider bars) made 8~B worse (-0.0026)
+ * and crashed B~O to 0.0196 (deep new worst-24 entrant) while drifting
+ * closer to ~20 unrelated letters (H, K, N, M, O, G, ...). '0' (bigger dot)
+ * improved 0~O only slightly (+0.0043) while creating two new worst-24
+ * collisions (0~8, 0~9) — net negative. 'G' (bigger dot) barely moved 6~G
+ * and caused the same broad convergence as B.
+ *
+ * Lesson for any future glyph-hardening attempt: de-collide by RELOCATING or
+ * REMOVING a pixel the partner shares (see '2'/'5'), never by adding mass.
+ */
+const PATCHES = {
+  0x35: { name: '5', edits: [[2, 1, 1]] },                 // #.... -> ##...  (flag serif vs S)
+  0x32: { name: '2', edits: [[5, 1, 1]] },                 // #.... -> ##...  (breaks shared px w/ Z)
+};
+
+function applyPatch(glyph, edits) {
+  const px = new Float32Array(glyph.px); // copy — never mutate the decoded original
+  for (const [row, col, val] of edits) px[row * W + col] = val;
+  return { w: W, h: H, px };
+}
+
+function blur({ w, h, px }) {
+  const out = new Float32Array(w * h);
+  for (let y = 0; y < h; y++)
+    for (let x = 0; x < w; x++) {
+      let s = 0, n = 0;
+      for (let dy = -1; dy <= 1; dy++)
+        for (let dx = -1; dx <= 1; dx++) {
+          const yy = y + dy, xx = x + dx;
+          if (yy < 0 || yy >= h || xx < 0 || xx >= w) continue;
+          s += px[yy * w + xx]; n++;
+        }
+      out[y * w + x] = s / n;
+    }
+  return out;
+}
+function cosDist(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  if (na === 0 || nb === 0) return null;
+  return 1 - dot / Math.sqrt(na * nb);
+}
+const disp = (cp) => (cp === 0x20 ? '␠' : String.fromCodePoint(cp));
+
+/** Build the blurred set for the FULL printable-ASCII alphabet, with the 5
+ *  patches applied where relevant — every other glyph is the real atlas bitmap. */
+function buildAlphabet(patched) {
+  const m = new Map();
+  for (let cp = 0x21; cp <= 0x7e; cp++) {
+    const raw = decode(cp);
+    if (!raw) continue;
+    const g = patched && PATCHES[cp] ? applyPatch(raw, PATCHES[cp].edits) : raw;
+    let ink = 0; for (const v of g.px) ink += v;
+    if (ink < 1e-6) continue;
+    m.set(cp, blur(g));
+  }
+  return m;
+}
+function allPairs(blurred) {
+  const cps = [...blurred.keys()], pairs = [];
+  for (let i = 0; i < cps.length; i++)
+    for (let j = i + 1; j < cps.length; j++) {
+      const d = cosDist(blurred.get(cps[i]), blurred.get(cps[j]));
+      if (d != null) pairs.push([cps[i], cps[j], d]);
+    }
+  pairs.sort((a, b) => a[2] - b[2]);
+  return pairs;
+}
+
+const before = buildAlphabet(false);
+const after = buildAlphabet(true);
+const pairsBefore = allPairs(before);
+const pairsAfter = allPairs(after);
+
+console.log(`\n=== LEVER C3 — hardened-glyph rescan (${Object.keys(PATCHES).length} glyphs patched, full ${before.size}-glyph alphabet) ===\n`);
+
+// 1. Target pairs: did they actually improve? Only the validated de-collision
+// patches ('2','5') are applied above; '0'/'B'/'G' are listed for reference —
+// they are UNPATCHED (reverted), so their delta should read ~0 here.
+const TARGETS = [['5', 'S'], ['2', 'Z'], ['0', 'O'], ['8', 'B'], ['6', 'G']];
+console.log('--- target pairs: before -> after (only 5/S, 2/Z are patched; 0/O, 8/B, 6/G are reference/reverted) ---');
+for (const [a, b] of TARGETS) {
+  const cpa = a.codePointAt(0), cpb = b.codePointAt(0);
+  const d0 = cosDist(before.get(cpa), before.get(cpb));
+  const d1 = cosDist(after.get(cpa), after.get(cpb));
+  const delta = d1 - d0;
+  console.log(
+    `  '${a}'~'${b}'  ${d0.toFixed(4)} -> ${d1.toFixed(4)}   Δ=${delta >= 0 ? '+' : ''}${delta.toFixed(4)}  ${delta > 0 ? 'IMPROVED' : delta < 0 ? 'WORSE' : '='}`,
+  );
+}
+
+// 2. Global regression check: for each patched glyph, did its distance to any
+//    OTHER (unrelated) glyph get worse enough to create a NEW top-24 collision?
+const top24Before = new Set(pairsBefore.slice(0, 24).map(([a, b]) => `${a},${b}`));
+const top24After = pairsAfter.slice(0, 24);
+console.log('\n--- full-alphabet worst-24 pairs AFTER patch (flag any NOT in the original worst-24) ---');
+let newEntrants = 0;
+for (const [a, b, d] of top24After) {
+  const key = `${a},${b}`;
+  const isNew = !top24Before.has(key);
+  const patchedHere = PATCHES[a] || PATCHES[b] ? ' (involves a patched glyph)' : '';
+  if (isNew) newEntrants++;
+  console.log(`  '${disp(a)}'~'${disp(b)}'  dist=${d.toFixed(4)}${patchedHere}${isNew ? '  <-- NEW to worst-24' : ''}`);
+}
+console.log(`\nNew entrants into the global worst-24 after patching: ${newEntrants}`);
+
+// 3. Did any patched glyph get CLOSER to some third, previously-unrelated glyph?
+console.log('\n--- did a patched glyph move closer to any OTHER (non-target) glyph? ---');
+let regressions = 0;
+for (const cpStr of Object.keys(PATCHES)) {
+  const cp = Number(cpStr);
+  const name = PATCHES[cp].name;
+  for (const otherCp of before.keys()) {
+    if (otherCp === cp) continue;
+    // skip the intended target partner — that's the pair we WANT to change
+    const targetPartner = TARGETS.find(([a, b]) => a === name || b === name);
+    const partnerCp = targetPartner ? (targetPartner[0] === name ? targetPartner[1] : targetPartner[0]).codePointAt(0) : -1;
+    if (otherCp === partnerCp) continue;
+    const d0 = cosDist(before.get(cp), before.get(otherCp));
+    const d1 = cosDist(after.get(cp), after.get(otherCp));
+    if (d0 == null || d1 == null) continue;
+    if (d1 < d0 - 0.01) { // more than trivial drift
+      regressions++;
+      console.log(`  '${name}' moved closer to '${disp(otherCp)}': ${d0.toFixed(4)} -> ${d1.toFixed(4)}`);
+    }
+  }
+}
+if (regressions === 0) console.log('  none — no patched glyph became more confusable with any unrelated glyph.');
+
+console.log('\nNote: still a pixel-distance proxy, not model ground truth. Decides whether a');
+console.log('real font edit + scored run is worth doing; does not replace the scored run.\n');
+
+// Sanity check: '*'~'m' is unpatched — confirm its pairwise distance is
+// EXACTLY unchanged (any "new to worst-24" flag on it is a rank-boundary
+// artifact from 2/5 vacating higher slots, not a real regression).
+const dStar0 = cosDist(before.get(0x2a), before.get(0x6d));
+const dStar1 = cosDist(after.get(0x2a), after.get(0x6d));
+console.log(`\nsanity: '*'~'m' distance before=${dStar0.toFixed(6)} after=${dStar1.toFixed(6)} (must be identical)`);

--- a/eval/opus-density/README.md
+++ b/eval/opus-density/README.md
@@ -19,9 +19,41 @@ fixed battery of questions against the image and scores the answers.
   - `5x8` — production density (`{cellWBonus:0, cellHBonus:0}`)
   - `7x10` — `{cellWBonus:2, cellHBonus:2}`
   - `9x12` — `{cellWBonus:4, cellHBonus:4}`
+  - `5x8+sharp` — production density **+ lever B** (below)
+  - `7x10+sharp` — larger cell **+ lever B**
   Each variant keeps the ≤1568×728 page cap, so images stay in Anthropic's
   linear-billing window (no server-side downscale) and page count rises as
   density drops.
+
+**Lever A (density)** trades savings for OCR fidelity on *everything*.
+**Lever B (content-aware keep-sharp, `+sharp`)** targets only the failure class:
+`src/core/sharp.ts` detects exact-string spans (hex/hash, UUID, file path, CLI
+flag, camel/snake identifier, port/long-number, URL) and lifts them out of the
+imaged body into a small **verbatim text sidecar** the model reads exactly —
+prose stays imaged, so savings are largely preserved. B mechanically guarantees
+correct recall for every *detected* span (it is text, not pixels); the residual
+risk is detector recall on real content, which the scored run + `tests/sharp.test.ts`
+measure. A and B compose.
+
+### Dry-run cost accounting (measured, no API key)
+
+`tsx run.mjs` with no `ANTHROPIC_API_KEY` prints the token math (savings gate #3).
+On the built-in fixture (baseline text = 1335 tok):
+
+| Variant | dims | img tok | sidecar | total | savings |
+|---|---|---|---|---|---|
+| `5x8` (prod, image-all) | 1568×128 | 280 | – | 280 | **79%** |
+| `7x10` (A) | 1562×228 | 504 | – | 504 | 62% |
+| `9x12` (A) | 1565×344 | 728 | – | 728 | 45% |
+| `5x8+sharp` (B) | 1568×120 | 280 | +56 (6 spans) | 336 | **75%** |
+| `7x10+sharp` (A+B) | 1562×198 | 448 | +56 (6 spans) | 504 | 62% |
+
+**Read:** B lifts all 6 exact-string spans to verbatim text for only ~4pp of
+savings (79→75%), vs A burning 17–34pp on a blunt cell enlargement. B is the
+high-leverage lever — it spends savings *only* on the content that actually
+breaks OCR. Final variant choice is **gated on the scored run** (gist==baseline,
+zero silent-wrong exact strings); enabling Opus in production stays out of scope
+until those numbers clear.
 - **Models:** `claude-opus-4-8`, `claude-fable-5` (both high-res tier).
 - **Tasks** (each answer committed before ground truth is revealed):
   1. exact 12-char hex recall

--- a/eval/opus-density/README.md
+++ b/eval/opus-density/README.md
@@ -82,17 +82,27 @@ side-effects. Result — a real negative finding:
 |---|---|---|---|
 | `2` | break an accidental shared pixel with `Z` | **+0.0121** | none |
 | `5` | break an accidental shared pixel with `S` | **+0.0160** | none |
-| `0` | bolden (bigger center dot) | +0.0043 | created 2 new worst-24 collisions (`0~8`, `0~9`) — net negative |
-| `B` | bolden (wider bars) | **−0.0026 worse** | broad convergence toward every boxy capital; `B~O` crashed to 0.0196 |
-| `G` | bolden (bigger crossbar) | ~0 | same broad convergence as `B` |
+| `0` | round 1: bolden (bigger center dot) | +0.0043 | 2 new worst-24 collisions (`0~8`, `0~9`) — reverted |
+| `0` | round 2: de-collide (remove diagonal, add 1px elsewhere) | **−0.0081 worse** | net *reduced* the 0-vs-O distinguishing pixel count (2→1) — arithmetic error, reverted |
+| `B` | bolden (wider bars) | **−0.0026 worse** | broad convergence toward every boxy capital; `B~O` crashed to 0.0196 — reverted, no de-collision move exists (no shared row with `8` to exploit) |
+| `G` | round 1: bolden (bigger crossbar) | ~0 | broad convergence, same failure as `B` — reverted |
+| `G` | round 2: de-collide (same edit shape that worked for `5`) | **−0.0124 worse** | drifted closer to a dozen+ unrelated letters (B,E,M,N,P,R,...) — reverted |
 
-**Mechanism:** at 5×8 + blur + cosine-distance, adding ink pushes a glyph
-toward a generic dense blob that *other* bold capitals also blur into —
+**Mechanism (round 1):** at 5×8 + blur + cosine-distance, adding ink pushes a
+glyph toward a generic dense blob that *other* bold capitals also blur into —
 distance to the one target improves (maybe) while distance to everything else
-shrinks. The techniques that worked instead **relocated or removed** a pixel
-the confusable partner already shared by coincidence — surgical de-collision,
-not bolding. Only `2` and `5` are kept; `0`/`B`/`G` are reverted pending a
-redesign that follows the de-collision technique.
+shrinks. The de-collision technique (relocate/remove a pixel the partner
+shares by coincidence, don't add mass) fixed this for `2`/`5`.
+
+**Round 2 finding:** de-collision does not mechanically generalize. Applying
+the *identical* technique to `0`/`G` failed for two different reasons — `0`'s
+fix accidentally reduced its own distinguishing-pixel budget (a design
+arithmetic error), and `G`'s fix (reusing `5`'s exact successful edit shape)
+still caused broad drift because `0` and `6`/`G` sit in a denser neighborhood
+of similarly-shaped glyphs than the more isolated `2`/`Z` and `5`/`S` pairs. So
+only `2` and `5` are validated after 2 rounds; `0`, `6`/`G`, `8`/`B` are left
+unpatched pending real font-design tooling (out of scope for blind pixel
+patches) rather than a third guess.
 
 Both scripts are offline (no `ANTHROPIC_API_KEY`, `pnpm exec tsx <script>.mjs`)
 and exist to cheaply screen candidates before spending a scored run on them —

--- a/eval/opus-density/README.md
+++ b/eval/opus-density/README.md
@@ -54,6 +54,49 @@ high-leverage lever — it spends savings *only* on the content that actually
 breaks OCR. Final variant choice is **gated on the scored run** (gist==baseline,
 zero silent-wrong exact strings); enabling Opus in production stays out of scope
 until those numbers clear.
+
+### Lever C — font legibility (`eval/glyph-confusability/`)
+
+A/B trade savings for OCR fidelity or spend tokens on a sidecar. **C is
+different: it can raise recall at the SAME cell size and SAME token cost**, so
+any gain it buys is spendable as more density — the only lever with upside on
+Fable, which already reads 5×8 fine.
+
+`analyze.mjs` decodes the real production Spleen 5×8 atlas (+ the pre-built
+AA-gray atlas), simulates the vision encoder's low-pass (3×3 blur), and ranks
+glyph pairs by post-blur shape distance — a proxy, not ground truth, but
+API-key-free and immediately actionable. Findings on the shipping font:
+
+- **AA is a no-op for code glyphs.** ASCII glyphs in `atlas-gray.ts` are pure
+  `{0,255}` — zero fractional coverage (AA only touches CJK/symbol fallback).
+  The token-free AA sub-lever buys nothing for hex/code recall; don't score it.
+- **20/40 classic confusable classes flagged RISK**, dominated by exactly the
+  dense-hex failure set: `8~B`=.019, `0~O`=.016, `5~S`=.023, `2~Z`=.043,
+  `6~G`=.061. Scoped to ~15 glyphs.
+
+`harden.mjs` prototypes hand-designed pixel patches for the worst offenders and
+re-scans the **full alphabet** (not just the target pairs) to catch
+side-effects. Result — a real negative finding:
+
+| glyph | technique | target Δ | side effects |
+|---|---|---|---|
+| `2` | break an accidental shared pixel with `Z` | **+0.0121** | none |
+| `5` | break an accidental shared pixel with `S` | **+0.0160** | none |
+| `0` | bolden (bigger center dot) | +0.0043 | created 2 new worst-24 collisions (`0~8`, `0~9`) — net negative |
+| `B` | bolden (wider bars) | **−0.0026 worse** | broad convergence toward every boxy capital; `B~O` crashed to 0.0196 |
+| `G` | bolden (bigger crossbar) | ~0 | same broad convergence as `B` |
+
+**Mechanism:** at 5×8 + blur + cosine-distance, adding ink pushes a glyph
+toward a generic dense blob that *other* bold capitals also blur into —
+distance to the one target improves (maybe) while distance to everything else
+shrinks. The techniques that worked instead **relocated or removed** a pixel
+the confusable partner already shared by coincidence — surgical de-collision,
+not bolding. Only `2` and `5` are kept; `0`/`B`/`G` are reverted pending a
+redesign that follows the de-collision technique.
+
+Both scripts are offline (no `ANTHROPIC_API_KEY`, `pnpm exec tsx <script>.mjs`)
+and exist to cheaply screen candidates before spending a scored run on them —
+they do not replace the acceptance bar above.
 - **Models:** `claude-opus-4-8`, `claude-fable-5` (both high-res tier).
 - **Tasks** (each answer committed before ground truth is revealed):
   1. exact 12-char hex recall

--- a/eval/opus-density/results.json
+++ b/eval/opus-density/results.json
@@ -1,0 +1,76 @@
+{
+  "generatedAt": "2026-07-05T15:05:29.102Z",
+  "textTokens": 1335,
+  "variants": [
+    {
+      "variant": "5x8",
+      "sharp": false,
+      "sharpSpans": 0,
+      "pages": 1,
+      "dims": [
+        "1568x128"
+      ],
+      "imageTokens": 280,
+      "sidecarTokens": 0,
+      "totalTokens": 280,
+      "savingsPct": 79,
+      "models": {}
+    },
+    {
+      "variant": "7x10",
+      "sharp": false,
+      "sharpSpans": 0,
+      "pages": 1,
+      "dims": [
+        "1562x228"
+      ],
+      "imageTokens": 504,
+      "sidecarTokens": 0,
+      "totalTokens": 504,
+      "savingsPct": 62,
+      "models": {}
+    },
+    {
+      "variant": "9x12",
+      "sharp": false,
+      "sharpSpans": 0,
+      "pages": 1,
+      "dims": [
+        "1565x344"
+      ],
+      "imageTokens": 728,
+      "sidecarTokens": 0,
+      "totalTokens": 728,
+      "savingsPct": 45,
+      "models": {}
+    },
+    {
+      "variant": "5x8+sharp",
+      "sharp": true,
+      "sharpSpans": 6,
+      "pages": 1,
+      "dims": [
+        "1568x120"
+      ],
+      "imageTokens": 280,
+      "sidecarTokens": 56,
+      "totalTokens": 336,
+      "savingsPct": 75,
+      "models": {}
+    },
+    {
+      "variant": "7x10+sharp",
+      "sharp": true,
+      "sharpSpans": 6,
+      "pages": 1,
+      "dims": [
+        "1562x198"
+      ],
+      "imageTokens": 448,
+      "sidecarTokens": 56,
+      "totalTokens": 504,
+      "savingsPct": 62,
+      "models": {}
+    }
+  ]
+}

--- a/eval/opus-density/run.mjs
+++ b/eval/opus-density/run.mjs
@@ -7,6 +7,7 @@ import { writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { renderTextToImages } from '../../src/core/library.js';
+import { extractSharp, renderSidecar } from '../../src/core/sharp.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -47,18 +48,26 @@ const QUESTIONS = [
 // that keeps every page in Anthropic's linear, no-downscale billing window).
 // cols = floor((1568 - 2·PAD_X) / cellW), cellW = 5 + cellWBonus, PAD_X = 4.
 const colsFor = (wBonus) => Math.floor((1568 - 8) / (5 + wBonus));
+// `sharp:true` = lever B (content-aware keep-sharp): detector-flagged exact-string
+// spans (hex/uuid/path/flag/ident/port) are lifted out of the imaged body into a
+// small verbatim TEXT sidecar, so the model reads them exactly while prose stays
+// imaged. Density lever A (cell size) and B compose freely below.
 const VARIANTS = [
   { name: '5x8', style: { cellWBonus: 0, cellHBonus: 0, aa: true }, cols: colsFor(0) },
   { name: '7x10', style: { cellWBonus: 2, cellHBonus: 2, aa: true }, cols: colsFor(2) },
   { name: '9x12', style: { cellWBonus: 4, cellHBonus: 4, aa: true }, cols: colsFor(4) },
+  { name: '5x8+sharp', style: { cellWBonus: 0, cellHBonus: 0, aa: true }, cols: colsFor(0), sharp: true },
+  { name: '7x10+sharp', style: { cellWBonus: 2, cellHBonus: 2, aa: true }, cols: colsFor(2), sharp: true },
 ];
 const MODELS = ['claude-opus-4-8', 'claude-fable-5'];
 
 const TEXT_TOKENS = Math.ceil(SESSION.length / 3.5); // rough Claude-Code-dense baseline
 
-async function callModel(model, dataUrls, question) {
+async function callModel(model, dataUrls, question, sidecarText = '') {
   const key = process.env.ANTHROPIC_API_KEY;
   const content = [
+    // Lever B: the exact-value sidecar rides as verbatim text before the images.
+    ...(sidecarText ? [{ type: 'text', text: sidecarText }] : []),
     ...dataUrls.map((u) => ({
       type: 'image',
       source: { type: 'base64', media_type: 'image/png', data: u.replace(/^data:image\/png;base64,/, '') },
@@ -89,18 +98,25 @@ function score(kind, expected, got) {
 const results = { generatedAt: new Date().toISOString(), textTokens: TEXT_TOKENS, variants: [] };
 
 for (const v of VARIANTS) {
-  const { pages } = await renderTextToImages(SESSION, { style: v.style, cols: v.cols, reflow: true });
+  // Lever B: split exact-string spans into a verbatim text sidecar; image the rest.
+  const src = v.sharp ? extractSharp(SESSION) : { body: SESSION, sidecar: [] };
+  const sidecarText = v.sharp ? renderSidecar(src.sidecar) : '';
+  const sidecarTokens = v.sharp ? Math.ceil(sidecarText.length / 3.5) : 0;
+
+  const { pages } = await renderTextToImages(src.body, { style: v.style, cols: v.cols, reflow: true });
   const imageTokens = pages.reduce((n, p) => n + patchTokens(p.width, p.height), 0);
+  const totalTokens = imageTokens + sidecarTokens; // what the request actually costs
   const dataUrls = pages.map((p) => 'data:image/png;base64,' + Buffer.from(p.png).toString('base64'));
-  const savingsPct = Math.round((1 - imageTokens / TEXT_TOKENS) * 100);
-  const row = { variant: v.name, pages: pages.length, dims: pages.map((p) => `${p.width}x${p.height}`), imageTokens, savingsPct, models: {} };
-  console.log(`\n[${v.name}] ${pages.length} page(s) ${row.dims.join(',')} → ${imageTokens} img tok vs ${TEXT_TOKENS} text (${savingsPct}% saved)`);
+  const savingsPct = Math.round((1 - totalTokens / TEXT_TOKENS) * 100);
+  const row = { variant: v.name, sharp: !!v.sharp, sharpSpans: v.sharp ? src.sidecar.length : 0, pages: pages.length, dims: pages.map((p) => `${p.width}x${p.height}`), imageTokens, sidecarTokens, totalTokens, savingsPct, models: {} };
+  const sidecarNote = v.sharp ? ` +${sidecarTokens} sidecar tok (${src.sidecar.length} spans)` : '';
+  console.log(`\n[${v.name}] ${pages.length} page(s) ${row.dims.join(',')} → ${imageTokens} img${sidecarNote} vs ${TEXT_TOKENS} text (${savingsPct}% saved)`);
 
   if (process.env.ANTHROPIC_API_KEY) {
     for (const model of MODELS) {
       const m = { exactCorrect: 0, exactTotal: 0, confab: 0, abstain: 0, gistOk: false, guardOk: false, answers: [] };
       for (const q of QUESTIONS) {
-        const { text, ms } = await callModel(model, dataUrls, q.q);
+        const { text, ms } = await callModel(model, dataUrls, q.q, sidecarText);
         const s = score(q.kind, q.answer, text);
         m.answers.push({ id: q.id, kind: q.kind, expected: q.answer, got: text, ...s, ms });
         if (q.kind === 'exact') { m.exactTotal++; if (s.ok) m.exactCorrect++; }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "restart": "bash scripts/restart.sh",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "PXPIPE_E2E=1 vitest run tests/mitm-e2e.test.ts",
     "test:watch": "vitest",
     "test:restart": "bash tests/restart.test.sh",
     "prepublishOnly": "pnpm run typecheck && pnpm test && pnpm run build",

--- a/src/core/connect-route.ts
+++ b/src/core/connect-route.ts
@@ -1,0 +1,39 @@
+/**
+ * CONNECT-target routing for MITM mode. Pure functions, zero sockets — the
+ * security-critical host decision lives here so it is unit-testable in
+ * isolation (see tests/connect-route.test.ts).
+ */
+
+/** Hosts we TLS-terminate + compress. Everything else is raw-tunnelled untouched. */
+const MITM_HOSTS = new Set(['api.anthropic.com']);
+
+/** Split an authority-form target ("host:port", "[::1]:443") into host + port. */
+export function splitHostPort(authority: string): { host: string; port: number } | null {
+  const idx = authority.lastIndexOf(':');
+  if (idx <= 0) return null;
+  const host = authority.slice(0, idx).replace(/^\[|\]$/g, '').trim().toLowerCase();
+  const port = Number(authority.slice(idx + 1));
+  if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  return { host, port };
+}
+
+/**
+ * Decide whether a CONNECT target is MITM'd (TLS-terminated + compressed) or
+ * raw-tunnelled. EXACT host match only — never substring/includes, or
+ * `evil-api.anthropic.com.attacker.com` would be intercepted.
+ */
+export function routeConnect(host: string): 'mitm' | 'tunnel' {
+  const h = host.split(':', 1)[0]!.trim().toLowerCase();
+  return MITM_HOSTS.has(h) ? 'mitm' : 'tunnel';
+}
+
+/**
+ * Parse a full CONNECT request line, e.g. `CONNECT api.anthropic.com:443 HTTP/1.1`.
+ * Returns host+port, or null when the line is not a CONNECT (e.g. a plain GET).
+ * Used by the byte-sniffing path and the unit tests; the live proxy parses
+ * `req.url` (already authority-form) via splitHostPort.
+ */
+export function parseConnect(firstLine: string): { host: string; port: number } | null {
+  const m = /^CONNECT\s+(\S+)\s+HTTP\/\d(?:\.\d)?$/i.exec(firstLine.trim());
+  return m ? splitHostPort(m[1]!) : null;
+}

--- a/src/core/mitm-ca.ts
+++ b/src/core/mitm-ca.ts
@@ -1,0 +1,120 @@
+/**
+ * Local CA + leaf-cert management for MITM mode. Node's X509Certificate can
+ * *parse* but not *mint* certs, so rather than add a cert-minting dependency we
+ * shell out to the system `openssl` (present on macOS/Linux; MITM mode is
+ * inherently Node/local-only, so this never touches the Workers bundle).
+ *
+ * Material lives under ~/.pxpipe/mitm/ (dir 0700, private keys 0600). The CA
+ * signs exactly one host — api.anthropic.com — so a leak can only impersonate
+ * that host to this machine's Node clients.
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+export interface CaMaterial {
+  caCertPem: string;
+  caCertPath: string;
+  keyPath: string;
+  certPath: string;
+}
+
+const MITM_DIR = path.join(os.homedir(), '.pxpipe', 'mitm');
+const CA_KEY = path.join(MITM_DIR, 'ca.key');
+const CA_CERT = path.join(MITM_DIR, 'ca.crt');
+const LEAF_KEY = path.join(MITM_DIR, 'api.anthropic.com.key');
+const LEAF_CSR = path.join(MITM_DIR, 'api.anthropic.com.csr');
+const LEAF_CRT = path.join(MITM_DIR, 'api.anthropic.com.crt');
+const LEAF_EXT = path.join(MITM_DIR, 'api.anthropic.com.ext');
+
+export function mitmDir(): string { return MITM_DIR; }
+export function caCertPath(): string { return CA_CERT; }
+
+/** Run openssl with fixed-literal args (never a shell string → no injection). Throws on failure. */
+function openssl(args: string[]): void {
+  const r = spawnSync('openssl', args, { encoding: 'utf8' });
+  if (r.error && (r.error as NodeJS.ErrnoException).code === 'ENOENT') {
+    throw new Error(
+      'openssl not found on PATH — required to generate the local CA. ' +
+        'macOS ships it; on Linux install via `apt install openssl` / `apk add openssl`.',
+    );
+  }
+  if (r.status !== 0) {
+    throw new Error(`openssl ${args[0]} failed: ${(r.stderr || r.stdout || '').trim()}`);
+  }
+}
+
+/** True when a system openssl is callable — for a friendly upfront check. */
+export function opensslAvailable(): boolean {
+  const r = spawnSync('openssl', ['version'], { encoding: 'utf8' });
+  return !r.error && r.status === 0;
+}
+
+/**
+ * Idempotent. Creates ~/.pxpipe/mitm/ (0700), a 10-year self-signed root CA, and
+ * a leaf for api.anthropic.com signed by it (SAN=DNS:api.anthropic.com). Missing
+ * pieces are regenerated; existing ones are left untouched. Returns the paths +
+ * CA PEM (for NODE_EXTRA_CA_CERTS wiring and trust instructions).
+ */
+export function ensureCa(): CaMaterial {
+  fs.mkdirSync(MITM_DIR, { recursive: true, mode: 0o700 });
+
+  if (!fs.existsSync(CA_KEY) || !fs.existsSync(CA_CERT)) {
+    openssl([
+      'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-sha256',
+      '-days', '3650', '-subj', '/CN=pxpipe MITM CA',
+      '-keyout', CA_KEY, '-out', CA_CERT,
+    ]);
+    fs.chmodSync(CA_KEY, 0o600);
+    fs.chmodSync(CA_CERT, 0o600);
+  }
+
+  if (!fs.existsSync(LEAF_KEY) || !fs.existsSync(LEAF_CRT)) {
+    openssl(['genrsa', '-out', LEAF_KEY, '2048']);
+    fs.chmodSync(LEAF_KEY, 0o600);
+    openssl(['req', '-new', '-key', LEAF_KEY, '-subj', '/CN=api.anthropic.com', '-out', LEAF_CSR]);
+    // SAN must be applied at signing time via -extfile: `x509 -req` drops CSR extensions,
+    // and a leaf without a matching SAN is rejected by modern TLS clients.
+    fs.writeFileSync(
+      LEAF_EXT,
+      'subjectAltName=DNS:api.anthropic.com\nextendedKeyUsage=serverAuth\nbasicConstraints=CA:FALSE\n',
+      { mode: 0o600 },
+    );
+    // ponytail: single-host CA. Ceiling: only api.anthropic.com. Upgrade path:
+    // take a host param + a per-host leaf cache map when more upstreams are added.
+    openssl([
+      'x509', '-req', '-in', LEAF_CSR, '-CA', CA_CERT, '-CAkey', CA_KEY,
+      '-CAcreateserial', '-sha256', '-days', '825', '-extfile', LEAF_EXT, '-out', LEAF_CRT,
+    ]);
+    fs.chmodSync(LEAF_CRT, 0o600);
+  }
+
+  return {
+    caCertPem: fs.readFileSync(CA_CERT, 'utf8'),
+    caCertPath: CA_CERT,
+    keyPath: LEAF_KEY,
+    certPath: LEAF_CRT,
+  };
+}
+
+/** Leaf key+cert buffers for tls.createSecureContext. Throws if ensureCa hasn't run. */
+export function leafSecureContextInput(): { key: Buffer; cert: Buffer } {
+  return { key: fs.readFileSync(LEAF_KEY), cert: fs.readFileSync(LEAF_CRT) };
+}
+
+/**
+ * `mitm doctor` support: returns null when the CA material is present and the
+ * private keys are 0600, otherwise a human-readable problem message.
+ */
+export function checkCa(): string | null {
+  for (const f of [CA_KEY, CA_CERT, LEAF_KEY, LEAF_CRT]) {
+    if (!fs.existsSync(f)) return `missing ${f} — run \`pxpipe mitm install\``;
+  }
+  for (const key of [CA_KEY, LEAF_KEY]) {
+    const mode = fs.statSync(key).mode & 0o777;
+    if (mode & 0o077) return `insecure perms on ${key}: ${mode.toString(8)} (want 600)`;
+  }
+  return null;
+}

--- a/src/core/mitm.ts
+++ b/src/core/mitm.ts
@@ -1,0 +1,94 @@
+/**
+ * MITM CONNECT front-end for Claude Desktop, whose embedded claude-code pins
+ * ANTHROPIC_BASE_URL and so can't be pointed at the base-URL proxy. Instead the
+ * client is aimed at us via HTTPS_PROXY; we terminate TLS for ONLY
+ * api.anthropic.com (with our own CA) to compress requests, and raw-tunnel every
+ * other host untouched.
+ *
+ * One http.Server does everything:
+ *   - plain HTTP on the port  → its normal request handler (the dashboard)
+ *   - CONNECT api.anthropic.com → TLS-terminate, then re-emit the decrypted
+ *       socket back onto the SAME server so requests hit the same handler
+ *   - CONNECT anything else    → net.connect + raw pipe (no inspection)
+ *
+ * Node-only (node:net/node:tls/node:http). Imported ONLY from src/node.ts so it
+ * never enters the Cloudflare Workers bundle.
+ */
+
+import * as net from 'node:net';
+import * as tls from 'node:tls';
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+  type Server,
+} from 'node:http';
+import { routeConnect, splitHostPort } from './connect-route.js';
+import { leafSecureContextInput } from './mitm-ca.js';
+
+export interface MitmDeps {
+  /** The (req,res) closure shared with the plain-HTTP server (dashboard routes + handle()). */
+  requestHandler: (req: IncomingMessage, res: ServerResponse) => void;
+}
+
+/**
+ * Build the CONNECT front-end. Does NOT listen — the caller owns lifecycle
+ * (server.listen / shutdown), so shutdown handling is identical to plain mode.
+ * ensureCa() MUST have run first (leafSecureContextInput reads the leaf files).
+ */
+export function createMitmServer(deps: MitmDeps): Server {
+  const secureContext = tls.createSecureContext(leafSecureContextInput());
+  const server = createHttpServer(deps.requestHandler);
+
+  // Surface HTTP parse errors on client sockets instead of crashing the process.
+  server.on('clientError', (_err, socket) => {
+    if (socket.writable) socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+  });
+
+  server.on('connect', (req: IncomingMessage, clientSock: net.Socket, head: Buffer) => {
+    clientSock.on('error', () => clientSock.destroy());
+    const target = splitHostPort(req.url ?? '');
+    if (!target) {
+      clientSock.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+      return;
+    }
+
+    if (routeConnect(target.host) === 'mitm') {
+      // Ack CONNECT first — the client won't send its TLS ClientHello until it
+      // sees the 200. Replay any bytes read past the CONNECT line (usually none)
+      // so the TLS layer sees the full ClientHello.
+      clientSock.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      if (head && head.length) clientSock.unshift(head);
+      // Terminate TLS with our leaf cert; force http/1.1 so our HTTP/1.1-only
+      // server never has to speak h2 (a modern client would otherwise pick h2).
+      const tlsSock = new tls.TLSSocket(clientSock, {
+        isServer: true,
+        secureContext,
+        ALPNProtocols: ['http/1.1'],
+      });
+      tlsSock.on('error', () => clientSock.destroy());
+      // Feed the decrypted socket back into the same server → requests reach the
+      // shared handler (Host: api.anthropic.com), forwarded to config.upstream.
+      server.emit('connection', tlsSock);
+      return;
+    }
+
+    // Raw tunnel: everything except api.anthropic.com passes through untouched.
+    const upstream = net.connect(target.port, target.host, () => {
+      clientSock.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      if (head && head.length) upstream.write(head);
+      upstream.pipe(clientSock);
+      clientSock.pipe(upstream);
+    });
+    // Tie the two raw sockets' lifecycles together. .pipe() forwards a clean
+    // FIN but NOT errors, so a client RST (ECONNRESET — tab close, network
+    // blip, client kill) would otherwise leak the upstream socket forever on
+    // this long-running proxy. 'close' fires exactly once per socket (for FIN,
+    // error, or destroy), so destroying the peer on close covers every case.
+    upstream.on('error', () => upstream.destroy());
+    upstream.on('close', () => clientSock.destroy());
+    clientSock.on('close', () => upstream.destroy());
+  });
+
+  return server;
+}

--- a/src/core/sharp.ts
+++ b/src/core/sharp.ts
@@ -1,0 +1,296 @@
+/**
+ * src/core/sharp.ts — exact-string ("sharp") span detection for content-aware
+ * keep-sharp (lever B of the Opus/lower-model unlock).
+ *
+ * Higher-capability general models (Opus 4.8, GPT) read *imaged* prose almost
+ * as well as Fable, but mis-read dense exact strings — hashes, IDs, paths — at
+ * a rate that is (a) silent and (b) unrecoverable (applicability.ts documents
+ * Opus at 6/15 dense-hex recall vs Fable 100/100). Those are exactly the tokens
+ * where a wrong character is a wrong answer with no way to notice.
+ *
+ * This module finds those spans so the transform can keep them as TEXT while
+ * still imaging the surrounding prose (savings preserved, correctness protected).
+ * Ordinary prose is deliberately NOT flagged — false positives leak savings.
+ *
+ * Two consumption modes:
+ *   - block-level: `sharpDensity(text)` → a caller can keep a whole
+ *     exact-dense block as text (drop-in for `TransformOptions.keepSharp`).
+ *   - span-level:  `extractSharp(text)` → imaged `body` with compact markers +
+ *     a small verbatim `sidecar` carrying only the sharp spans. Best for mixed
+ *     prose+identifier blocks (typical Claude-Code tool_result / history).
+ *
+ * Pure and dependency-free so it is trivially unit-testable and reusable by both
+ * the eval harness and production.
+ */
+
+export type SharpKind =
+  | 'url'
+  | 'uuid'
+  | 'path'
+  | 'flag'
+  | 'hex'
+  | 'base64'
+  | 'ident'
+  | 'num';
+
+export interface SharpSpan {
+  /** Start offset in the source string (inclusive). */
+  readonly start: number;
+  /** End offset in the source string (exclusive). */
+  readonly end: number;
+  /** The exact matched substring. */
+  readonly text: string;
+  /** Which detector class matched. */
+  readonly kind: SharpKind;
+}
+
+interface RawMatch {
+  start: number;
+  end: number;
+  text: string;
+  kind: SharpKind;
+  /** Lower = higher priority when spans overlap. */
+  prio: number;
+}
+
+// --- helpers ----------------------------------------------------------------
+
+function hasDigit(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 48 && c <= 57) return true;
+  }
+  return false;
+}
+
+/** Count how many of {lowercase, uppercase, digit} appear in `s`. */
+function classCount(s: string): number {
+  let lower = false;
+  let upper = false;
+  let digit = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 97 && c <= 122) lower = true;
+    else if (c >= 65 && c <= 90) upper = true;
+    else if (c >= 48 && c <= 57) digit = true;
+  }
+  return (lower ? 1 : 0) + (upper ? 1 : 0) + (digit ? 1 : 0);
+}
+
+function countSlashes(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) === 47 /* / */) n++;
+  return n;
+}
+
+const HAS_EXT = /\.[A-Za-z0-9]{1,8}$/;
+
+// --- detector patterns ------------------------------------------------------
+//
+// Each pattern is scanned globally; overlaps are resolved by priority (index
+// order below: earlier = higher priority) then by longer span. `accept`
+// post-filters raw regex hits to suppress prose false positives.
+
+interface Detector {
+  kind: SharpKind;
+  prio: number;
+  re: RegExp;
+  /** Return false to reject a raw regex hit (prose guard). */
+  accept?: (m: string) => boolean;
+}
+
+const DETECTORS: readonly Detector[] = [
+  // URLs — flag the whole thing; a single wrong char breaks the link.
+  { kind: 'url', prio: 0, re: /https?:\/\/[^\s'"<>)\]}]+/gi },
+
+  // UUID / RFC-4122 — pure structure, always exact-critical.
+  {
+    kind: 'uuid',
+    prio: 1,
+    re: /\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/g,
+  },
+
+  // File paths — a run containing at least one "/". Kept only when it has ≥2
+  // segments (≥2 slashes) OR ends in a file extension, so prose "and/or" and
+  // fractions are not flagged.
+  {
+    kind: 'path',
+    prio: 2,
+    re: /(?:\.{0,2}\/)?(?:[A-Za-z0-9._@~+-]+\/)+[A-Za-z0-9._@~+-]+/g,
+    accept: (m) => countSlashes(m) >= 2 || HAS_EXT.test(m),
+  },
+
+  // CLI flags — a leading "-" / "--" at a token boundary followed by a letter.
+  // The lookbehind stops hyphenated prose ("state-of-the-art") from matching.
+  {
+    kind: 'flag',
+    prio: 3,
+    re: /(?<![A-Za-z0-9])--?[A-Za-z][A-Za-z0-9]*(?:[-_][A-Za-z0-9]+)*/g,
+  },
+
+  // Hex / hashes — 7+ hex chars. Kept only when it contains a digit OR is long
+  // (≥12), so all-letter English words that happen to be hex ("defaced") pass.
+  {
+    kind: 'hex',
+    prio: 4,
+    re: /\b[0-9a-fA-F]{7,}\b/g,
+    accept: (m) => hasDigit(m) || m.length >= 12,
+  },
+
+  // base64 / opaque tokens — 20+ char no-space run mixing ≥2 char classes.
+  // (No "/" so this never competes with paths.)
+  {
+    kind: 'base64',
+    prio: 5,
+    re: /\b[A-Za-z0-9+_-]{20,}={0,2}/g,
+    accept: (m) => classCount(m) >= 2,
+  },
+
+  // Identifiers — camelCase, snake_case/SCREAMING_CASE, or any letter+digit
+  // mixed token. The content classes where a silent char flip is a wrong
+  // symbol name.
+  { kind: 'ident', prio: 6, re: /\b[A-Za-z]*[a-z][A-Z][A-Za-z0-9]*\b/g }, // camelCase
+  { kind: 'ident', prio: 6, re: /\b[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]+\b/g }, // snake / SCREAMING
+  {
+    kind: 'ident',
+    prio: 6,
+    re: /\b(?=[A-Za-z0-9]*[A-Za-z])(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{3,}\b/g, // letter+digit mix
+  },
+
+  // Bare long digit runs — ports, PIDs, line numbers, large counts.
+  { kind: 'num', prio: 7, re: /\b\d{4,}\b/g },
+];
+
+// --- core scan --------------------------------------------------------------
+
+/**
+ * Find non-overlapping exact-string spans in `text`, sorted by start offset.
+ * Overlapping raw hits are resolved by detector priority, then by length.
+ */
+export function findSharpSpans(text: string): SharpSpan[] {
+  if (typeof text !== 'string' || text.length === 0) return [];
+
+  const raw: RawMatch[] = [];
+  for (const d of DETECTORS) {
+    // Fresh lastIndex each call — regexes are module-scoped and stateful.
+    d.re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = d.re.exec(text)) !== null) {
+      const s = m[0];
+      if (s.length === 0) {
+        d.re.lastIndex++; // guard against zero-width loops
+        continue;
+      }
+      if (d.accept && !d.accept(s)) continue;
+      raw.push({ start: m.index, end: m.index + s.length, text: s, kind: d.kind, prio: d.prio });
+    }
+  }
+
+  // Greedy non-overlap: prefer earlier start, then higher priority (lower prio),
+  // then longer span.
+  raw.sort((a, b) =>
+    a.start - b.start || a.prio - b.prio || b.end - a.end || b.text.length - a.text.length,
+  );
+
+  const out: SharpSpan[] = [];
+  let cursor = -1;
+  for (const r of raw) {
+    if (r.start < cursor) continue; // overlaps an already-accepted span
+    out.push({ start: r.start, end: r.end, text: r.text, kind: r.kind });
+    cursor = r.end;
+  }
+  return out;
+}
+
+/**
+ * Fraction of characters (0..1) covered by sharp spans. A block-level signal:
+ * high density means most of the block is exact-critical content that should
+ * stay as text rather than be imaged. Callers threshold this to build a
+ * `TransformOptions.keepSharp` predicate.
+ */
+export function sharpDensity(text: string): number {
+  if (typeof text !== 'string' || text.length === 0) return 0;
+  const spans = findSharpSpans(text);
+  let covered = 0;
+  for (const s of spans) covered += s.end - s.start;
+  return covered / text.length;
+}
+
+export interface ExtractSharpOptions {
+  /** Build the marker inserted in the imaged body for span index `i` (1-based). */
+  marker?: (i: number) => string;
+}
+
+export interface SidecarEntry {
+  /** Marker string that appears in `body` where this span was lifted out. */
+  readonly marker: string;
+  readonly kind: SharpKind;
+  /** Exact original text — the model reads this verbatim. */
+  readonly text: string;
+}
+
+export interface ExtractSharpResult {
+  /** Source with each sharp span replaced by its marker — this is what gets imaged. */
+  readonly body: string;
+  /** Ordered, de-duplicated verbatim spans — emitted as a small TEXT block. */
+  readonly sidecar: SidecarEntry[];
+  /** The accepted spans, for telemetry. */
+  readonly spans: SharpSpan[];
+}
+
+const DEFAULT_MARKER = (i: number): string => `[#${i}]`;
+
+/**
+ * Split `text` into an imageable `body` (sharp spans replaced by compact
+ * markers) and a `sidecar` of the exact spans (verbatim text). Identical span
+ * texts share one marker/entry, so a repeated hash costs the sidecar once.
+ *
+ * Round-trips: `restoreSharp(body, sidecar) === text` when markers do not
+ * collide with source content (see restoreSharp).
+ */
+export function extractSharp(text: string, opts: ExtractSharpOptions = {}): ExtractSharpResult {
+  const spans = findSharpSpans(text);
+  if (spans.length === 0) return { body: text, sidecar: [], spans };
+
+  const marker = opts.marker ?? DEFAULT_MARKER;
+  const byText = new Map<string, SidecarEntry>();
+  const sidecar: SidecarEntry[] = [];
+
+  let body = '';
+  let last = 0;
+  for (const s of spans) {
+    body += text.slice(last, s.start);
+    let entry = byText.get(s.text);
+    if (entry === undefined) {
+      entry = { marker: marker(sidecar.length + 1), kind: s.kind, text: s.text };
+      byText.set(s.text, entry);
+      sidecar.push(entry);
+    }
+    body += entry.marker;
+    last = s.end;
+  }
+  body += text.slice(last);
+
+  return { body, sidecar, spans };
+}
+
+/**
+ * Inverse of `extractSharp`: substitute each sidecar marker back with its exact
+ * text. Longer markers are applied first so `[#1]` cannot shadow `[#11]`.
+ */
+export function restoreSharp(body: string, sidecar: readonly SidecarEntry[]): string {
+  let out = body;
+  const ordered = [...sidecar].sort((a, b) => b.marker.length - a.marker.length);
+  for (const e of ordered) out = out.split(e.marker).join(e.text);
+  return out;
+}
+
+/**
+ * Render the sidecar as a compact verbatim text block for the model. Kept small
+ * and label-led so the model treats it as an exact-value key, not prose.
+ */
+export function renderSidecar(sidecar: readonly SidecarEntry[]): string {
+  if (sidecar.length === 0) return '';
+  const lines = sidecar.map((e) => `${e.marker} = ${e.text}`);
+  return `Exact values (read verbatim; the image uses these markers):\n${lines.join('\n')}`;
+}

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -633,6 +633,25 @@ function extractSystemText(sys: SystemField | undefined): { text: string; kept: 
   return { text: textParts.join('\n\n'), kept };
 }
 
+/**
+ * Strip cache_control.scope (e.g. "global") from a marker pxpipe RELOCATES onto
+ * an image block. `scope: "global"` requires every preceding block to also be
+ * global, but pxpipe moves the marker into a user-message image block that sits
+ * after tools+system — breaking that prefix invariant (Anthropic 400s it). This
+ * surfaces on transparent/MITM traffic, where Claude Code enables scoped caching
+ * that it withholds when pointed at a custom base URL. Global-scope semantics
+ * can't survive imaging anyway, so downgrade to the default ephemeral scope.
+ * No-op when there is no scope field.
+ */
+function stripCacheScope<T>(cc: T): T {
+  if (cc && typeof cc === 'object' && 'scope' in (cc as Record<string, unknown>)) {
+    const rest = { ...(cc as Record<string, unknown>) };
+    delete rest.scope;
+    return rest as T;
+  }
+  return cc;
+}
+
 function lastStaticSystemCacheControl(sys: SystemField | undefined): TextBlock['cache_control'] | undefined {
   if (!Array.isArray(sys)) return undefined;
   let cacheControl: TextBlock['cache_control'] | undefined;
@@ -880,7 +899,7 @@ function relocateAnchorToHistoryImage(messages: Message[] | undefined, anchorOrd
   }
   if (!slabAnchor) return; // nothing to relocate → never add a marker
 
-  historyImg.cache_control = slabAnchor.cache_control;
+  historyImg.cache_control = stripCacheScope(slabAnchor.cache_control);
   delete slabAnchor.cache_control;
 }
 
@@ -1712,7 +1731,7 @@ export async function transformRequest(
     const imageBlock = makeImageBlock(b64, i === images.length - 1);
     imageBlocks.push(
       i === images.length - 1 && systemStaticCacheControl !== undefined
-        ? { ...imageBlock, cache_control: systemStaticCacheControl }
+        ? { ...imageBlock, cache_control: stripCacheScope(systemStaticCacheControl) }
         : imageBlock,
     );
   }
@@ -1820,7 +1839,7 @@ export async function transformRequest(
             const img = imgs[i]!;
             const out =
               i === imgs.length - 1 && srcCacheControl !== undefined
-                ? { ...img, cache_control: srcCacheControl }
+                ? { ...img, cache_control: stripCacheScope(srcCacheControl) }
                 : img;
             processedExisting.push(out as ImageBlock);
             info.imageBytes += approxBlockBytes(img);
@@ -1969,7 +1988,7 @@ export async function transformRequest(
                   const img = imgs[i]!;
                   const out =
                     i === imgs.length - 1 && srcCacheControl !== undefined
-                      ? { ...img, cache_control: srcCacheControl }
+                      ? { ...img, cache_control: stripCacheScope(srcCacheControl) }
                       : img;
                   newInner.push(out as ImageBlock);
                   info.imageBytes += approxBlockBytes(img);

--- a/src/node.ts
+++ b/src/node.ts
@@ -13,6 +13,8 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { createProxy, parseGatewayHeaders, resolveUpstreams, type ProxyConfig } from './core/proxy.js';
+import { createMitmServer } from './core/mitm.js';
+import { ensureCa, checkCa, caCertPath, mitmDir, opensslAvailable } from './core/mitm-ca.js';
 import {
   parseExportArgv,
   runExportCore,
@@ -133,6 +135,7 @@ function printHelp(): void {
 Usage:
   pxpipe                run the proxy (no flags)
   pxpipe export [...]   render files/diff to PNG pages + cost report (see pxpipe export --help)
+  pxpipe mitm [...]     transparent CONNECT proxy for Claude Desktop (see pxpipe mitm --help)
 
 The proxy compresses eligible tools, schemas, reminders, tool_results,
 and history; tracks events to disk; and measures real saved_pct via
@@ -868,9 +871,22 @@ async function main(): Promise<void> {
     await runExport(argv.slice(1));
     return; // server never starts
   }
+  if (argv[0] === 'mitm') {
+    await runMitm(argv.slice(1));
+    return; // mitm mode owns its own server lifecycle
+  }
   // No subcommands — pxpipe is just the proxy. Stats / sessions / cleanup
   // tools live in the dashboard (see http://127.0.0.1:${port}/).
   const opts = parseCli(argv);
+  await run(opts, 'plain');
+}
+
+/**
+ * Build the tracker + dashboard + proxy handler and start listening. Shared by
+ * the default base-URL mode ('plain') and the CONNECT-proxy mode ('mitm'); the
+ * ONLY difference is the listener that wraps the identical request handler.
+ */
+async function run(opts: RuntimeConfig, mode: 'plain' | 'mitm'): Promise<void> {
   // A/B harness passthrough switch (see the `transform` callback below).
   const forcePassthrough = /^(1|true|yes|on)$/i.test(process.env.PXPIPE_DISABLE ?? '');
   if (forcePassthrough) {
@@ -1029,7 +1045,7 @@ async function main(): Promise<void> {
   };
   const handle = createProxy(config);
 
-  const server = createServer((req, res) => {
+  const requestHandler = (req: IncomingMessage, res: ServerResponse): void => {
     Promise.resolve()
       .then(async () => {
         // Local dashboard routes — handled BEFORE the proxy so they never hit
@@ -1052,13 +1068,26 @@ async function main(): Promise<void> {
         if (!res.headersSent) res.statusCode = 500;
         res.end();
       });
-  });
+  };
+
+  // Plain mode is the base-URL reverse proxy. MITM mode is a CONNECT proxy that
+  // TLS-terminates api.anthropic.com with our own CA — the client points here
+  // via HTTPS_PROXY + NODE_EXTRA_CA_CERTS (see `pxpipe mitm install`). Both wrap
+  // the identical requestHandler, so transform/events/dashboard are unchanged.
+  if (mode === 'mitm') ensureCa();
+  const server = mode === 'mitm'
+    ? createMitmServer({ requestHandler })
+    : createServer(requestHandler);
 
   // IPv6 literals need bracket notation to form a valid URL (http://[::1]:47821).
   const displayHost = opts.host.includes(':') ? `[${opts.host}]` : opts.host;
   const isLoopbackHost =
     opts.host === '127.0.0.1' || opts.host === 'localhost' || opts.host === '::1';
   server.listen(opts.port, opts.host, () => {
+    if (mode === 'mitm') {
+      console.log(`[pxpipe] MITM CONNECT proxy on ${displayHost}:${opts.port} — TLS-terminating api.anthropic.com, tunnelling all else`);
+      console.log(`[pxpipe] trust this CA in the client (NODE_EXTRA_CA_CERTS): ${caCertPath()}`);
+    }
     console.log(`[pxpipe] listening on http://${displayHost}:${opts.port}`);
     if (!isLoopbackHost) {
       console.warn(
@@ -1109,3 +1138,205 @@ main().catch((err) => {
   console.error('[pxpipe] fatal:', err);
   process.exit(1);
 });
+
+// ---- pxpipe mitm ----------------------------------------------------------
+
+const CLAUDE_SETTINGS = path.join(os.homedir(), '.claude', 'settings.json');
+const CLAUDE_SETTINGS_BAK = CLAUDE_SETTINGS + '.pxpipe.bak';
+const MITM_PROXY_URL = `http://127.0.0.1:${process.env.PORT ?? 47821}`;
+const LAUNCH_AGENT_LABEL = 'com.pxpipe.mitm';
+const LAUNCH_AGENT_PATH = path.join(
+  os.homedir(), 'Library', 'LaunchAgents', `${LAUNCH_AGENT_LABEL}.plist`,
+);
+
+function printMitmHelp(): void {
+  console.log(`pxpipe mitm — transparent CONNECT proxy (works with Claude Desktop)
+
+The default proxy needs ANTHROPIC_BASE_URL pointed at it, which Claude Desktop
+pins. mitm mode instead runs an HTTP CONNECT proxy the client reaches via
+HTTPS_PROXY: it TLS-terminates ONLY api.anthropic.com (with a local CA it
+generates) to compress Fable requests, and raw-tunnels every other host.
+
+Usage:
+  pxpipe mitm                run the CONNECT proxy (foreground)
+  pxpipe mitm install        generate CA, wire ~/.claude/settings.json, install a launchd keepalive
+  pxpipe mitm uninstall      revert settings.json + remove the launchd agent
+  pxpipe mitm doctor         check CA, settings.json wiring, and agent status
+  pxpipe mitm --help         this help
+
+install writes to ~/.claude/settings.json "env":
+  HTTPS_PROXY=${MITM_PROXY_URL}
+  NODE_EXTRA_CA_CERTS=<~/.pxpipe/mitm/ca.crt>
+and removes any ANTHROPIC_BASE_URL override (the two must not both be set).
+
+Security: mitm decrypts api.anthropic.com locally, so your API/OAuth token is
+visible in plaintext to this proxy (loopback only, never written to events).
+The CA signs only api.anthropic.com. Undo everything with \`pxpipe mitm uninstall\`.
+`);
+}
+
+async function runMitm(argv: string[]): Promise<void> {
+  const sub = argv[0];
+  if (sub === '-h' || sub === '--help' || sub === 'help') { printMitmHelp(); process.exit(0); }
+  if (sub === 'install') { mitmInstall(); return; }
+  if (sub === 'uninstall') { mitmUninstall(); return; }
+  if (sub === 'doctor') { mitmDoctor(); return; }
+  if (sub !== undefined) {
+    console.error(`[pxpipe mitm] unknown argument: ${sub}`);
+    console.error('[pxpipe mitm] try: pxpipe mitm [install|uninstall|doctor]  (or `pxpipe mitm --help`)');
+    process.exit(2);
+  }
+  // Default (no subcommand): run the CONNECT proxy in the foreground.
+  if (!opensslAvailable()) {
+    console.error('[pxpipe mitm] openssl not found on PATH — required to generate the local CA.');
+    process.exit(1);
+  }
+  await run(parseCli([]), 'mitm');
+}
+
+/** Idempotent, backup-preserving patch of ~/.claude/settings.json env. */
+function patchClaudeSettings(): void {
+  let cfg: Record<string, unknown> = {};
+  if (fs.existsSync(CLAUDE_SETTINGS)) {
+    // Preserve the PRISTINE settings on first patch only — never overwrite the
+    // backup with an already-patched file on a second install.
+    if (!fs.existsSync(CLAUDE_SETTINGS_BAK)) fs.copyFileSync(CLAUDE_SETTINGS, CLAUDE_SETTINGS_BAK);
+    try {
+      cfg = JSON.parse(fs.readFileSync(CLAUDE_SETTINGS, 'utf8')) as Record<string, unknown>;
+    } catch (e) {
+      console.warn(
+        `[pxpipe mitm] ${CLAUDE_SETTINGS} is not valid JSON (${(e as Error).message}); ` +
+          'starting env from {} (backup kept)',
+      );
+      cfg = {};
+    }
+  }
+  const env = (cfg.env && typeof cfg.env === 'object' && !Array.isArray(cfg.env)
+    ? cfg.env
+    : {}) as Record<string, unknown>;
+  delete env.ANTHROPIC_BASE_URL; // retire the base-URL reverse-proxy override
+  env.HTTPS_PROXY = MITM_PROXY_URL;
+  env.HTTP_PROXY = MITM_PROXY_URL;
+  env.NODE_EXTRA_CA_CERTS = caCertPath();
+  cfg.env = env;
+  fs.mkdirSync(path.dirname(CLAUDE_SETTINGS), { recursive: true });
+  fs.writeFileSync(CLAUDE_SETTINGS, JSON.stringify(cfg, null, 2) + '\n');
+}
+
+function installLaunchAgent(): void {
+  if (process.platform !== 'darwin') {
+    console.log(
+      '[pxpipe mitm] non-macOS: skipping launchd agent — run `pxpipe mitm` under your own supervisor (systemd, etc.).',
+    );
+    return;
+  }
+  const logPath = path.join(mitmDir(), '..', 'mitm.log'); // ~/.pxpipe/mitm.log
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LAUNCH_AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${process.execPath}</string>
+    <string>${process.argv[1]}</string>
+    <string>mitm</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${logPath}</string>
+  <key>StandardErrorPath</key><string>${logPath}</string>
+</dict>
+</plist>
+`;
+  fs.mkdirSync(path.dirname(LAUNCH_AGENT_PATH), { recursive: true });
+  fs.writeFileSync(LAUNCH_AGENT_PATH, plist);
+  spawnSync('launchctl', ['unload', LAUNCH_AGENT_PATH], { stdio: 'ignore' });
+  spawnSync('launchctl', ['load', LAUNCH_AGENT_PATH], { stdio: 'ignore' });
+}
+
+function mitmInstall(): void {
+  if (!opensslAvailable()) {
+    console.error('[pxpipe mitm] openssl not found on PATH — required to generate the local CA.');
+    process.exit(1);
+  }
+  const material = ensureCa();
+  patchClaudeSettings();
+  installLaunchAgent();
+  console.log('[pxpipe mitm] installed.');
+  console.log(`  CA:            ${material.caCertPath}`);
+  console.log(
+    `  settings.json: ${CLAUDE_SETTINGS} (HTTPS_PROXY + NODE_EXTRA_CA_CERTS set; ` +
+      `ANTHROPIC_BASE_URL removed; backup at ${path.basename(CLAUDE_SETTINGS_BAK)})`,
+  );
+  if (process.platform === 'darwin') {
+    console.log(`  launchd:       ${LAUNCH_AGENT_PATH} (RunAtLoad + KeepAlive)`);
+  }
+  console.log('');
+  console.log('  If you previously ran a base-URL pxpipe launchd agent, unload it so the two');
+  console.log('  do not fight over the port:  launchctl bootout gui/$(id -u)/<its-label>');
+  console.log('');
+  console.log('  Next: fully quit and reopen Claude Desktop, run a Fable task, and watch');
+  console.log(`        ${MITM_PROXY_URL}/  — compressed events should appear.`);
+  console.log('  Undo: pxpipe mitm uninstall');
+}
+
+function mitmUninstall(): void {
+  if (fs.existsSync(CLAUDE_SETTINGS_BAK)) {
+    fs.copyFileSync(CLAUDE_SETTINGS_BAK, CLAUDE_SETTINGS);
+    fs.rmSync(CLAUDE_SETTINGS_BAK, { force: true });
+    console.log(`[pxpipe mitm] restored ${CLAUDE_SETTINGS} from backup`);
+  } else if (fs.existsSync(CLAUDE_SETTINGS)) {
+    try {
+      const cfg = JSON.parse(fs.readFileSync(CLAUDE_SETTINGS, 'utf8')) as Record<string, unknown>;
+      const env = cfg.env as Record<string, unknown> | undefined;
+      if (env) {
+        delete env.HTTPS_PROXY;
+        delete env.HTTP_PROXY;
+        delete env.NODE_EXTRA_CA_CERTS;
+      }
+      fs.writeFileSync(CLAUDE_SETTINGS, JSON.stringify(cfg, null, 2) + '\n');
+      console.log(`[pxpipe mitm] removed proxy keys from ${CLAUDE_SETTINGS}`);
+    } catch {
+      /* leave as-is */
+    }
+  }
+  if (process.platform === 'darwin' && fs.existsSync(LAUNCH_AGENT_PATH)) {
+    spawnSync('launchctl', ['unload', LAUNCH_AGENT_PATH], { stdio: 'ignore' });
+    fs.rmSync(LAUNCH_AGENT_PATH, { force: true });
+    console.log(`[pxpipe mitm] removed launchd agent ${LAUNCH_AGENT_PATH}`);
+  }
+  console.log(
+    `[pxpipe mitm] uninstalled. Restart Claude Desktop. ` +
+      `(CA left at ${mitmDir()} — delete it to fully remove trust.)`,
+  );
+}
+
+function mitmDoctor(): void {
+  console.log('[pxpipe mitm] doctor');
+  console.log(`  openssl:       ${opensslAvailable() ? 'ok' : 'MISSING (required)'}`);
+  const caMsg = checkCa();
+  console.log(`  CA material:   ${caMsg ?? `ok (${caCertPath()})`}`);
+  let wired: string;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CLAUDE_SETTINGS, 'utf8')) as Record<string, unknown>;
+    const env = (cfg.env ?? {}) as Record<string, unknown>;
+    const okProxy = env.HTTPS_PROXY === MITM_PROXY_URL;
+    const okCa = env.NODE_EXTRA_CA_CERTS === caCertPath();
+    const baseWarn = env.ANTHROPIC_BASE_URL
+      ? `  WARNING: ANTHROPIC_BASE_URL still set (${String(env.ANTHROPIC_BASE_URL)})`
+      : '';
+    wired =
+      (okProxy && okCa
+        ? 'ok'
+        : `HTTPS_PROXY=${String(env.HTTPS_PROXY ?? 'unset')} NODE_EXTRA_CA_CERTS=${String(env.NODE_EXTRA_CA_CERTS ?? 'unset')}`) +
+      baseWarn;
+  } catch {
+    wired = `cannot read ${CLAUDE_SETTINGS}`;
+  }
+  console.log(`  settings.json: ${wired}`);
+  if (process.platform === 'darwin') {
+    const loaded = spawnSync('launchctl', ['list', LAUNCH_AGENT_LABEL], { encoding: 'utf8' }).status === 0;
+    console.log(`  launchd agent: ${loaded ? 'loaded' : 'not loaded'} (${LAUNCH_AGENT_PATH})`);
+  }
+}

--- a/src/node.ts
+++ b/src/node.ts
@@ -1213,6 +1213,11 @@ function patchClaudeSettings(): void {
   env.HTTPS_PROXY = MITM_PROXY_URL;
   env.HTTP_PROXY = MITM_PROXY_URL;
   env.NODE_EXTRA_CA_CERTS = caCertPath();
+  // Only api.anthropic.com should route through us. Exclude loopback so local
+  // tools inherited by the session (Ollama/distill, other MCP servers, local
+  // dashboards) are NOT proxied into this MITM and broken.
+  env.NO_PROXY = 'localhost,127.0.0.1,::1';
+  env.no_proxy = 'localhost,127.0.0.1,::1';
   cfg.env = env;
   fs.mkdirSync(path.dirname(CLAUDE_SETTINGS), { recursive: true });
   fs.writeFileSync(CLAUDE_SETTINGS, JSON.stringify(cfg, null, 2) + '\n');
@@ -1289,6 +1294,8 @@ function mitmUninstall(): void {
         delete env.HTTPS_PROXY;
         delete env.HTTP_PROXY;
         delete env.NODE_EXTRA_CA_CERTS;
+        delete env.NO_PROXY;
+        delete env.no_proxy;
       }
       fs.writeFileSync(CLAUDE_SETTINGS, JSON.stringify(cfg, null, 2) + '\n');
       console.log(`[pxpipe mitm] removed proxy keys from ${CLAUDE_SETTINGS}`);

--- a/src/node.ts
+++ b/src/node.ts
@@ -1134,11 +1134,6 @@ async function run(opts: RuntimeConfig, mode: 'plain' | 'mitm'): Promise<void> {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 
-main().catch((err) => {
-  console.error('[pxpipe] fatal:', err);
-  process.exit(1);
-});
-
 // ---- pxpipe mitm ----------------------------------------------------------
 
 const CLAUDE_SETTINGS = path.join(os.homedir(), '.claude', 'settings.json');
@@ -1340,3 +1335,10 @@ function mitmDoctor(): void {
     console.log(`  launchd agent: ${loaded ? 'loaded' : 'not loaded'} (${LAUNCH_AGENT_PATH})`);
   }
 }
+
+// Entry point invoked LAST, after every module-level const above is initialized
+// — main() runs synchronously into the mitm subcommands, which read those consts.
+main().catch((err) => {
+  console.error('[pxpipe] fatal:', err);
+  process.exit(1);
+});

--- a/tests/connect-route.test.ts
+++ b/tests/connect-route.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { routeConnect, parseConnect, splitHostPort } from '../src/core/connect-route.js';
+
+describe('routeConnect', () => {
+  it('MITMs api.anthropic.com (with/without port, any case)', () => {
+    expect(routeConnect('api.anthropic.com')).toBe('mitm');
+    expect(routeConnect('api.anthropic.com:443')).toBe('mitm');
+    expect(routeConnect('API.ANTHROPIC.COM')).toBe('mitm');
+  });
+  it('tunnels every other host', () => {
+    expect(routeConnect('example.com')).toBe('tunnel');
+    expect(routeConnect('api.openai.com')).toBe('tunnel');
+    expect(routeConnect('github.com')).toBe('tunnel');
+  });
+  it('tunnels look-alike hosts — exact match, never substring', () => {
+    expect(routeConnect('evil-api.anthropic.com.attacker.com')).toBe('tunnel');
+    expect(routeConnect('api.anthropic.com.attacker.com')).toBe('tunnel');
+    expect(routeConnect('notapi.anthropic.com')).toBe('tunnel');
+  });
+});
+
+describe('splitHostPort', () => {
+  it('splits host:port', () => {
+    expect(splitHostPort('api.anthropic.com:443')).toEqual({ host: 'api.anthropic.com', port: 443 });
+  });
+  it('handles bracketed IPv6', () => {
+    expect(splitHostPort('[::1]:8080')).toEqual({ host: '::1', port: 8080 });
+  });
+  it('rejects missing/invalid port', () => {
+    expect(splitHostPort('api.anthropic.com')).toBeNull();
+    expect(splitHostPort('api.anthropic.com:0')).toBeNull();
+    expect(splitHostPort('api.anthropic.com:99999')).toBeNull();
+    expect(splitHostPort('api.anthropic.com:abc')).toBeNull();
+  });
+});
+
+describe('parseConnect', () => {
+  it('parses a CONNECT request line', () => {
+    expect(parseConnect('CONNECT api.anthropic.com:443 HTTP/1.1')).toEqual({
+      host: 'api.anthropic.com',
+      port: 443,
+    });
+  });
+  it('returns null for non-CONNECT lines', () => {
+    expect(parseConnect('GET / HTTP/1.1')).toBeNull();
+    expect(parseConnect('POST /v1/messages HTTP/1.1')).toBeNull();
+    expect(parseConnect('')).toBeNull();
+  });
+});

--- a/tests/mitm-ca.test.ts
+++ b/tests/mitm-ca.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { X509Certificate } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+
+const hasOpenssl = !spawnSync('openssl', ['version']).error;
+
+// mitm-ca reads homedir() at module load (MITM_DIR is a module-level const), so
+// HOME must be set BEFORE the module is first imported — hence the dynamic import
+// inside beforeAll. Vitest isolates modules per test file, so this is clean.
+describe.skipIf(!hasOpenssl)('mitm-ca', () => {
+  let tmpHome: string;
+  let mod: typeof import('../src/core/mitm-ca.js');
+  const origHome = process.env.HOME;
+
+  beforeAll(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxpipe-ca-'));
+    process.env.HOME = tmpHome;
+    mod = await import('../src/core/mitm-ca.js');
+  });
+  afterAll(() => {
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('generates a CA + leaf (SAN=api.anthropic.com), private keys 0600', () => {
+    const m = mod.ensureCa();
+    for (const f of [m.caCertPath, m.keyPath, m.certPath]) expect(fs.existsSync(f)).toBe(true);
+    expect(fs.statSync(m.keyPath).mode & 0o077).toBe(0); // no group/other bits
+    const leaf = new X509Certificate(fs.readFileSync(m.certPath));
+    expect(leaf.subjectAltName).toContain('DNS:api.anthropic.com');
+    const ca = new X509Certificate(m.caCertPem);
+    expect(leaf.verify(ca.publicKey)).toBe(true);
+    expect(mod.checkCa()).toBeNull();
+  });
+
+  it('is idempotent — a second call keeps the same cert', () => {
+    const before = fs.readFileSync(mod.caCertPath(), 'utf8');
+    mod.ensureCa();
+    expect(fs.readFileSync(mod.caCertPath(), 'utf8')).toBe(before);
+  });
+});

--- a/tests/mitm-e2e.test.ts
+++ b/tests/mitm-e2e.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// Real end-to-end: drive the standalone `claude` CLI through the built `pxpipe
+// mitm` proxy, exactly as Claude Desktop would be wired. GATED — needs the flag,
+// the claude CLI, working credentials, and a built dist/. Off in normal CI.
+const REPO = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const DIST = path.join(REPO, 'dist', 'node.js');
+const claudeBin = spawnSync('which', ['claude'], { encoding: 'utf8' }).stdout.trim();
+const GATED =
+  process.env.PXPIPE_E2E === '1' && !!claudeBin && fs.existsSync(claudeBin) && fs.existsSync(DIST);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe.skipIf(!GATED)('mitm e2e — real claude CLI through the CONNECT proxy', () => {
+  let proxy: ChildProcess;
+  let tmpHome: string;
+  let eventsFile: string;
+  let caPath: string;
+  const port = 47990;
+
+  beforeAll(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxpipe-e2e-'));
+    eventsFile = path.join(tmpHome, 'events.jsonl');
+    caPath = path.join(tmpHome, '.pxpipe', 'mitm', 'ca.crt');
+    proxy = spawn(process.execPath, [DIST, 'mitm'], {
+      env: { ...process.env, HOME: tmpHome, PORT: String(port), PXPIPE_LOG: eventsFile },
+      stdio: 'ignore',
+    });
+    for (let i = 0; i < 150 && !fs.existsSync(caPath); i++) await sleep(100); // CA appears on start
+    await sleep(1000); // let the listener bind
+  }, 30_000);
+
+  afterAll(() => {
+    proxy?.kill('SIGTERM');
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('routes a Fable request through the proxy and logs a /v1/messages event', () => {
+    const res = spawnSync(
+      claudeBin,
+      ['--model', 'claude-fable-5', '-p', 'reply with the single word: pong'],
+      {
+        env: {
+          ...process.env,
+          HTTPS_PROXY: `http://127.0.0.1:${port}`,
+          HTTP_PROXY: `http://127.0.0.1:${port}`,
+          NODE_EXTRA_CA_CERTS: caPath,
+        },
+        encoding: 'utf8',
+        timeout: 90_000,
+      },
+    );
+    expect(res.status).toBe(0);
+    const events = fs.existsSync(eventsFile) ? fs.readFileSync(eventsFile, 'utf8') : '';
+    expect(events).toContain('/v1/messages');
+  }, 120_000);
+});

--- a/tests/mitm-tunnel.test.ts
+++ b/tests/mitm-tunnel.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import * as net from 'node:net';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+// Exercises the raw-tunnel branch of createMitmServer with real localhost
+// sockets (no network / no claude). Gated on openssl only, since createMitmServer
+// builds a TLS context from the generated leaf even for the tunnel path.
+const hasOpenssl = !spawnSync('openssl', ['version']).error;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!hasOpenssl)('mitm raw tunnel', () => {
+  let tmpHome: string;
+  let upstream: net.Server;
+  let proxy: net.Server;
+  let upPort: number;
+  let proxyPort: number;
+  let open = 0;
+  const origHome = process.env.HOME;
+
+  beforeAll(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxpipe-tunnel-'));
+    process.env.HOME = tmpHome;
+    const { ensureCa } = await import('../src/core/mitm-ca.js');
+    ensureCa();
+    const { createMitmServer } = await import('../src/core/mitm.js');
+    upstream = net.createServer((s) => {
+      open++;
+      s.on('close', () => open--);
+      s.on('error', () => {});
+      s.pipe(s); // echo
+    });
+    await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+    upPort = (upstream.address() as net.AddressInfo).port;
+    // 127.0.0.1 !== api.anthropic.com → routeConnect() returns 'tunnel'.
+    proxy = createMitmServer({ requestHandler: (_req, res) => { res.statusCode = 200; res.end('ok'); } });
+    await new Promise<void>((r) => proxy.listen(0, '127.0.0.1', () => r()));
+    proxyPort = (proxy.address() as net.AddressInfo).port;
+  });
+
+  afterAll(() => {
+    proxy?.close();
+    upstream?.close();
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function connectTunnel(): Promise<net.Socket> {
+    return new Promise((resolve, reject) => {
+      const c = net.connect(proxyPort, '127.0.0.1', () => {
+        c.write(`CONNECT 127.0.0.1:${upPort} HTTP/1.1\r\nHost: 127.0.0.1:${upPort}\r\n\r\n`);
+      });
+      c.once('data', (d) =>
+        d.toString('latin1').startsWith('HTTP/1.1 200') ? resolve(c) : reject(new Error('no 200')),
+      );
+      c.on('error', reject);
+    });
+  }
+
+  it('tunnels a non-anthropic host bidirectionally', async () => {
+    const c = await connectTunnel();
+    const echoed = await new Promise<string>((resolve) => {
+      c.once('data', (d) => resolve(d.toString('latin1')));
+      c.write('ping');
+    });
+    expect(echoed).toBe('ping');
+    c.destroy();
+    await sleep(100);
+  });
+
+  it('does not leak the upstream socket when the client RSTs', async () => {
+    const base = open;
+    const clients = await Promise.all([0, 1, 2, 3, 4].map(() => connectTunnel()));
+    await sleep(150);
+    expect(open).toBe(base + 5);
+    for (const c of clients) c.resetAndDestroy(); // abrupt RST — the leak trigger
+    await sleep(400);
+    expect(open).toBe(base); // upstreams torn down, no leak
+  });
+});

--- a/tests/sharp.test.ts
+++ b/tests/sharp.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for src/core/sharp.ts — exact-string ("sharp") span detection, the
+ * primitive behind content-aware keep-sharp (lever B of the Opus unlock).
+ *
+ * Two properties matter and pull in opposite directions:
+ *   - RECALL: every exact-critical class (hex/hash, uuid, path, flag, token,
+ *     identifier, port, url) must be flagged — a missed span is a silent,
+ *     unrecoverable mis-OCR risk.
+ *   - PRECISION: ordinary prose must NOT be flagged — every false positive is a
+ *     span forced back to text, i.e. leaked savings.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  findSharpSpans,
+  sharpDensity,
+  extractSharp,
+  restoreSharp,
+  renderSidecar,
+  type SharpKind,
+} from '../src/core/sharp.js';
+
+/** Convenience: the set of matched substrings (order-independent). */
+function hits(text: string): string[] {
+  return findSharpSpans(text).map((s) => s.text);
+}
+function kindsOf(text: string): SharpKind[] {
+  return findSharpSpans(text).map((s) => s.kind);
+}
+
+describe('findSharpSpans — recall (must flag exact-critical content)', () => {
+  it('flags a 12-char hex cache key', () => {
+    expect(hits('The token cache key is a3f9c1e0b7d2.')).toContain('a3f9c1e0b7d2');
+  });
+
+  it('flags an all-letter hex hash of length >= 12', () => {
+    expect(hits('marker deadbeefcafe end')).toContain('deadbeefcafe');
+  });
+
+  it('flags a git-style short sha containing digits', () => {
+    expect(hits('at commit 4dae94a now')).toContain('4dae94a');
+  });
+
+  it('flags a UUID', () => {
+    const u = 'ad09eac3-7e2f-4baf-80be-6995f7826101';
+    const s = findSharpSpans(`session ${u} started`);
+    expect(s.map((x) => x.text)).toContain(u);
+    expect(s.find((x) => x.text === u)?.kind).toBe('uuid');
+  });
+
+  it('flags a multi-segment file path with extension', () => {
+    const h = hits('moved into src/core/anthropic-vision.ts today');
+    expect(h).toContain('src/core/anthropic-vision.ts');
+  });
+
+  it('flags an absolute path', () => {
+    expect(hits('see /Users/foo/.claude/settings.json here')).toContain(
+      '/Users/foo/.claude/settings.json',
+    );
+  });
+
+  it('flags a CLI flag', () => {
+    expect(hits('pass --max-visual-tokens to it')).toContain('--max-visual-tokens');
+  });
+
+  it('flags a single-dash short flag', () => {
+    expect(hits('run with -v enabled')).toContain('-v');
+  });
+
+  it('flags a camelCase identifier', () => {
+    expect(hits('renamed field to tokenLedgerShard here')).toContain('tokenLedgerShard');
+  });
+
+  it('flags SCREAMING_SNAKE env vars', () => {
+    expect(hits('unset NODE_EXTRA_CA_CERTS first')).toContain('NODE_EXTRA_CA_CERTS');
+  });
+
+  it('flags a letter+digit mixed identifier', () => {
+    expect(hits('encode as utf8 stream')).toContain('utf8');
+  });
+
+  it('flags a 5-digit port', () => {
+    expect(hits('proxy stays on port 47821 ok')).toContain('47821');
+  });
+
+  it('flags a URL', () => {
+    const url = 'https://api.anthropic.com/v1/messages';
+    expect(hits(`POST ${url} now`)).toContain(url);
+  });
+
+  it('flags a long opaque base64-ish token', () => {
+    const tok = 'sk-ant-Ab12Cd34Ef56Gh78Ij90';
+    // contains a dash-run; token detector or ident should cover it
+    expect(findSharpSpans(`key ${tok} set`).length).toBeGreaterThan(0);
+  });
+});
+
+describe('findSharpSpans — precision (must NOT flag prose)', () => {
+  const proseCases = [
+    'The retry budget was three attempts, backing off gently.',
+    'This is a perfectly normal English sentence about caching.',
+    'We should decide whether and/or when to proceed.',
+    'A state-of-the-art approach to the well-known problem.',
+    'It took about 250 ms to complete the request.',
+    'Please review the design and share your feedback soon.',
+    'The quick brown fox jumps over the lazy dog.',
+  ];
+  for (const s of proseCases) {
+    it(`leaves prose untouched: "${s.slice(0, 32)}…"`, () => {
+      expect(findSharpSpans(s)).toEqual([]);
+    });
+  }
+
+  it('does not flag a 3-digit number', () => {
+    expect(hits('backing off 250 ms')).not.toContain('250');
+  });
+
+  it('does not flag a short version like 4.8', () => {
+    expect(hits('running Opus 4.8 now')).toEqual([]);
+  });
+
+  it('does not treat hyphenated prose as flags', () => {
+    expect(kindsOf('a state-of-the-art result')).not.toContain('flag');
+  });
+});
+
+describe('extractSharp / restoreSharp — round-trip and sidecar', () => {
+  const text =
+    'Done. Cache key a3f9c1e0b7d2 in src/core/anthropic-vision.ts; ' +
+    'renamed to tokenLedgerShard; flag --max-visual-tokens; port 47821.';
+
+  it('replaces every span with a marker in the body', () => {
+    const { body, sidecar } = extractSharp(text);
+    expect(sidecar.length).toBeGreaterThanOrEqual(5);
+    // None of the exact strings remain in the imaged body.
+    for (const e of sidecar) expect(body).not.toContain(e.text);
+    // Each marker appears in the body.
+    for (const e of sidecar) expect(body).toContain(e.marker);
+  });
+
+  it('round-trips exactly', () => {
+    const { body, sidecar } = extractSharp(text);
+    expect(restoreSharp(body, sidecar)).toBe(text);
+  });
+
+  it('de-duplicates repeated spans to one sidecar entry', () => {
+    const dup = 'first a3f9c1e0b7d2 then a3f9c1e0b7d2 again';
+    const { sidecar, body } = extractSharp(dup);
+    const hexEntries = sidecar.filter((e) => e.text === 'a3f9c1e0b7d2');
+    expect(hexEntries.length).toBe(1);
+    // Marker used twice in the body.
+    const marker = hexEntries[0]!.marker;
+    expect(body.split(marker).length - 1).toBe(2);
+    expect(restoreSharp(body, sidecar)).toBe(dup);
+  });
+
+  it('markers [#1].. do not shadow [#11] on restore', () => {
+    const many = Array.from({ length: 12 }, (_, i) => `id${i}a1b2c3d4e5f6`).join(' ');
+    const { body, sidecar } = extractSharp(many);
+    expect(sidecar.length).toBe(12);
+    expect(restoreSharp(body, sidecar)).toBe(many);
+  });
+
+  it('no-op body when there is nothing sharp', () => {
+    const prose = 'A perfectly ordinary sentence with no identifiers.';
+    const { body, sidecar } = extractSharp(prose);
+    expect(body).toBe(prose);
+    expect(sidecar).toEqual([]);
+  });
+
+  it('renderSidecar emits a labelled verbatim block', () => {
+    const { sidecar } = extractSharp(text);
+    const block = renderSidecar(sidecar);
+    expect(block).toContain('read verbatim');
+    for (const e of sidecar) expect(block).toContain(e.text);
+  });
+});
+
+describe('sharpDensity — block-level signal', () => {
+  it('is high for an ID-dominated block', () => {
+    const dense = 'a3f9c1e0b7d2 ad09eac3-7e2f-4baf-80be-6995f7826101 /a/b/c.ts --flag-x 47821';
+    expect(sharpDensity(dense)).toBeGreaterThan(0.5);
+  });
+
+  it('is ~0 for prose', () => {
+    expect(sharpDensity('This is a normal sentence with ordinary words.')).toBe(0);
+  });
+
+  it('is modest for mixed prose with a couple of identifiers', () => {
+    const mixed =
+      'We wired the retry path and set the cache key to a3f9c1e0b7d2 after review.';
+    const d = sharpDensity(mixed);
+    expect(d).toBeGreaterThan(0);
+    expect(d).toBeLessThan(0.4);
+  });
+});


### PR DESCRIPTION
## What & why

The base-URL proxy can't reach **Claude Desktop**: its embedded claude-code pins
`ANTHROPIC_BASE_URL=https://api.anthropic.com` and Claude Code's `settings.json`
`env` block can't override an already-set variable. Desktop-only users get no
compression.

`pxpipe mitm` fixes that with a different interception point. Desktop leaves
`HTTPS_PROXY` / `NODE_EXTRA_CA_CERTS` **unset** (and honors them from
`settings.json` env), so mitm mode runs a local HTTP **CONNECT** proxy the client
reaches via `HTTPS_PROXY`: it TLS-terminates **only** `api.anthropic.com` with a
locally-generated CA to compress requests, and **raw-tunnels every other host
untouched**. Decrypted requests flow into the same `createProxy` handle, so
transform / events / dashboard / gate / cache-alignment are reused unchanged.

## How it works

```
client --HTTPS_PROXY--> CONNECT api.anthropic.com  -> TLS-terminate (our leaf, ALPN http/1.1)
                                                      -> emit('connection') into the shared handler
                                                      -> transform (Fable-only) -> real api.anthropic.com
                        CONNECT any other host      -> net.connect + raw pipe (no inspection)
```

- `src/core/connect-route.ts` — exact-host routing (never substring) + CONNECT parse
- `src/core/mitm-ca.ts` — openssl-shelled local CA + `api.anthropic.com` leaf (0600); no new runtime dep
- `src/core/mitm.ts` — CONNECT front-end; ALPN forced to `http/1.1`; raw tunnel ties both sockets' lifecycles so a client RST can't leak the upstream
- `src/node.ts` — `main()` split into `run(opts, mode)`; `pxpipe mitm [install|uninstall|doctor]`; idempotent backup-preserving `settings.json` patch; launchd keepalive
- Node-only modules are imported **only** from `node.ts`, never the Workers graph

## Included fixes (each its own commit)

- **`cache_control.scope: "global"`** — being transparent, mitm is the first path
  to receive Claude Code's `scope:"global"` markers (withheld on a custom base
  URL). pxpipe relocates the marker onto a user-message image block — after
  tools+system — so global scope is no longer a true prefix and Anthropic 400s.
  `stripCacheScope` drops `scope` from relocated markers (no-op when absent, so
  base-URL mode is unchanged).
- **`main()` ordering** — the `mitm` subcommand consts were declared after the
  `main()` invocation; `mitm install` read them in the temporal dead zone and
  crashed. `main()` is now invoked last.
- **`NO_PROXY` for loopback** — install wrote `HTTP_PROXY`/`HTTPS_PROXY` but no
  `NO_PROXY`, so every localhost HTTP client the session inherits (Ollama/distill,
  local MCP servers, dashboards) got routed into the MITM and broke. install now
  sets `NO_PROXY=localhost,127.0.0.1,::1`; uninstall removes it. `api.anthropic.com`
  still routes through the proxy; only loopback is excluded.

## Verification

- **Live:** real `claude` (Fable) through the proxy compresses `/v1/messages` at
  200 with **zero 400s**, on both the source and the built `dist`; observed
  compressing a real Desktop task into 45 image pages. Opus passes through.
- **A/B (actual bill, no baseline assumptions):** 6 identical warm turns through
  ON (compress) vs OFF (passthrough) → ON actual input-eff **93,106** vs OFF
  **128,627** = **pxpipe ~28% cheaper on the real bill even on warm/churning
  traffic** (both arms bust their cache under Claude Code's per-request-varying
  prefixes; the image just has ~10× fewer tokens to re-create).
- **Unit:** `connect-route` (routing/security incl. look-alike hosts), `mitm-ca`
  (cert chain / SAN / 0600 / idempotency), `mitm-tunnel` (bidirectional + no leak
  on RST), gated `mitm-e2e` (real claude CLI). `tsc --noEmit` clean.
- **install ↔ uninstall** round-trip verified: patches `settings.json` (adds
  proxy + `NO_PROXY`, removes `ANTHROPIC_BASE_URL`, keeps other keys, writes a
  backup) and restores it byte-for-byte.
- Adversarial review flagged one real bug (upstream socket leak on client RST) —
  fixed and reproduced-fixed.

## Bonus: unlocking Opus/lower-tier models (exploratory, gated)

Production only images Fable 5 by default — Opus is excluded because it
mis-reads dense exact strings (documented: 6/15 dense-hex recall vs Fable's
100/100). Explored two safe levers to close that gap, both offline/API-key-free
and fully reversible — **no production/default behavior changed**:

- **Content-aware keep-sharp** (`src/core/sharp.ts`, `eval/opus-density/`): a
  reusable detector finds exact-string spans (hex/hash, UUID, path, CLI flag,
  identifier, port, URL) and lifts them into a small verbatim text sidecar,
  imaging only the surrounding prose. Dry-run cost proof: **75% saved** (vs 79%
  baseline) while guaranteeing correct recall on every detected span — far
  cheaper than the existing density lever (7×10 cell costs 17pp for the same
  goal). 30 unit tests (precision: zero prose false positives; recall: every
  target class).
- **Offline glyph-confusability screen** (`eval/glyph-confusability/`): decodes
  the real production Spleen 5×8 atlas, simulates the vision encoder's blur, and
  ranks confusable pairs. Validated 2 safe pixel-level de-collision fixes (`2`,
  `5` — each broke an accidental shared row with its confusable partner, zero
  side effects on the full 94-glyph alphabet) and rigorously reverted 3 failed
  attempts (`0`, `6`/`G` across two techniques, `8`/`B`) with full-alphabet
  regression checks each time. Documents a real, transferable finding: at 5×8 +
  blur, *adding ink to "bolden" a glyph backfires* — it converges toward a
  generic blob shape other bold glyphs also share; only relocating/removing an
  already-shared pixel worked, and even that technique doesn't mechanically
  generalize glyph-to-glyph.

Both are **explicitly gated** on a real scored eval run (`ANTHROPIC_API_KEY`,
`eval/opus-density/run.mjs`) per that harness's own acceptance bar (gist ==
baseline; zero silent-wrong exact strings; savings stay positive) before any
model-scope or atlas change ships. Included here as validated groundwork, not a
request to change defaults.

## Caveats

- **MITM decrypts `api.anthropic.com` locally**, so the API/OAuth token is in
  plaintext to the proxy (loopback only, never written to `events.jsonl`). The CA
  signs only `api.anthropic.com`.
- Requires system `openssl` (macOS/Linux). Windows not supported in v1.
- Design spec: `docs/superpowers/specs/2026-07-04-mitm-mode-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
