### PR TITLE
fix(node): use Codex ChatGPT auth for OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ npx pxpipe-proxy                                  # proxy on 127.0.0.1:47821
 ANTHROPIC_BASE_URL=http://127.0.0.1:47821 claude  # point Claude Code at it
 ```
 
+OpenAI-compatible clients can use `OPENAI_BASE_URL=http://127.0.0.1:47821/v1`.
+Set `OPENAI_API_KEY` to override auth; if it is unset, the Node proxy also
+uses Codex ChatGPT login from `~/.codex/auth.json` when present.
+
 Dashboard at <http://127.0.0.1:47821/>: tokens saved, every text→image
 conversion side by side, kill switch, live model chips. Responses stream
 normally — pxpipe compresses the *request* only, never the model's output.

--- a/src/node-auth.ts
+++ b/src/node-auth.ts
@@ -1,0 +1,66 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const CODEX_AUTH_MODE_CHATGPT = 'chatgpt';
+const CODEX_AUTH_FILE_ENV = 'PXPIPE_CODEX_AUTH_FILE';
+const DEFAULT_CODEX_AUTH_FILE = path.join(os.homedir(), '.codex', 'auth.json');
+
+interface CodexAuthFile {
+  auth_mode?: unknown;
+  tokens?: unknown;
+}
+
+interface CodexAuthTokens {
+  access_token?: unknown;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function defaultCodexAuthFile(): string {
+  return process.env[CODEX_AUTH_FILE_ENV] ?? DEFAULT_CODEX_AUTH_FILE;
+}
+
+export function readCodexChatGptAccessToken(
+  authFile: string = defaultCodexAuthFile(),
+): string | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(authFile, 'utf8');
+  } catch {
+    return undefined;
+  }
+
+  let parsed: CodexAuthFile;
+  try {
+    parsed = JSON.parse(raw) as CodexAuthFile;
+  } catch {
+    return undefined;
+  }
+
+  if (!isObjectRecord(parsed) || parsed.auth_mode !== CODEX_AUTH_MODE_CHATGPT) {
+    return undefined;
+  }
+
+  if (!isObjectRecord(parsed.tokens)) {
+    return undefined;
+  }
+
+  return nonEmptyString((parsed.tokens as CodexAuthTokens).access_token);
+}
+
+export function resolveOpenAIApiKey(
+  explicitOpenAIKey: string | undefined = process.env.OPENAI_API_KEY,
+  codexAuthFile?: string,
+): string | undefined {
+  const explicit = nonEmptyString(explicitOpenAIKey);
+  return explicit ?? readCodexChatGptAccessToken(codexAuthFile);
+}

--- a/src/node.ts
+++ b/src/node.ts
@@ -12,7 +12,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 import { createProxy, parseGatewayHeaders, resolveUpstreams, type ProxyConfig } from './core/proxy.js';
+import { resolveOpenAIApiKey } from './node-auth.js';
 import {
   parseExportArgv,
   runExportCore,
@@ -35,7 +37,7 @@ import {
 /** Runtime config. The core transform tuning comes from DEFAULTS in
  *  transform.ts; startup knobs cover deployment plus emergency GPT scope
  *  control. No CLI flags beyond --help/--version. */
-interface RuntimeConfig {
+export interface RuntimeConfig {
   port: number;
   /** Interface to bind. Defaults to 127.0.0.1 (loopback only) — the dashboard
    *  is unauthenticated and serves captured request context, so it must not be
@@ -52,6 +54,7 @@ interface RuntimeConfig {
 }
 
 const DEFAULT_CONFIG_FILE = path.join(os.homedir(), '.config', 'pxpipe', 'config.json');
+const PROCESS_ARGV_SCRIPT_INDEX = 1;
 
 function normalizeModelsConfig(value: unknown): string | undefined {
   if (Array.isArray(value)) {
@@ -83,7 +86,7 @@ function applyConfigFileDefaults(): void {
   }
 }
 
-function parseCli(argv: string[]): RuntimeConfig {
+export function parseCli(argv: string[]): RuntimeConfig {
   // Only flags accepted are --help and --version. Anything else is an
   // error — there is exactly ONE way to run pxpipe and the dashboard
   // exposes every metric the operator might want to inspect.
@@ -110,7 +113,7 @@ function parseCli(argv: string[]): RuntimeConfig {
     host: process.env.HOST?.trim() || '127.0.0.1',
     upstream: process.env.ANTHROPIC_UPSTREAM ?? sharedUpstream ?? 'https://api.anthropic.com',
     openAIUpstream: process.env.OPENAI_UPSTREAM ?? sharedUpstream ?? 'https://api.openai.com',
-    openAIApiKey: process.env.OPENAI_API_KEY,
+    openAIApiKey: resolveOpenAIApiKey(),
     provider: parseProvider(process.env.PXPIPE_PROVIDER),
     gatewayBaseUrl: process.env.PXPIPE_GATEWAY_BASE_URL,
     gatewayHeaders: parseGatewayHeaders(process.env.PXPIPE_GATEWAY_HEADERS),
@@ -156,6 +159,8 @@ Environment:
   OPENAI_UPSTREAM         OpenAI API base; overrides PXPIPE_UPSTREAM
                            (default https://api.openai.com)
   OPENAI_API_KEY          optional OpenAI key override; otherwise forwarded
+                          or read from Codex ChatGPT auth when available
+  PXPIPE_CODEX_AUTH_FILE  Codex auth path (default ~/.codex/auth.json)
   PXPIPE_PROVIDER         optional: 'cloudflare-ai-gateway' — route both API
                           families through one gateway base URL
   PXPIPE_GATEWAY_BASE_URL gateway base URL (required with PXPIPE_PROVIDER)
@@ -1105,7 +1110,14 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 
-main().catch((err) => {
-  console.error('[pxpipe] fatal:', err);
-  process.exit(1);
-});
+function isDirectCliEntrypoint(): boolean {
+  const script = process.argv[PROCESS_ARGV_SCRIPT_INDEX];
+  return script !== undefined && import.meta.url === pathToFileURL(script).href;
+}
+
+if (isDirectCliEntrypoint()) {
+  main().catch((err) => {
+    console.error('[pxpipe] fatal:', err);
+    process.exit(1);
+  });
+}

--- a/tests/node-auth.test.ts
+++ b/tests/node-auth.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolveOpenAIApiKey } from '../src/node-auth.js';
+import { parseCli } from '../src/node.js';
+
+const TMP_PREFIX = 'pxpipe-codex-auth-';
+const AUTH_FILE_NAME = 'auth.json';
+const CHATGPT_AUTH_MODE = 'chatgpt';
+const API_KEY_AUTH_MODE = 'api-key';
+const EXPLICIT_OPENAI_KEY = 'sk-explicit-test-key';
+const CODEX_ACCESS_TOKEN = 'codex-chatgpt-access-token';
+const IGNORED_CODEX_ACCESS_TOKEN = 'ignored-codex-token';
+const MALFORMED_AUTH_JSON = '{';
+const ORIGINAL_OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const ORIGINAL_CODEX_AUTH_FILE = process.env.PXPIPE_CODEX_AUTH_FILE;
+
+const tmpDirs: string[] = [];
+
+function writeAuthFile(contents: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), TMP_PREFIX));
+  tmpDirs.push(dir);
+  const file = path.join(dir, AUTH_FILE_NAME);
+  fs.writeFileSync(file, JSON.stringify(contents), 'utf8');
+  return file;
+}
+
+function writeRawAuthFile(contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), TMP_PREFIX));
+  tmpDirs.push(dir);
+  const file = path.join(dir, AUTH_FILE_NAME);
+  fs.writeFileSync(file, contents, 'utf8');
+  return file;
+}
+
+afterEach(() => {
+  setOptionalEnv('OPENAI_API_KEY', ORIGINAL_OPENAI_API_KEY);
+  setOptionalEnv('PXPIPE_CODEX_AUTH_FILE', ORIGINAL_CODEX_AUTH_FILE);
+
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function setOptionalEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+describe('resolveOpenAIApiKey', () => {
+  it('prefers an explicit OPENAI_API_KEY over Codex ChatGPT auth', () => {
+    const authFile = writeAuthFile({
+      auth_mode: CHATGPT_AUTH_MODE,
+      tokens: { access_token: IGNORED_CODEX_ACCESS_TOKEN },
+    });
+
+    expect(resolveOpenAIApiKey(EXPLICIT_OPENAI_KEY, authFile)).toBe(EXPLICIT_OPENAI_KEY);
+  });
+
+  it('uses the Codex ChatGPT access token when OPENAI_API_KEY is absent', () => {
+    const authFile = writeAuthFile({
+      auth_mode: CHATGPT_AUTH_MODE,
+      OPENAI_API_KEY: null,
+      tokens: { access_token: CODEX_ACCESS_TOKEN },
+    });
+
+    expect(resolveOpenAIApiKey(undefined, authFile)).toBe(CODEX_ACCESS_TOKEN);
+  });
+
+  it('wires Codex ChatGPT auth into the Node runtime config', () => {
+    const authFile = writeAuthFile({
+      auth_mode: CHATGPT_AUTH_MODE,
+      OPENAI_API_KEY: null,
+      tokens: { access_token: CODEX_ACCESS_TOKEN },
+    });
+    delete process.env.OPENAI_API_KEY;
+    process.env.PXPIPE_CODEX_AUTH_FILE = authFile;
+
+    expect(parseCli([]).openAIApiKey).toBe(CODEX_ACCESS_TOKEN);
+  });
+
+  it('ignores non-ChatGPT Codex auth files', () => {
+    const authFile = writeAuthFile({
+      auth_mode: API_KEY_AUTH_MODE,
+      tokens: { access_token: IGNORED_CODEX_ACCESS_TOKEN },
+    });
+
+    expect(resolveOpenAIApiKey(undefined, authFile)).toBeUndefined();
+  });
+
+  it('ignores missing or malformed Codex auth files', () => {
+    const missingAuthFile = path.join(os.tmpdir(), TMP_PREFIX + AUTH_FILE_NAME);
+    const malformedAuthFile = writeRawAuthFile(MALFORMED_AUTH_JSON);
+
+    expect(resolveOpenAIApiKey(undefined, missingAuthFile)).toBeUndefined();
+    expect(resolveOpenAIApiKey(undefined, malformedAuthFile)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds Node-runtime support for Codex ChatGPT login when `OPENAI_API_KEY` is not set. The proxy now reads a non-empty `tokens.access_token` from Codex auth only when `auth_mode` is `chatgpt`, while still preferring an explicit `OPENAI_API_KEY`.

Also documents the fallback in the CLI help and README.

| Q | A |
| --- | --- |
| Issues | Fix #41 |
| Tests | `pnpm test -- tests/node-auth.test.ts`; `pnpm run typecheck`; `pnpm test`; `pnpm run build` |

## Test verification (RED → GREEN)

RED, with the production `parseCli` integration temporarily reverted to `process.env.OPENAI_API_KEY`:

```text
FAIL  tests/node-auth.test.ts > resolveOpenAIApiKey > wires Codex ChatGPT auth into the Node runtime config
AssertionError: expected undefined to be 'codex-chatgpt-access-token' // Object.is equality

- Expected:
"codex-chatgpt-access-token"

+ Received:
undefined

Test Files  1 failed | 32 passed (33)
Tests  1 failed | 649 passed (650)
```

GREEN, with the fix applied:

```text
[targeted] pnpm test -- tests/node-auth.test.ts
Test Files  33 passed (33)
Tests  650 passed (650)

[typecheck] pnpm run typecheck
[test] pnpm test
Test Files  33 passed (33)
Tests  650 passed (650)

[build] pnpm run build
✓ emitted dist/ library modules + declarations
✓ built dist/node.js
✓ version smoke check: --version prints 0.8.0
```
