### PR TITLE
Skip tool-doc rewrite for native typed tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ normally — pxpipe compresses the *request* only, never the model's output.
 Recent turns stay text; the system prompt, tool docs, and older bulk history
 are imaged.
 
+## Offline export
+
+You can also render local text, files, or diffs to PNG pages without running
+the proxy or connecting Claude Code:
+
+```bash
+echo "your prompt text" | npx pxpipe-proxy export --stdin --open
+npx pxpipe-proxy export path/to/folder
+npx pxpipe-proxy export . --include "*.ts"
+npx pxpipe-proxy export --git
+```
+
+`pxpipe export` writes `page-001.png...`, `factsheet.txt`, `manifest.json`,
+and `prompt.txt` to an output folder. Use this for bulky code, logs, JSON, or
+docs that another vision-capable client can accept as image uploads; short
+prompts usually cost less as plain text.
+
 ## The honest part
 
 - **It is lossy.** Exact 12-char hex strings in dense imaged content:

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1536,11 +1536,15 @@ export async function transformRequest(
   //    and cache-friendly. Each stub description cites its own heading
   //    ("## Tool: <name>") so the model can link stub → full doc
   //    deterministically.
-  let toolDocsText = '';
-  let toolsRewritten: ToolDef[] | undefined;
-  if (o.compressTools && Array.isArray(req.tools) && req.tools.length > 0) {
+    let toolDocsText = '';
+    let toolsRewritten: ToolDef[] | undefined;
+    if (o.compressTools && Array.isArray(req.tools) && req.tools.length > 0) {
     const docs: string[] = [];
     toolsRewritten = req.tools.map((t) => {
+      const toolType = (t as { type?: unknown }).type;
+      if (typeof toolType === 'string' && toolType !== 'custom') {
+        return t;
+      }
       docs.push(renderToolDoc(t));
       // tools[] keeps the annotation-STRIPPED schema: structure (type/properties/
       // required/enum/items) stays for Anthropic's tool-use validator — a bare

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -744,6 +744,40 @@ describe('transform', () => {
     expect(refHeader).toContain("this user's local proxy");
   });
 
+  it('skips tool-doc rewriting for native typed tools', async () => {
+    const req = JSON.stringify({
+      model: 'claude-3-5-sonnet',
+      messages: [{ role: 'user', content: 'hi' }],
+      system: 'x'.repeat(30000),
+      tools: [
+        {
+          type: 'advisor_20260301',
+          name: 'advisor_20260301',
+          description: 'Native advisor tool docs should stay intact.',
+          input_schema: { type: 'object', properties: { prompt: { type: 'string' } } },
+        },
+        {
+          type: 'custom',
+          name: 'CustomTool',
+          description: 'Custom tool should still be compressed.',
+          input_schema: { type: 'object', properties: { arg: { type: 'string' } } },
+        },
+      ],
+    });
+    const bytes = new TextEncoder().encode(req);
+    const { body, info } = await transformRequest(bytes);
+    expect(info.compressed).toBe(true);
+    expect(info.toolDocsChars).toBeGreaterThan(0);
+
+    const out = JSON.parse(new TextDecoder().decode(body));
+    const nativeTool = out.tools.find((tool: { type?: string }) => tool.type === 'advisor_20260301');
+    const customTool = out.tools.find((tool: { type?: string }) => tool.type === 'custom');
+    expect(nativeTool).toBeDefined();
+    expect(customTool).toBeDefined();
+    expect(nativeTool?.description).toBe('Native advisor tool docs should stay intact.');
+    expect(customTool?.description).toContain('Tool Reference');
+  });
+
   it('ships annotation-stripped schemas in tools[], full schema in the imaged reference', async () => {
     // History: a bare `{type:'object'}` stub caused validator 400s; a text
     // reference paid the annotations at text rates. Current contract: tools[]


### PR DESCRIPTION
## What this fixes
- Skip tool-doc rewriting for Anthropic native/typed tools in `transformRequest` when a `type` is present and not `custom`.
- Keep native typed tools untouched in `tools[]` to avoid injecting a `description` field that can trigger 400 extra-inputs.
- Add a regression test that verifies native typed tools stay unchanged while `custom` tools still get compressed stubs.

## Validation
- pnpm typecheck
- pnpm test tests/render.test.ts
