### PR TITLE
[codex] Support Windows build and service tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bin/",
     "dist/",
     "!dist/**/*.map",
+    "scripts/service.mjs",
     "README.md",
     "LICENSE"
   ],
@@ -50,6 +51,9 @@
     "dev:worker": "wrangler dev",
     "deploy:worker": "wrangler deploy",
     "restart": "bash scripts/restart.sh",
+    "service": "node scripts/service.mjs",
+    "start": "node scripts/service.mjs start",
+    "stop": "node scripts/service.mjs stop",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -19,7 +19,9 @@ await mkdir(OUT, { recursive: true });
 
 const tsc = spawnSync('pnpm', ['exec', 'tsc', '-p', 'tsconfig.json'], {
   stdio: 'inherit',
-  shell: false,
+  // shell: true so Windows resolves the `pnpm.cmd` shim (spawn can't exec a
+  // .cmd without a shell); harmless on POSIX.
+  shell: true,
 });
 if (tsc.status !== 0) process.exit(tsc.status ?? 1);
 console.log('✓ emitted dist/ library modules + declarations');

--- a/scripts/service.mjs
+++ b/scripts/service.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// Cross-platform start/stop/toggle for the local pxpipe proxy.
+//
+// Unlike scripts/restart.sh (bash + pgrep/lsof, POSIX-only, restart-only),
+// this runs anywhere Node does — including Windows Git Bash / PowerShell — and
+// tracks the process by a pidfile instead of scanning the process table.
+//
+// Usage:
+//   node scripts/service.mjs [start|stop|restart|status|toggle]
+//   (no argument defaults to `toggle`: start if down, stop if up)
+//
+// Honors PORT / HOST like the proxy itself. Logs go to ~/.pxpipe/pxpipe.log.
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, openSync } from 'node:fs';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const entry = path.join(repoRoot, 'dist', 'node.js');
+const stateDir = path.join(homedir(), '.pxpipe');
+const pidFile = path.join(stateDir, 'pxpipe.pid');
+const logFile = path.join(stateDir, 'pxpipe.log');
+const port = process.env.PORT || '47821';
+
+function cleanPidFile() {
+  rmSync(pidFile, { force: true });
+}
+
+function samePath(a, b) {
+  const left = path.resolve(a);
+  const right = path.resolve(b);
+  return process.platform === 'win32' ? left.toLowerCase() === right.toLowerCase() : left === right;
+}
+
+function readPidState() {
+  if (!existsSync(pidFile)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(pidFile, 'utf8'));
+    if (
+      parsed &&
+      Number.isInteger(parsed.pid) &&
+      parsed.pid > 0 &&
+      typeof parsed.entry === 'string' &&
+      typeof parsed.repoRoot === 'string'
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Legacy/plain or corrupt pidfile. Do not trust it enough to signal a PID.
+  }
+  cleanPidFile();
+  return null;
+}
+
+function processCommandLine(pid) {
+  if (process.platform === 'win32') {
+    const ps = spawnSync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; ` +
+          `if ($p -and $p.CommandLine) { ` +
+          `[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($p.CommandLine)) ` +
+          `}`,
+      ],
+      { encoding: 'utf8', windowsHide: true },
+    );
+    return ps.status === 0 ? Buffer.from(ps.stdout.trim(), 'base64').toString('utf8') : '';
+  }
+
+  const procCmdline = `/proc/${pid}/cmdline`;
+  if (existsSync(procCmdline)) {
+    const raw = readFileSync(procCmdline, 'utf8').replace(/\0/g, ' ').trim();
+    if (raw) return raw;
+  }
+
+  const ps = spawnSync('ps', ['-p', String(pid), '-o', 'command='], { encoding: 'utf8' });
+  return ps.status === 0 ? ps.stdout.trim() : '';
+}
+
+function commandMatchesEntry(command) {
+  const normalize = (s) => {
+    const out = s.replace(/\\/g, '/');
+    return process.platform === 'win32' ? out.toLowerCase() : out;
+  };
+  return normalize(command).includes(normalize(entry));
+}
+
+// A pid is "alive" if signal 0 doesn't throw. Returns the pid or null.
+function runningPid() {
+  const state = readPidState();
+  if (!state) return null;
+  const { pid } = state;
+  if (!samePath(state.entry, entry) || !samePath(state.repoRoot, repoRoot)) {
+    cleanPidFile();
+    return null;
+  }
+  try {
+    process.kill(pid, 0);
+  } catch {
+    cleanPidFile(); // stale pidfile, clean it up
+    return null;
+  }
+  if (!commandMatchesEntry(processCommandLine(pid))) {
+    cleanPidFile();
+    return null;
+  }
+  return pid;
+}
+
+function start() {
+  const pid = runningPid();
+  if (pid) {
+    console.log(`[pxpipe] already running (pid ${pid}) → http://127.0.0.1:${port}/`);
+    return;
+  }
+  if (!existsSync(entry)) {
+    console.error(`[pxpipe] ${path.relative(repoRoot, entry)} missing — run \`pnpm run build\` first.`);
+    process.exit(1);
+  }
+  mkdirSync(stateDir, { recursive: true });
+  const out = openSync(logFile, 'a');
+  const child = spawn(process.execPath, [entry], {
+    cwd: repoRoot,
+    env: process.env,
+    detached: true, // survive this launcher exiting
+    stdio: ['ignore', out, out],
+    windowsHide: true,
+  });
+  child.unref();
+  writeFileSync(
+    pidFile,
+    JSON.stringify(
+      {
+        pid: child.pid,
+        entry,
+        repoRoot,
+        startedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`[pxpipe] started (pid ${child.pid}) → http://127.0.0.1:${port}/`);
+  console.log(`[pxpipe] logs: ${logFile}`);
+}
+
+function stop() {
+  const pid = runningPid();
+  if (!pid) {
+    console.log('[pxpipe] not running');
+    return;
+  }
+  try {
+    process.kill(pid, 'SIGTERM'); // proxy flushes its tracker on SIGTERM
+  } catch {
+    /* already gone */
+  }
+  cleanPidFile();
+  console.log(`[pxpipe] stopped (pid ${pid})`);
+}
+
+function status() {
+  const pid = runningPid();
+  if (pid) console.log(`[pxpipe] running (pid ${pid}) → http://127.0.0.1:${port}/`);
+  else console.log('[pxpipe] stopped');
+}
+
+const cmd = (process.argv[2] || 'toggle').toLowerCase();
+switch (cmd) {
+  case 'start':
+    start();
+    break;
+  case 'stop':
+    stop();
+    break;
+  case 'restart':
+    stop();
+    start();
+    break;
+  case 'status':
+    status();
+    break;
+  case 'toggle':
+    if (runningPid()) stop();
+    else start();
+    break;
+  default:
+    console.error(`[pxpipe] unknown command: ${cmd}`);
+    console.error('[pxpipe] usage: node scripts/service.mjs [start|stop|restart|status|toggle]');
+    process.exit(2);
+}

--- a/tests/design-behavior-e2e.test.ts
+++ b/tests/design-behavior-e2e.test.ts
@@ -181,6 +181,8 @@ describe('design: TOOLS IN RECENT TURNS (Anthropic)', () => {
 
 // ===========================================================================
 describe('design: RECENT REQUEST stays legible (GPT)', () => {
+  // Real PNG render of a 60k-char slab; the default 5s timeout is too tight
+  // when the full suite renders in parallel under CPU contention.
   it('images the system slab but keeps the most-recent user request as readable text', async () => {
     const turns = Array.from({ length: 12 }, (_, i) => ({
       role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
@@ -198,5 +200,5 @@ describe('design: RECENT REQUEST stays legible (GPT)', () => {
     expect(imageCount(out)).toBeGreaterThan(0); // system imaged
     // The agent's live request must remain legible text, never OCR-only.
     expect(hay).toContain('FINAL_REQUEST_MARKER please answer');
-  });
+  }, 20_000);
 });

--- a/tests/docs-integrity.test.ts
+++ b/tests/docs-integrity.test.ts
@@ -16,7 +16,9 @@ function markdownFiles(): string[] {
     const abs = path.join(repoRoot, rel);
     if (!fs.existsSync(abs)) return;
     for (const name of fs.readdirSync(abs, { withFileTypes: true })) {
-      const childRel = path.join(rel, name.name);
+      // posix.join keeps forward slashes so the collected paths match the
+      // `docs/…` link/assertion style on every platform (Windows included).
+      const childRel = path.posix.join(rel, name.name);
       if (name.isDirectory()) {
         if (name.name === 'node_modules' || name.name.startsWith('.')) continue;
         walk(childRel, opts);

--- a/tests/export-git-e2e.test.ts
+++ b/tests/export-git-e2e.test.ts
@@ -10,7 +10,10 @@ import { fileURLToPath } from 'node:url';
 // Runs the actual CLI via tsx against a throwaway git repo and asserts the
 // untracked-file filtering. Kept in its own file because it spawns a subprocess.
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const tsxBin = path.join(repoRoot, 'node_modules', '.bin', 'tsx');
+// On Windows the .bin entry is `tsx.cmd`, which Node can only exec through a
+// shell; POSIX runs the extensionless shim directly.
+const isWin = process.platform === 'win32';
+const tsxBin = path.join(repoRoot, 'node_modules', '.bin', isWin ? 'tsx.cmd' : 'tsx');
 
 function git(cwd: string, args: string[]): void {
   const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
@@ -45,7 +48,7 @@ describe('pxpipe export --git (end-to-end)', () => {
     const run = spawnSync(
       tsxBin,
       ['src/node.ts', 'export', '--git', repo, '--include', '*.ts', '--out', outDir, '--json'],
-      { cwd: repoRoot, encoding: 'utf8', timeout: 120_000 },
+      { cwd: repoRoot, encoding: 'utf8', timeout: 120_000, shell: isWin },
     );
     expect(run.status, `stderr:\n${run.stderr}`).toBe(0);
 

--- a/tests/service-script.test.ts
+++ b/tests/service-script.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const serviceScript = path.join(repoRoot, 'scripts', 'service.mjs');
+
+function homeEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+  };
+}
+
+describe('service script', () => {
+  it('does not treat an arbitrary live pidfile as a managed pxpipe process', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'pxpipe-service-home-'));
+    try {
+      const stateDir = path.join(home, '.pxpipe');
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(path.join(stateDir, 'pxpipe.pid'), String(process.pid));
+
+      const run = spawnSync(process.execPath, [serviceScript, 'status'], {
+        cwd: repoRoot,
+        env: homeEnv(home),
+        encoding: 'utf8',
+      });
+
+      expect(run.status, `stderr:\n${run.stderr}`).toBe(0);
+      expect(run.stdout).toContain('[pxpipe] stopped');
+      expect(run.stdout).not.toContain('running');
+      expect(fs.existsSync(path.join(stateDir, 'pxpipe.pid'))).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('package service scripts', () => {
+  it('includes the service launcher in the published package files', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>;
+      files: string[];
+    };
+    const serviceRefs = Object.values(pkg.scripts).filter((script) => script.includes('scripts/service.mjs'));
+
+    expect(serviceRefs.length).toBeGreaterThan(0);
+    expect(pkg.files).toContain('scripts/service.mjs');
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes Windows-only friction in the build/test/tooling path without changing proxy product logic under `src/`.

- Let the build script resolve the `pnpm.cmd` shim on Windows.
- Make the `export --git` e2e test resolve `tsx.cmd` on Windows while keeping the POSIX path unchanged.
- Keep docs-integrity paths POSIX-style so assertions match on Windows.
- Give the expensive PNG-render e2e assertion an explicit timeout under full-suite CPU contention.
- Add a cross-platform service launcher for local start/stop/status use, with pidfile validation so it does not treat arbitrary live PIDs as pxpipe-managed processes.
- Include the service launcher in published package files.

## Root Cause

The failures were Unix-only assumptions in repository tooling: extensionless shims in `node_modules/.bin`, platform path separators in test expectations, and a render test whose default 5s timeout was too tight under Windows full-suite contention.

## Validation

- `pnpm run typecheck`
- `pnpm test` — 33 files, 647 tests passed
- `pnpm run build` — includes `--version` smoke check for 0.8.0
- `npm pack --dry-run --json` — confirms `scripts/service.mjs` is included with `dist/`
- Windows smoke: `node scripts/service.mjs start/status/stop` with isolated HOME and PORT
