### PR TITLE
Make 4xx request-body capture opt-in (default off)

### DIFF
--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -33,6 +33,11 @@ export interface ProxyConfig {
   transform?: TransformOptions | (() => TransformOptions);
   /** Called after every request — useful for logging / metrics in the host. */
   onRequest?: (event: ProxyEvent) => void | Promise<void>;
+  /** Capture a gzipped sample of the request body on 4xx responses, surfaced on
+   *  ProxyEvent.reqBodyGz (the Node host then writes it to events.jsonl or a
+   *  sidecar file). Off by default so request/message content is never logged;
+   *  opt in only for 4xx debugging. */
+  capture4xxBody?: boolean;
 }
 
 export interface ProxyEvent {
@@ -630,7 +635,7 @@ export function createProxy(config: ProxyConfig = {}) {
       // Gzip body lazily (only on 4xx). Async IIFE keeps fire() synchronous.
       const finalize = async (): Promise<void> => {
         let reqBodyGz: Uint8Array | undefined;
-        if (is4xx && reqBodyBytes && reqBodyBytes.byteLength > 0) {
+        if (is4xx && config.capture4xxBody && reqBodyBytes && reqBodyBytes.byteLength > 0) {
           try {
             reqBodyGz = await gzipBytes(reqBodyBytes);
           } catch {

--- a/src/node.ts
+++ b/src/node.ts
@@ -167,6 +167,9 @@ Environment:
   PXPIPE_LOG              JSONL events path (default ~/.pxpipe/events.jsonl)
   PXPIPE_DUMP_DIR         debug: write every rendered PNG here (what the model
                           sees); off unless set. Compress arm only.
+  PXPIPE_CAPTURE_4XX_BODY debug: set to 1 to log a gzipped sample of the request
+                          body on 4xx (events.jsonl / sidecar). Off by default —
+                          request/message content is not logged unless you opt in.
 
 Use with Claude Code:
   ANTHROPIC_BASE_URL=http://127.0.0.1:47821 claude
@@ -932,6 +935,9 @@ async function main(): Promise<void> {
     upstream: opts.upstream,
     openAIUpstream: opts.openAIUpstream,
     openAIApiKey: opts.openAIApiKey,
+    // Off by default so request/message content is never logged. Opt into a
+    // gzipped 4xx request-body sample (events.jsonl / sidecar) for debugging.
+    capture4xxBody: process.env.PXPIPE_CAPTURE_4XX_BODY === '1',
     // Per-request transform options:
     //   1. Runtime kill switch — when the dashboard "passthrough" toggle
     //      is off, force compress=false so /v1/messages forwards


### PR DESCRIPTION
## What

Makes the 4xx request-body capture opt-in, off by default.

## Why

On any 4xx, `fire()` in `src/core/proxy.ts` gzips the request body and surfaces it on `ProxyEvent.reqBodyGz`. The Node host then writes it into `events.jsonl` as `req_body_sample_b64` (inline, up to 32 KB) or a sidecar `.json.gz`. For uncompressed or passthrough requests that is the user's message content, recoverable in the clear with `gunzip`. That is surprising for what otherwise reads as a token-metrics log, and it persists prompt content to disk on every upstream 4xx.

## Change

- New `ProxyConfig.capture4xxBody` flag, default off. The 4xx gzip is gated on it.
- The Node host sets it from `PXPIPE_CAPTURE_4XX_BODY=1`.
- `proxy.ts` stays free of `process.env` so the Cloudflare Worker build is unaffected.
- `error_body` (the upstream error response, not the request) is unchanged.

## Verify

- `pnpm typecheck` and `pnpm build` both clean.
- On a freshly built bundle: a forced 4xx writes no `req_body_sample` by default, and writes one only when `PXPIPE_CAPTURE_4XX_BODY=1`. Binding is loopback in both cases.
