### PR TITLE
fix: preserve $schema and draft-07 tuple items in schema stripper

### DIFF
--- a/src/core/schema-strip.ts
+++ b/src/core/schema-strip.ts
@@ -18,13 +18,17 @@
  *  deeper nodes are left untouched rather than corrupted. */
 const SCHEMA_STRIP_MAX_DEPTH = 20;
 
-/** Metadata keys that add tokens but no validation; the image carries them for the model. */
+/** Metadata keys that add tokens but no validation; the image carries them for the model.
+ *  `$schema` is deliberately NOT here: it is the dialect declaration, not an annotation.
+ *  Stripping it re-dialects the schema to the validator's default (JSON Schema 2020-12),
+ *  which 400s draft-07 constructs the original legally used — e.g. tuple-form
+ *  `items: [...]` in Voiceflow MCP tools ("tools.N.custom.input_schema: JSON schema
+ *  is invalid. It must match JSON Schema draft 2020-12"). */
 const SCHEMA_STRIP_KEYS = new Set([
   'description',
   'title',
   'examples',
   'default',
-  '$schema',
   '$id',
   '$comment',
 ]);

--- a/src/core/schema-strip.ts
+++ b/src/core/schema-strip.ts
@@ -64,6 +64,7 @@ const SCHEMA_SINGLE_SUBSCHEMA_KEYS = new Set([
  *  `required`/`enum`/`const` MUST survive untouched: stripping a property while
  *  leaving its name in `required` is exactly the bug this module prevents. */
 const SCHEMA_VERBATIM_KEYS = new Set([
+  '$schema',        // dialect declaration; stripping it can invalidate the schema
   'required',
   'enum',
   'const',
@@ -89,7 +90,7 @@ const FORMAT_MAX_LEN = 32;
 
 /** Strip long-form metadata from a JSON Schema node, preserving the structural
  *  keys a tool-use validator needs. Strips: description, title, examples,
- *  default, $schema, $id, $comment, long format. Recurses into
+ *  default, $id, $comment, long format. Recurses into
  *  properties/oneOf/anyOf/allOf/items etc. Returns a fresh object — never
  *  mutates the input. Property *names* (the keys inside `properties` and
  *  friends) are preserved even when they collide with annotation keywords. */
@@ -136,6 +137,8 @@ export function stripSchemaDescriptions(node: unknown, depth = 0): unknown {
       // additionalProperties may be a boolean — pass through untouched.
       if (typeof v === 'boolean') {
         out[k] = v;
+      } else if (Array.isArray(v)) {
+        out[k] = v.map((sub) => stripSchemaDescriptions(sub, depth + 1));
       } else {
         out[k] = stripSchemaDescriptions(v, depth + 1);
       }

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -870,7 +870,13 @@ describe('transform', () => {
                       properties: {
                         op: { type: 'string', enum: ['between'], description: 'operator' },
                         // draft-07 tuple validation — array-form `items`.
-                        value: { type: 'array', items: [{ type: 'number' }, { type: 'number' }] },
+                        value: {
+                          type: 'array',
+                          items: [
+                            { type: 'number', description: 'lower bound' },
+                            { type: 'number', description: 'upper bound' },
+                          ],
+                        },
                       },
                       required: ['op', 'value'],
                     },

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -747,9 +747,9 @@ describe('transform', () => {
   it('ships annotation-stripped schemas in tools[], full schema in the imaged reference', async () => {
     // History: a bare `{type:'object'}` stub caused validator 400s; a text
     // reference paid the annotations at text rates. Current contract: tools[]
-    // keeps the structural contract (type/properties/required/enum) for the
-    // validator, annotations (description/default/$schema) move into the
-    // imaged reference where they cost image rates.
+    // keeps the structural contract (type/properties/required/enum) AND the
+    // `$schema` dialect declaration for the validator; annotations
+    // (description/default) move into the imaged reference at image rates.
     const req = JSON.stringify({
       model: 'claude-3-5-sonnet',
       messages: [{ role: 'user', content: 'hi' }],
@@ -821,9 +821,11 @@ describe('transform', () => {
     expect(Object.keys(s0.properties)).toEqual(['file_path', 'mode']);
     expect(s0.required).toEqual(['file_path']);
     expect(s0.properties.mode.enum).toEqual(['read', 'binary']);
-    // Annotations are stripped from tools[] everywhere in the tree.
+    // Annotations are stripped from tools[] everywhere in the tree — but the
+    // `$schema` dialect declaration survives (stripping it re-dialects a
+    // draft-07 schema to 2020-12 and the validator 400s legal draft-07 syntax).
     expect(JSON.stringify(s0)).not.toContain('description');
-    expect(s0.$schema).toBeUndefined();
+    expect(s0.$schema).toBe('http://json-schema.org/draft-07/schema#');
     expect(s0.properties.mode.default).toBeUndefined();
     const s1 = out.tools[1].input_schema;
     expect(s1.required).toEqual(['command']);
@@ -837,6 +839,61 @@ describe('transform', () => {
     // Stubs cite the reference heading.
     expect(out.tools[0].description).toContain('"## Tool: Read"');
     expect(out.tools[1].description).toContain('"## Tool: Bash"');
+  });
+
+  it('keeps $schema so draft-07 tuple items stay valid under the declared dialect', async () => {
+    // Regression (2026-07-05): Voiceflow MCP's voiceflow_transcript declares
+    // draft-07 and uses tuple-form `items: [...]`, which is illegal in the
+    // API's default dialect (2020-12, where tuples are `prefixItems`).
+    // Stripping `$schema` re-dialected the schema and every compressed request
+    // 400'd: "tools.N.custom.input_schema: JSON schema is invalid. It must
+    // match JSON Schema draft 2020-12". Passthrough of the same schema is
+    // accepted — so the transform must keep the declaration.
+    const req = JSON.stringify({
+      model: 'claude-3-5-sonnet',
+      messages: [{ role: 'user', content: 'hi' }],
+      system: 'x'.repeat(30000),
+      tools: [
+        {
+          name: 'voiceflow_transcript',
+          description: 'Search transcripts',
+          input_schema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+              filters: {
+                type: 'array',
+                items: {
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        op: { type: 'string', enum: ['between'], description: 'operator' },
+                        // draft-07 tuple validation — array-form `items`.
+                        value: { type: 'array', items: [{ type: 'number' }, { type: 'number' }] },
+                      },
+                      required: ['op', 'value'],
+                    },
+                  ],
+                },
+              },
+            },
+            required: ['filters'],
+          },
+        },
+      ],
+    });
+    const { body, info } = await transformRequest(new TextEncoder().encode(req));
+    expect(info.compressed).toBe(true);
+    const out = JSON.parse(new TextDecoder().decode(body));
+    const s = out.tools[0].input_schema;
+    // Dialect declaration survives — the tuple `items` stays legal.
+    expect(s.$schema).toBe('http://json-schema.org/draft-07/schema#');
+    const between = s.properties.filters.items.oneOf[0];
+    expect(Array.isArray(between.properties.value.items)).toBe(true);
+    expect(between.properties.value.items).toEqual([{ type: 'number' }, { type: 'number' }]);
+    // Annotations still stripped.
+    expect(between.properties.op.description).toBeUndefined();
   });
 
   it('passes a bare {type:"object"} schema through with no advisory', async () => {


### PR DESCRIPTION
## Problem

`stripSchemaDescriptions` treats `$schema` as a strippable annotation key and collapses array-form (tuple) `items` subschemas.

For MCP tools that publish draft-07 schemas using tuple syntax — e.g. a transcript filter declaring `"items": [{"type":"number"},{"type":"number"}]` for a `between` range — stripping the `$schema` dialect declaration causes the API to validate the schema as 2020-12, where array-form `items` is invalid. The result is a 400 on every compressed request containing the tool, and since the retry re-sends the same transformed body, pxpipe silently 400-loops and falls back to the uncompressed path (losing all token savings).

## Fix

- Move `$schema` from `SCHEMA_STRIP_KEYS` to `SCHEMA_VERBATIM_KEYS` so dialect declarations survive verbatim at any depth
- Recurse tuple-form `items` arrays per-element instead of collapsing them

## Testing

- Added a regression test replaying a captured real-world failing tool schema (Voiceflow MCP `voiceflow_transcript`, draft-07 with tuple `items`) through `transformRequest`
- Full suite passes (631/631), typecheck clean
- Verified live: after deploying the patched build, previously-failing compressed requests return 200 with no new 4xx captures