### PR TITLE
Fix silent build failure on Windows (spawnSync pnpm.cmd)

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -6,6 +6,9 @@ import { build } from 'esbuild';
 import { mkdir, rm, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 // Single source of truth for the CLI version: read it here, inline it into the
 // bundle via esbuild `define`. Reading npm_package_version at CLI *runtime* is
@@ -17,10 +20,20 @@ const OUT = 'dist';
 if (existsSync(OUT)) await rm(OUT, { recursive: true, force: true });
 await mkdir(OUT, { recursive: true });
 
-const tsc = spawnSync('pnpm', ['exec', 'tsc', '-p', 'tsconfig.json'], {
+// Run tsc's JS entry directly with the current Node binary rather than via
+// `pnpm exec`. On Windows the pnpm launcher is `pnpm.cmd`, which spawnSync
+// refuses to run without shell:true (EINVAL since the CVE-2024-27980 fix), and
+// with shell:true trips the DEP0190 arg-escaping warning. Resolving the tsc bin
+// and invoking `node <tsc>` sidesteps both — same pattern as the smoke check
+// below, and drops the build's dependency on pnpm being the caller.
+const tscBin = require.resolve('typescript/bin/tsc');
+const tsc = spawnSync(process.execPath, [tscBin, '-p', 'tsconfig.json'], {
   stdio: 'inherit',
-  shell: false,
 });
+if (tsc.error) {
+  console.error(`✗ failed to run tsc: ${tsc.error.message}`);
+  process.exit(1);
+}
 if (tsc.status !== 0) process.exit(tsc.status ?? 1);
 console.log('✓ emitted dist/ library modules + declarations');
 


### PR DESCRIPTION
## Problem

On Windows, `pnpm run build` fails silently — exit code 1 with **no output**, so `dist/` is never produced and there's no clue why.

Root cause is in `scripts/build.mjs`:

```js
const tsc = spawnSync('pnpm', ['exec', 'tsc', '-p', 'tsconfig.json'], {
  stdio: 'inherit',
  shell: false,
});
if (tsc.status !== 0) process.exit(tsc.status ?? 1);
```

On Windows the pnpm launcher is `pnpm.cmd`. `spawnSync` with `shell: false` can't execute a `.cmd`:
- it returns `status: null` with `error.code = 'ENOENT'` (and `EINVAL` since the CVE-2024-27980 hardening that blocks `.cmd`/`.bat` without a shell),
- so `process.exit(tsc.status ?? 1)` exits **1 with no message**.

`tsc` itself is fine — `pnpm exec tsc` / `pnpm typecheck` pass. Only the spawn wrapper breaks.

## Fix

Invoke tsc's JS entry with the current Node binary instead of going through `pnpm exec`:

```js
const tscBin = require.resolve('typescript/bin/tsc');
const tsc = spawnSync(process.execPath, [tscBin, '-p', 'tsconfig.json'], { stdio: 'inherit' });
```

This mirrors the pattern the `--version` smoke check already uses (`spawnSync(process.execPath, ['dist/node.js', ...])`), and:

- works on Windows/macOS/Linux without a shell,
- avoids the `shell: true` route, which would trip the DEP0190 arg-escaping deprecation warning,
- drops the build's implicit assumption that **pnpm** is the caller,
- surfaces spawn errors explicitly instead of collapsing them into a bare `exit 1`.

## Testing

- Windows 11 / Node 24 / pnpm 10.21: `pnpm run build` now completes — `✓ emitted dist/`, `✓ built dist/node.js`, `✓ version smoke check: --version prints 0.8.0`. Before the fix it exited 1 with empty output.
- `node bin/cli.js --version` → `0.8.0`; proxy boots and serves the dashboard (HTTP 200).
- No behavior change on macOS/Linux: `node <tsc>` is equivalent to `pnpm exec tsc` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)