### PR TITLE
fix(transform): never inject description into native typed tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ pnpm install && pnpm test
 pnpm run build                # regenerates dist/
 ```
 
+Inside a checkout of this repo, `npx pxpipe-proxy` (the quickstart command
+above) won't work — npm sees the local `package.json` name matches and tries
+to run *this checkout's own* bin instead of fetching the published package,
+but an unbuilt checkout has no `dist/` to run. Use `pnpm run dev:node` (runs
+`src/node.ts` directly, no build needed) or `pnpm run build && node
+bin/cli.js` instead.
+
 ## FAQ
 
 **Is the headline end-to-end, or only on the requests you touched?**

--- a/src/core/hash.ts
+++ b/src/core/hash.ts
@@ -1,0 +1,12 @@
+/** Dependency-free hash helper, split out of transform.ts so history.ts (which
+ *  transform.ts already imports from) can use it without an import cycle. */
+
+/** sha256[0..8] hex via Web Crypto (works in Node 18+ and Workers). 32-bit collision-safe. */
+export async function sha8(text: string): Promise<string> {
+  const buf = new TextEncoder().encode(text);
+  const digest = await crypto.subtle.digest('SHA-256', buf);
+  const bytes = new Uint8Array(digest);
+  let hex = '';
+  for (let i = 0; i < 4; i++) hex += bytes[i]!.toString(16).padStart(2, '0');
+  return hex;
+}

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -15,6 +15,8 @@ import type { CacheControl, ContentBlock, ImageBlock, Message, TextBlock, ToolUs
 import { DENSE_CONTENT_CHARS_PER_IMAGE, DENSE_CONTENT_COLS, DENSE_RENDER_STYLE, neutralizeSentinel, reflow, renderTextToPngsWithCharLimit, roleSlotSegment, SLOT_MARK_ASSISTANT, SLOT_MARK_USER } from './render.js';
 import { factSheetText } from './factsheet.js';
 import { bytesToBase64 } from './png.js';
+import { sha8 } from './hash.js';
+import { cachedRender } from './render-cache.js';
 
 /**
  * Banner text blocks that bracket the collapsed-history image(s) in the synthetic
@@ -600,13 +602,20 @@ export async function collapseHistory(
     // colorByRole tints the structural <role> tags so turn boundaries are scannable
     // in the history image; it's token-free (vision cost is by pixel dims, not PNG
     // byte depth) and carries the serialize-time slot string instead of re-parsing.
-    const imgs = await renderTextToPngsWithCharLimit(
-      chunkRender,
-      DENSE_CONTENT_COLS,
-      DENSE_CONTENT_CHARS_PER_IMAGE,
-      { ...DENSE_RENDER_STYLE, colorByRole: true },
-      undefined,
-      chunkSlot,
+    // Cached: a frozen chunk's (chunkRender, chunkSlot) pair is a pure function of an
+    // immutable message range (see the append-only freeze design above), so repeat
+    // turns skip the glyph blit + PNG deflate for every chunk except the newest one.
+    const imgs = await cachedRender(
+      `hist:${await sha8(chunkRender + ' ' + chunkSlot)}`,
+      () =>
+        renderTextToPngsWithCharLimit(
+          chunkRender,
+          DENSE_CONTENT_COLS,
+          DENSE_CONTENT_CHARS_PER_IMAGE,
+          { ...DENSE_RENDER_STYLE, colorByRole: true },
+          undefined,
+          chunkSlot,
+        ),
     );
     const markerCC = markerByEnd.get(chunkEnd);
     for (let k = 0; k < imgs.length; k++) {

--- a/src/core/render-cache.ts
+++ b/src/core/render-cache.ts
@@ -1,0 +1,35 @@
+/**
+ * Content-addressed memoization for rendered PNG pages. The two call sites that use
+ * this (transform.ts's static slab, history.ts's frozen collapse chunks) are already
+ * designed to produce byte-identical render output across turns — see the
+ * "byte-stable"/"cache-friendly" comments at those call sites, written for Anthropic's
+ * prompt cache. That same guarantee means a cache hit here can skip the real work
+ * (glyph blit + PNG deflate) entirely and return the prior bytes untouched.
+ *
+ * Bounded LRU, same eviction pattern as transform.ts's tagObservations.
+ */
+
+import type { RenderedImage } from './render.js';
+
+const RENDER_CACHE_MAX = 128;
+const cache = new Map<string, RenderedImage[]>();
+
+export async function cachedRender(
+  key: string,
+  render: () => Promise<RenderedImage[]>,
+): Promise<RenderedImage[]> {
+  const hit = cache.get(key);
+  if (hit) {
+    cache.delete(key); // refresh LRU position
+    cache.set(key, hit);
+    return hit;
+  }
+  const images = await render();
+  cache.set(key, images);
+  while (cache.size > RENDER_CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+  return images;
+}

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -40,6 +40,8 @@ import { bytesToBase64 } from './png.js';
 import { collapseHistory, HISTORY_SYNTHETIC_INTRO } from './history.js';
 import type { GptHistoryOptions } from './openai-history.js';
 import { CACHE_CREATE_RATE, CACHE_READ_RATE } from './baseline.js';
+import { sha8 } from './hash.js';
+import { cachedRender } from './render-cache.js';
 
 /** Per-block descriptor passed to `TransformOptions.keepSharp`. */
 export interface KeepSharpBlock {
@@ -777,15 +779,7 @@ function observeStaticTagChurn(
   return churned;
 }
 
-/** sha256[0..8] hex via Web Crypto (works in Node 18+ and Workers). 32-bit collision-safe. */
-export async function sha8(text: string): Promise<string> {
-  const buf = new TextEncoder().encode(text);
-  const digest = await crypto.subtle.digest('SHA-256', buf);
-  const bytes = new Uint8Array(digest);
-  let hex = '';
-  for (let i = 0; i < 4; i++) hex += bytes[i]!.toString(16).padStart(2, '0');
-  return hex;
-}
+export { sha8 } from './hash.js';
 
 /** Record a recovery entry when `emitRecoverable` is on. No-op (no hash cost) when off. */
 async function recordRecoverable(
@@ -1709,10 +1703,15 @@ export async function transformRequest(
   // single-modal framing keeps encoder in image-reading mode for both header + content).
   // Header text is continuous prose (no hard \n) so the renderer soft-wraps densely.
   // 3. Render to PNGs at slabCols width (banner sets natural floor).
-  const images =
-    numCols > 1
-      ? await renderTextToPngsMultiCol(combinedWithHeader, slabCols, numCols)
-      : await renderTextToPngs(combinedWithHeader, slabCols);
+  // Cached: combinedWithHeader is byte-stable per session (same CLAUDE.md + tool
+  // list), so repeat turns skip the glyph blit + PNG deflate entirely.
+  const images = await cachedRender(
+    `slab:${await sha8(combinedWithHeader)}:${slabCols}:${numCols}`,
+    () =>
+      numCols > 1
+        ? renderTextToPngsMultiCol(combinedWithHeader, slabCols, numCols)
+        : renderTextToPngs(combinedWithHeader, slabCols),
+  );
   const imageBlocks: ImageBlock[] = [];
   for (let i = 0; i < images.length; i++) {
     const img = images[i]!;

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1035,6 +1035,18 @@ function stripMarkdownEnvSection(text: string): { kept: string; body: string } {
  *  at text rates would have duplicated what tools[] already pays for; at image
  *  rates the duplicate structure is cheap and the stripped annotations are the
  *  compression.) */
+/** Anthropic's native/versioned tools (e.g. `bash_20250124`, `web_search_20250305`,
+ *  `advisor_20260301`) carry a fixed server-side schema that does NOT accept a
+ *  `description` field — injecting one 400s with "Extra inputs are not permitted"
+ *  and Claude Code silently falls back to a different model. Anthropic marks
+ *  user-defined tools with `type: 'custom'` or omits `type`; any other string is a
+ *  native tool pxpipe must pass through untouched. Exclusion check, not an
+ *  allowlist (cf. openai.ts's isFunctionTool), because new native type strings
+ *  ship faster than pxpipe can track them. */
+function isNativeTypedTool(t: ToolDef): boolean {
+  return typeof t.type === 'string' && t.type !== 'custom';
+}
+
 function renderToolDoc(t: ToolDef): string {
   const parts: string[] = [`## Tool: ${t.name ?? '?'}`];
   if (t.description) parts.push(t.description);
@@ -1541,6 +1553,8 @@ export async function transformRequest(
   if (o.compressTools && Array.isArray(req.tools) && req.tools.length > 0) {
     const docs: string[] = [];
     toolsRewritten = req.tools.map((t) => {
+      if (isNativeTypedTool(t)) return t; // byte-identical passthrough; nothing to doc/stub
+
       docs.push(renderToolDoc(t));
       // tools[] keeps the annotation-STRIPPED schema: structure (type/properties/
       // required/enum/items) stays for Anthropic's tool-use validator — a bare

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -50,6 +50,7 @@ export interface Message {
 
 export interface ToolDef {
   name: string;
+  type?: string;
   description?: string;
   input_schema?: unknown;
   cache_control?: CacheControl;

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -15,7 +15,7 @@
  *     enough turns to fire, off when no closed prefix exists.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   findClosedPrefixBoundary,
   blocksToText,
@@ -26,6 +26,7 @@ import {
 } from '../src/core/history.js';
 import { transformRequest, isCompressionProfitable } from '../src/core/transform.js';
 import { DENSE_CONTENT_CHARS_PER_IMAGE } from '../src/core/render.js';
+import * as renderModule from '../src/core/render.js';
 import type { Message } from '../src/core/types.js';
 
 // A tiny helper so test fixtures are readable.
@@ -551,6 +552,34 @@ describe('collapseHistory', () => {
     const c = await collapseHistory(mk(70), profitable);
     expect(c.info.collapsedTurns).toBe(50);
     expect(JSON.stringify(imagesOf(c))).not.toBe(JSON.stringify(imgA));
+  });
+
+  it('reuses the render cache instead of re-rendering an unchanged collapsed chunk', async () => {
+    // Same fixture as the byte-identical-image test above: two conversations
+    // whose collapsed prefix (and therefore chunkRender/chunkSlot) is
+    // identical. The first call must render; the second must be a pure
+    // cache hit — proving the cache introduced for the performance
+    // bottleneck (re-rendering byte-stable history on every turn) is wired
+    // up, not just that the output happens to match.
+    const mk = (n: number): Message[] => {
+      const m: Message[] = [];
+      for (let i = 0; i < n; i++) {
+        const body = `turn ${i}: ` + 'y'.repeat(2800);
+        m.push(i % 2 === 0 ? usr(body) : asst(body));
+      }
+      return m;
+    };
+    const spy = vi.spyOn(renderModule, 'renderTextToPngsWithCharLimit');
+    try {
+      await collapseHistory(mk(20), profitable);
+      const callsAfterFirst = spy.mock.calls.length;
+      expect(callsAfterFirst).toBeGreaterThan(0);
+
+      await collapseHistory(mk(22), profitable);
+      expect(spy.mock.calls.length).toBe(callsAfterFirst); // no new renders — cache hit
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/tests/render-cache.test.ts
+++ b/tests/render-cache.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cachedRender } from '../src/core/render-cache.js';
+import type { RenderedImage } from '../src/core/render.js';
+
+function fakeImage(tag: string): RenderedImage[] {
+  return [
+    {
+      png: new Uint8Array([tag.charCodeAt(0)]),
+      width: 1,
+      height: 1,
+      charsRendered: 1,
+      droppedChars: 0,
+      droppedCodepoints: new Map(),
+    },
+  ];
+}
+
+describe('cachedRender', () => {
+  it('returns the cached array without re-invoking render on a repeated key', async () => {
+    const render = vi.fn(async () => fakeImage('a'));
+    const key = `render-cache-test:${Math.random()}`;
+
+    const first = await cachedRender(key, render);
+    const second = await cachedRender(key, render);
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first); // same array instance, not just equal content
+  });
+
+  it('invokes render for a distinct key', async () => {
+    const renderA = vi.fn(async () => fakeImage('a'));
+    const renderB = vi.fn(async () => fakeImage('b'));
+    const base = `render-cache-test:${Math.random()}`;
+
+    await cachedRender(`${base}:a`, renderA);
+    await cachedRender(`${base}:b`, renderB);
+
+    expect(renderA).toHaveBeenCalledTimes(1);
+    expect(renderB).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the oldest entry once the cache exceeds its cap', async () => {
+    const base = `render-cache-test-evict:${Math.random()}`;
+    // Cap is 128; fill past it so the very first key falls off the LRU.
+    for (let i = 0; i < 129; i++) {
+      await cachedRender(`${base}:${i}`, async () => fakeImage(String(i)));
+    }
+    const render0 = vi.fn(async () => fakeImage('0-again'));
+    await cachedRender(`${base}:0`, render0);
+    expect(render0).toHaveBeenCalledTimes(1); // evicted, so this must be a fresh render
+
+    const render128 = vi.fn(async () => fakeImage('128-again'));
+    await cachedRender(`${base}:128`, render128);
+    expect(render128).toHaveBeenCalledTimes(0); // still warm, no re-render
+  });
+});

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   renderChunkToPng,
   renderTextToPngs,
@@ -15,6 +15,7 @@ import {
   CELL_H,
   CELL_W,
 } from '../src/core/render.js';
+import * as renderModule from '../src/core/render.js';
 import { encodeGrayPng, bytesToBase64 } from '../src/core/png.js';
 import {
   transformRequest,
@@ -693,6 +694,41 @@ describe('transform', () => {
     // And the system field must NOT contain image blocks (would 400).
     if (Array.isArray(out.system)) {
       for (const b of out.system) expect(b.type).not.toBe('image');
+    }
+  });
+
+  it('caches the slab render: a repeat request with an identical system+tools payload is a pure cache hit', async () => {
+    // Regression guard for the render-cache bottleneck fix: the static
+    // system-prompt slab is byte-stable per session, so a second identical
+    // request must not re-invoke the renderer at all, and must return
+    // byte-identical image bytes. Nonce keeps this test's cache key from
+    // colliding with any other test's identical-looking slab content —
+    // the render cache is a module-level singleton shared across this file.
+    const nonce = `nonce-${Math.random()}`;
+    const bigSystem = `${nonce} You are a helpful assistant. `.repeat(5000);
+    const req = JSON.stringify({
+      model: 'claude-3-5-sonnet',
+      messages: [{ role: 'user', content: 'hi' }],
+      system: bigSystem,
+    });
+    const bytes = new TextEncoder().encode(req);
+
+    const spy = vi.spyOn(renderModule, 'renderTextToPngs');
+    try {
+      const first = await transformRequest(bytes);
+      const callsAfterFirst = spy.mock.calls.length;
+      expect(callsAfterFirst).toBeGreaterThan(0);
+
+      const second = await transformRequest(bytes);
+      expect(spy.mock.calls.length).toBe(callsAfterFirst); // no new render calls
+
+      const outA = JSON.parse(new TextDecoder().decode(first.body));
+      const outB = JSON.parse(new TextDecoder().decode(second.body));
+      const imagesOf = (out: any) =>
+        (out.messages[0].content as any[]).filter((b) => b.type === 'image');
+      expect(JSON.stringify(imagesOf(outA))).toBe(JSON.stringify(imagesOf(outB)));
+    } finally {
+      spy.mockRestore();
     }
   });
 

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -744,6 +744,39 @@ describe('transform', () => {
     expect(refHeader).toContain("this user's local proxy");
   });
 
+  it('passes native typed tools through untouched, only stubs custom tools', async () => {
+    const nativeTool = { type: 'bash_20250124', name: 'bash' };
+    const customTool = {
+      name: 'BigTool',
+      description: 'A very long tool description. '.repeat(500),
+      input_schema: { type: 'object', properties: { x: { type: 'string' } } },
+    };
+    const req = JSON.stringify({
+      model: 'claude-3-5-sonnet',
+      messages: [{ role: 'user', content: 'hi' }],
+      system: 'x'.repeat(30000),
+      tools: [nativeTool, customTool],
+    });
+    const bytes = new TextEncoder().encode(req);
+    const { body, info } = await transformRequest(bytes);
+    expect(info.compressed).toBe(true);
+
+    const out = JSON.parse(new TextDecoder().decode(body));
+    // Native tool: byte-identical passthrough — this is the exact shape that
+    // previously caused the 400 (an injected `description` key on a native tool).
+    expect(out.tools[0]).toEqual(nativeTool);
+    expect('description' in out.tools[0]).toBe(false);
+    // Custom tool: still stubbed and imaged as before.
+    expect(out.tools[1].name).toBe('BigTool');
+    expect(out.tools[1].description).toContain('"## Tool: BigTool"');
+    expect(out.tools[1].description).toContain('Tool Reference');
+
+    // Native tool must not appear in the imaged Tool Reference (nothing to move).
+    const imgSrc = info.imageSourceText ?? '';
+    expect(imgSrc).not.toContain('## Tool: bash');
+    expect(imgSrc).toContain('## Tool: BigTool');
+  });
+
   it('ships annotation-stripped schemas in tools[], full schema in the imaged reference', async () => {
     // History: a bare `{type:'object'}` stub caused validator 400s; a text
     // reference paid the annotations at text rates. Current contract: tools[]


### PR DESCRIPTION
Anthropic's native/versioned tools (bash_20250124, web_search_20250305, etc.) reject a description field, so the tool-doc compression path's blanket stub 400'd on them and Claude Code silently fell back to an out-of-scope model. Pass native typed tools through untouched, mirroring openai.ts's isFunctionTool guard.