### PR TITLE
fix(transform): keep appended system blocks live (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ Three kinds of *input* blocks, each behind a profitability gate:
    ~6k chars of token-dense content
 2. older collapsed history: turns behind the live tail get re-rendered as
    image pages, recent turns always stay text
-3. the static system prompt + tool docs slab
+3. the static cacheable system prompt + tool docs slab; appended non-cacheable
+   system blocks stay live text so host custom instructions keep system-level
+   salience
 
 Everything else passes through byte-identical: your messages, recent turns,
 the model's output (it is the response, the proxy never touches it), sparse

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -621,11 +621,18 @@ export interface TransformInfo {
 function extractSystemText(sys: SystemField | undefined): { text: string; kept: SystemField } {
   if (sys == null) return { text: '', kept: [] };
   if (typeof sys === 'string') return { text: sys, kept: '' };
+  const hasCacheControlledText = sys.some(
+    (block) => block && block.type === 'text' && block.cache_control !== undefined,
+  );
   const textParts: string[] = [];
   const kept: SystemField = [];
   for (const block of sys) {
     if (block && typeof block === 'object' && block.type === 'text') {
-      textParts.push(block.text);
+      if (!hasCacheControlledText || block.cache_control !== undefined) {
+        textParts.push(block.text);
+      } else {
+        kept.push(block);
+      }
     } else {
       kept.push(block);
     }

--- a/tests/design-behavior-e2e.test.ts
+++ b/tests/design-behavior-e2e.test.ts
@@ -59,6 +59,9 @@ function fakeUpstream() {
 
 const FORCE = { charsPerToken: 1, minCompressChars: 1 } as const;
 const big = (n: number) => 'x'.repeat(n);
+const APPENDED_SYSTEM_SENTINEL = 'APPENDED_SYSTEM_SENTINEL_keep_live_text';
+const BASE_SYSTEM_SENTINEL = 'BASE_SYSTEM_SENTINEL_image_me';
+const LARGE_SYSTEM_CHARS = 80_000;
 
 async function drive(path: string, body: string): Promise<any> {
   const cap = fakeUpstream();
@@ -94,7 +97,7 @@ describe('design: SYSTEM PROMPT imaging (Anthropic)', () => {
       JSON.stringify({
         model: 'claude-fable-5',
         max_tokens: 16,
-        system: [{ type: 'text', text: 'SLAB_SECRET_' + big(80_000), cache_control: { type: 'ephemeral' } }],
+        system: [{ type: 'text', text: 'SLAB_SECRET_' + big(LARGE_SYSTEM_CHARS), cache_control: { type: 'ephemeral' } }],
         messages: [{ role: 'user', content: 'LIVE_QUESTION here' }],
       }),
     );
@@ -106,6 +109,30 @@ describe('design: SYSTEM PROMPT imaging (Anthropic)', () => {
     // The system field no longer carries the slab (Anthropic forbids images there).
     expect(JSON.stringify(out.system ?? '')).not.toContain('SLAB_SECRET_');
     // The live turn is preserved verbatim and legible.
+    expect(hay).toContain('LIVE_QUESTION here');
+  });
+
+  it('keeps non-cache-controlled appended system blocks as live text', async () => {
+    const out = await drive(
+      '/v1/messages',
+      JSON.stringify({
+        model: 'claude-fable-5',
+        max_tokens: 16,
+        system: [
+          {
+            type: 'text',
+            text: BASE_SYSTEM_SENTINEL + big(LARGE_SYSTEM_CHARS),
+            cache_control: { type: 'ephemeral' },
+          },
+          { type: 'text', text: APPENDED_SYSTEM_SENTINEL },
+        ],
+        messages: [{ role: 'user', content: 'LIVE_QUESTION here' }],
+      }),
+    );
+    const hay = JSON.stringify(out);
+    expect(imageCount(out)).toBeGreaterThan(0);
+    expect(hay).not.toContain(BASE_SYSTEM_SENTINEL);
+    expect(JSON.stringify(out.system ?? '')).toContain(APPENDED_SYSTEM_SENTINEL);
     expect(hay).toContain('LIVE_QUESTION here');
   });
 });


### PR DESCRIPTION
## Summary

Fix #66

- keep non-cache-controlled appended system text in the live Anthropic `system` field
- continue imaging the cache-controlled static system slab and tool reference
- document that appended non-cacheable system blocks stay as text

## Test verification (RED -> GREEN)

RED with production fix reverted:

```text
FAIL  tests/design-behavior-e2e.test.ts > design: SYSTEM PROMPT imaging (Anthropic) > keeps non-cache-controlled appended system blocks as live text
AssertionError: expected '""' to contain 'APPENDED_SYSTEM_SENTINEL_keep_live_te…'

Expected: "APPENDED_SYSTEM_SENTINEL_keep_live_text"
Received: """"

 Test Files  1 failed | 31 passed (32)
      Tests  1 failed | 645 passed (646)
```

GREEN with fix applied:

```text
[14:17:01] Final typecheck: pnpm run typecheck
[14:17:04] Final tests: pnpm test
 Test Files  32 passed (32)
      Tests  646 passed (646)
[14:17:19] Final build: pnpm run build
✓ built dist/node.js
✓ version smoke check: --version prints 0.8.0
```

## Files changed

| File | Change |
|------|--------|
| `src/core/transform.ts` | split structured system text so only cache-controlled blocks enter the image slab when present |
| `tests/design-behavior-e2e.test.ts` | add regression coverage for appended non-cacheable system blocks |
| `README.md` | document live-text behavior for appended non-cacheable system blocks |

Generated by Ora Studio
Vibe coded by ousamabenyounes