### PR TITLE
fix(proxy): never route an sk-ant bearer to the OpenAI upstream

### DIFF
--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -520,7 +520,14 @@ function isOpenAIResponsesPath(pathname: string): boolean {
 
 function isCanonicalOpenAIPath(pathname: string, headers: Headers, hasOpenAIKey: boolean): boolean {
   const isModelsPath = pathname === '/v1/models' || pathname.startsWith('/v1/models/');
-  const looksOpenAIAuth = hasOpenAIKey || (headers.has('authorization') && !headers.has('x-api-key'));
+  // `/v1/models` exists on BOTH APIs, so it is routed by auth style — but an
+  // `sk-ant-…` bearer is Anthropic by construction (Claude Code subscription
+  // auth sends `authorization: Bearer sk-ant-oat01-…` with no x-api-key).
+  // Without this check that OAuth token would be forwarded to the OpenAI
+  // upstream: a credential leak, and a guaranteed 401.
+  const bearerIsAnthropic = /^Bearer\s+sk-ant-/i.test(headers.get('authorization') ?? '');
+  const looksOpenAIAuth =
+    hasOpenAIKey || (headers.has('authorization') && !headers.has('x-api-key') && !bearerIsAnthropic);
   return pathname === '/v1/chat/completions'
     || pathname === '/v1/responses'
     || pathname.startsWith('/v1/responses/')

--- a/tests/models-auth-routing.test.ts
+++ b/tests/models-auth-routing.test.ts
@@ -1,0 +1,67 @@
+/**
+ * /v1/models routing by auth style. The path exists on BOTH APIs, so the
+ * proxy sniffs the auth header — but an `sk-ant-…` bearer is Anthropic by
+ * construction (Claude Code subscription auth sends
+ * `authorization: Bearer sk-ant-oat01-…` with no x-api-key). It must never
+ * be forwarded to the OpenAI upstream. All tokens here are fake; the suite
+ * never touches the network (global fetch is stubbed).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { createProxy } from '../src/core/proxy.js';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function stubFetch(capture: { url?: string; headers?: Headers }) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    capture.url = String(input);
+    capture.headers = new Headers(init?.headers);
+    return new Response(JSON.stringify({ data: [] }), {
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+describe('/v1/models auth-style routing', () => {
+  const proxy = () => createProxy({});
+
+  it('routes an sk-ant bearer (Claude Code OAuth) to the Anthropic upstream', async () => {
+    const cap: { url?: string; headers?: Headers } = {};
+    stubFetch(cap);
+    await proxy()(
+      new Request('http://localhost/v1/models', {
+        method: 'GET',
+        headers: { authorization: 'Bearer sk-ant-oat01-fake-oauth-token' },
+      }),
+    );
+    expect(cap.url).toBe('https://api.anthropic.com/v1/models');
+    // The token stays on the Anthropic leg, never crosses to api.openai.com.
+    expect(cap.headers?.get('authorization')).toBe('Bearer sk-ant-oat01-fake-oauth-token');
+  });
+
+  it('still routes a non-Anthropic bearer to the OpenAI upstream', async () => {
+    const cap: { url?: string; headers?: Headers } = {};
+    stubFetch(cap);
+    await proxy()(
+      new Request('http://localhost/v1/models', {
+        method: 'GET',
+        headers: { authorization: 'Bearer fake-openai-key' },
+      }),
+    );
+    expect(cap.url).toBe('https://api.openai.com/v1/models');
+  });
+
+  it('still routes x-api-key requests to the Anthropic upstream', async () => {
+    const cap: { url?: string; headers?: Headers } = {};
+    stubFetch(cap);
+    await proxy()(
+      new Request('http://localhost/v1/models', {
+        method: 'GET',
+        headers: { 'x-api-key': 'fake-anthropic-key' },
+      }),
+    );
+    expect(cap.url).toBe('https://api.anthropic.com/v1/models');
+  });
+});


### PR DESCRIPTION
`/v1/models` exists on both APIs, so the proxy routes it by auth style: any request carrying an `authorization` header and no `x-api-key` was treated as OpenAI-bound. Claude Code subscription auth matches exactly that shape — `authorization: Bearer sk-ant-oat01-…`, no `x-api-key` — so a client calling `GET /v1/models` through the proxy would have its **Anthropic OAuth token forwarded to api.openai.com**: a credential sent to a third party, plus a guaranteed 401 for the caller.

I hit this reviewing the routing while wiring pxpipe up as an always-on proxy for Claude Code subscription sessions (where every request authenticates with an sk-ant bearer). I didn't observe Claude Code calling `/v1/models` in practice, so this is latent rather than actively firing — but the leak path is real for any client that does, and cheap to close.

### Fix

An `sk-ant-`-prefixed bearer is Anthropic by construction; exclude it from the OpenAI auth sniff in `isCanonicalOpenAIPath`. Behavior is otherwise unchanged: non-Anthropic bearers keep routing `/v1/models` to OpenAI, `x-api-key` requests keep routing to Anthropic, and the explicit-key and provider-prefixed paths are untouched.

### Tests

`tests/models-auth-routing.test.ts` (stubbed fetch, no network, matching the `gateway.test.ts` conventions):

- sk-ant bearer on `/v1/models` → `https://api.anthropic.com/v1/models`, token stays on the Anthropic leg
- non-Anthropic bearer on `/v1/models` → `https://api.openai.com/v1/models` (unchanged)
- `x-api-key` on `/v1/models` → Anthropic (unchanged)

Full suite: 648/648 passing, typecheck clean.

### Verification (runtime, not code-reading)

1. **The misroute is real.** Running `tests/models-auth-routing.test.ts` against the parent commit (pre-fix tree, stubbed fetch capturing the outbound URL):

   ```
   AssertionError: expected 'https://api.openai.com/v1/models' to be 'https://api.anthropic.com/v1/models'
   Received: "https://api.openai.com/v1/models"
   ```

   The sk-ant bearer request is captured leaving for the OpenAI upstream. The other two tests (non-Anthropic bearer → OpenAI, x-api-key → Anthropic) pass on the pre-fix tree too, i.e. the fix changes nothing else.

2. **The auth shape is real.** Wire capture of a live Claude Code subscription session pointed at a local listener: every request carries `authorization: Bearer sk-ant-oat01-…` and **no `x-api-key` header** — exactly the shape the pre-fix sniff classifies as OpenAI. (The session issued only `POST /v1/messages` during capture — no `/v1/models` — consistent with "latent rather than actively firing" above.)
