### PR TITLE
fix(dashboard): escape model id in hx-vals

### DIFF
--- a/src/dashboard/fragments.ts
+++ b/src/dashboard/fragments.ts
@@ -119,7 +119,7 @@ export function renderModelsFragment(
     return (
       `<button class="chip${lit ? ' on' : ''}" type="button" ` +
       `hx-post="/fragments/models" hx-target="#frag-models" ` +
-      `hx-vals='{"model":"${id}","on":${!lit}}'>${escapeHtml(label)}${lit ? ' ✓' : ''}</button>`
+      `hx-vals='{"model":${JSON.stringify(id)},"on":${!lit}}'>${escapeHtml(label)}${lit ? ' ✓' : ''}</button>`
     );
   };
   const claudeChips = ids.filter((id) => !id.startsWith('gpt')).map(chipFor).join('');

--- a/tests/dashboard-models.test.ts
+++ b/tests/dashboard-models.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { renderModelsFragment } from '../src/dashboard/fragments.js';
+
+describe('renderModelsFragment model chips', () => {
+  it('keeps configured model IDs inside the hx-vals JSON model value', () => {
+    const model = 'foo","evil":"bar';
+
+    const html = renderModelsFragment([model], [model], true);
+
+    const hxVals = [...html.matchAll(/hx-vals='([^']+)'/g)]
+      .map((match) => match[1])
+      .find((value) => value.includes('evil'));
+
+    expect(hxVals).toBeDefined();
+
+    const parsed = JSON.parse(hxVals!);
+
+    expect(parsed).toEqual({
+      model,
+      on: false,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #58.

## Summary
Escapes configured model IDs before embedding them into the dashboard `hx-vals` JSON attribute.

## Why
`renderModelsFragment()` rendered model IDs directly inside JSON. A model ID containing quotes could break out of the `model` value and alter the `hx-vals` payload shape.

Before:

```html
hx-vals='{"model":"foo","evil":"bar","on":false}'
```

After:

```html
hx-vals='{"model":"foo\",\"evil\":\"bar","on":false}'
```

## Testing
- Reproduced locally with a crafted configured model ID
- Added regression coverage for quoted model IDs
- `npm test -- tests/dashboard-models.test.ts`
- `npm run typecheck`