### PR TITLE
Fix build.mjs spawnSync ENOENT on Windows

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -19,7 +19,9 @@ await mkdir(OUT, { recursive: true });
 
 const tsc = spawnSync('pnpm', ['exec', 'tsc', '-p', 'tsconfig.json'], {
   stdio: 'inherit',
-  shell: false,
+  // pnpm is a .cmd/.ps1 shim on Windows; spawnSync only resolves those
+  // through a shell, so shell:false gives a silent ENOENT there.
+  shell: process.platform === 'win32',
 });
 if (tsc.status !== 0) process.exit(tsc.status ?? 1);
 console.log('✓ emitted dist/ library modules + declarations');


### PR DESCRIPTION
## Summary
- `scripts/build.mjs` calls `spawnSync('pnpm', ..., { shell: false })` to run `tsc`
- On Windows, `pnpm` resolves to a `.cmd`/`.ps1` shim, which `spawnSync` cannot exec with `shell: false` — it fails with a silent `ENOENT` and no diagnostic output, so `pnpm run build` is broken out of the box on Windows
- Enables `shell: true` only on `win32` so pnpm resolves correctly there, while keeping the direct exec path (no shell) on other platforms

## Test plan
- [x] `pnpm install` on Windows
- [x] `pnpm run build` completes: emits `dist/`, bundles `dist/node.js`, passes the `--version` smoke check
- [x] `pnpm test`: 641/645 passing (pre-existing failures unrelated to this change: two perf-timeout tests, one docs-integrity test referencing a file not present in the checkout, one git-e2e test)
