### PR TITLE
fix(transform): never inject description into native typed tools

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1541,6 +1541,18 @@ export async function transformRequest(
   if (o.compressTools && Array.isArray(req.tools) && req.tools.length > 0) {
     const docs: string[] = [];
     toolsRewritten = req.tools.map((t) => {
+      // Native server-side tools (`advisor_20260301`, `web_search_20250305`,
+      // `computer_20250124`, `bash_20250124`, `text_editor_20250429`, ...) carry
+      // a versioned `type` fixed by Anthropic's own API schema, which rejects a
+      // `description` field on that tool entry outright (400 invalid_request_error:
+      // "tools.N.<type>.description: Extra inputs are not permitted" — reproduced
+      // 4/4 on claude-fable-5, 2026-07-05). Only the default 'custom' shape (no
+      // `type`, or `type: 'custom'`) accepts a description/input_schema rewrite.
+      // Pass anything else through byte-identical: it never had docs to relocate,
+      // so there's nothing to move into the imaged Tool Reference either.
+      if (typeof t.type === 'string' && t.type !== 'custom') {
+        return t;
+      }
       docs.push(renderToolDoc(t));
       // tools[] keeps the annotation-STRIPPED schema: structure (type/properties/
       // required/enum/items) stays for Anthropic's tool-use validator — a bare

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -53,6 +53,10 @@ export interface ToolDef {
   description?: string;
   input_schema?: unknown;
   cache_control?: CacheControl;
+  /** Anthropic server-side tools (e.g. `advisor_20260301`, `web_search_20250305`,
+   *  `computer_20250124`) set this to a versioned type string fixed by their own
+   *  API schema. Absent, or `'custom'`, on ordinary client-defined tools. */
+  type?: string;
 }
 
 export type SystemField = string | Array<TextBlock | ImageBlock>;

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -744,6 +744,51 @@ describe('transform', () => {
     expect(refHeader).toContain("this user's local proxy");
   });
 
+  it('never rewrites native server-side tools (versioned `type`), only stubs custom ones', async () => {
+    // Regression for the 2026-07-05 incident: Anthropic's native tools (advisor,
+    // web_search, computer, bash, text_editor, ...) are versioned by `type` and
+    // their API schema rejects a `description` field on the tool entry outright
+    // — 400 invalid_request_error: "tools.N.advisor_20260301.description: Extra
+    // inputs are not permitted". Reproduced 4/4 on claude-fable-5 because the
+    // old code unconditionally overwrote every tools[] entry's description with
+    // the "Full docs: see ..." stub, native tools included. Native-typed entries
+    // must pass through byte-identical (no description added, no schema touched,
+    // no doc pulled into the imaged reference); ordinary custom tools keep the
+    // existing stub-and-image behavior.
+    const nativeTool = { type: 'advisor_20260301', name: 'advisor' };
+    const req = JSON.stringify({
+      model: 'claude-3-5-sonnet',
+      messages: [{ role: 'user', content: 'hi' }],
+      system: 'x'.repeat(30000),
+      tools: [
+        nativeTool,
+        {
+          name: 'BigTool',
+          description: 'A very long tool description. '.repeat(500),
+          input_schema: { type: 'object', properties: { x: { type: 'string' } } },
+        },
+      ],
+    });
+    const bytes = new TextEncoder().encode(req);
+    const { body, info } = await transformRequest(bytes);
+    expect(info.compressed).toBe(true);
+    expect(info.toolDocsChars).toBeGreaterThan(0);
+
+    const out = JSON.parse(new TextDecoder().decode(body));
+    // The native tool entry is untouched: no description key was added, no
+    // input_schema key was added, and the object is deep-equal to the original.
+    expect(out.tools[0]).toEqual(nativeTool);
+    expect(Object.keys(out.tools[0]).sort()).toEqual(['name', 'type']);
+    // The custom tool still gets the usual stub-and-image treatment.
+    expect(out.tools[1].name).toBe('BigTool');
+    expect(out.tools[1].description).toContain('"## Tool: BigTool"');
+    // The native tool never had docs to relocate — it must not appear in the
+    // imaged Tool Reference at all.
+    const imgSrc = info.imageSourceText ?? '';
+    expect(imgSrc).toContain('## Tool: BigTool');
+    expect(imgSrc).not.toContain('## Tool: advisor');
+  });
+
   it('ships annotation-stripped schemas in tools[], full schema in the imaged reference', async () => {
     // History: a bare `{type:'object'}` stub caused validator 400s; a text
     // reference paid the annotations at text rates. Current contract: tools[]


### PR DESCRIPTION
## Summary

The Anthropic tool-doc compression path in `transformRequest()` unconditionally overwrites `description` on every `tools[]` entry with the `"ⓘ Full docs: see …"` stub. Native server-side tools with a versioned `type` (e.g. `advisor_20260301` from the `advisor-tool-2026-03-01` beta) have a fixed API schema that does not accept a `description` field, so any request carrying one of these tools gets rejected with:

```
400 invalid_request_error:
tools.287.advisor_20260301.description: Extra inputs are not permitted
```

The OpenAI path already guards against this via `isFunctionTool()` (`src/core/openai.ts`); the Anthropic path lacked the equivalent guard.

## Fix

Pass tool entries through untouched when `typeof t.type === 'string' && t.type !== 'custom'` — i.e. any native/versioned tool type — and skip them when building the imaged Tool Reference doc, mirroring the existing `isFunctionTool()` guard on the OpenAI side.

## Testing

- Added a unit test covering the native typed-tool pass-through.
- Full suite: 644/646 pass. The 2 failures are pre-existing on a clean `main` checkout (unrelated: a docs-integrity check missing `RENDER_SIZING.md`, and a flaky canvas timeout).
- E2E smoke test: 3/3 requests on `claude-fable-5` with the native advisor tool present in `tools[]` now return 200 with `compressed:true` and −46…−48% billed input (previously 400 on every request).

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
