### PR TITLE
fix: don't route Anthropic OAuth clients' /v1/models to the OpenAI upstream

### DIFF
--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -520,7 +520,12 @@ function isOpenAIResponsesPath(pathname: string): boolean {
 
 function isCanonicalOpenAIPath(pathname: string, headers: Headers, hasOpenAIKey: boolean): boolean {
   const isModelsPath = pathname === '/v1/models' || pathname.startsWith('/v1/models/');
-  const looksOpenAIAuth = hasOpenAIKey || (headers.has('authorization') && !headers.has('x-api-key'));
+  // Anthropic clients on subscription OAuth send Authorization: Bearer without
+  // x-api-key — the same shape as OpenAI auth. anthropic-version/-beta headers
+  // are the reliable discriminator: never route those clients to OpenAI.
+  const looksAnthropicClient = headers.has('anthropic-version') || headers.has('anthropic-beta');
+  const looksOpenAIAuth = !looksAnthropicClient
+    && (hasOpenAIKey || (headers.has('authorization') && !headers.has('x-api-key')));
   return pathname === '/v1/chat/completions'
     || pathname === '/v1/responses'
     || pathname.startsWith('/v1/responses/')


### PR DESCRIPTION
## Problem

`isCanonicalOpenAIPath` classifies any request carrying `Authorization` without `x-api-key` as OpenAI-authenticated (`looksOpenAIAuth`). Anthropic clients on **subscription OAuth** — e.g. Claude Code running on a Pro/Max plan, which is exactly the population pxpipe targets now that Fable 5 access on those plans goes through usage credits — send that exact header shape. Their `GET /v1/models` therefore gets forwarded to `api.openai.com` (or `OPENAI_UPSTREAM`) instead of the Anthropic upstream, and fails.

## Fix

Those clients also send `anthropic-version` (and often `anthropic-beta`), which OpenAI clients never do. Use that as the discriminator before falling back to the auth-shape heuristic. `/v1/chat/completions` and `/v1/responses` routing is unchanged.

## Verification

E2E against a mock upstream: `GET /v1/models` with `Authorization: Bearer …` + `anthropic-version: 2023-06-01` now reaches the Anthropic upstream (before the patch it went to the OpenAI upstream). `vitest run`: 645/645 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)