### PR TITLE
fix: slab default cols 313 -> 312 to stay at the 1568px long-edge bound

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -134,8 +134,10 @@ const DEFAULTS: Required<TransformOptions> = {
   minToolResultChars: 6000,
   // system field rejects images (400 system.N.type: Input should be 'text') —
   // images always go into the first user message.
-  // 313 cols × 5 px + 8 px pad = 1573 px slab width (under 2000 px ceiling).
-  cols: 313,
+  // 312 cols × 5 px + 8 px pad = 1568 px slab width — exactly the API's long-edge
+  // bound (313 cols = 1573 px triggers a 0.997× resample, blurring every glyph;
+  // see DEFAULT_COLS in render.ts).
+  cols: 312,
   maxImagesPerToolResult: 10,
   charsPerToken: 4,
   historyAmortizationHorizon: 1,


### PR DESCRIPTION
## Problem

`DEFAULTS.cols` in `transform.ts` is `313`, which renders slab pages at **1573 px** wide (313 × 5 px + 8 px pad). That overshoots the API's 1568 px long-edge bound that `render.ts` itself documents at `DEFAULT_COLS`:

> 313 cols = 1573 px would trigger a 0.997× resample, blurring every glyph

So every slab image (system prompt + tool docs — the highest-value region) currently gets resampled server-side with a slight blur, degrading readback. The comment on the default ("under 2000 px ceiling") looks like it predates the 1568 px finding in `render.ts` (measured 2026-07-01) and the two files were never re-synced.

## Verification

Measured E2E against a mock upstream (`ANTHROPIC_UPSTREAM` pointed at a local capture server, `PXPIPE_DUMP_DIR` enabled):

- **Before**: slab pages dumped at 1573 px wide; tool_result pages (which use `render.ts` `DEFAULT_COLS=312`) already at 1568 px.
- **After**: all pages at 1568 px.
- `vitest run`: 645/645 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)