### PR TITLE
fix: capture transactional factsheet anchors

### DIFF
--- a/src/core/factsheet.ts
+++ b/src/core/factsheet.ts
@@ -19,7 +19,10 @@
 const PATTERNS: readonly RegExp[] = [
   /\b[A-Z][A-Z0-9_]{2,}=[^\s)"'<>]+/g, // semantic LABEL=value pair (preserve association)
   /\bhttps?:\/\/[^\s)"'<>]+/g, // URLs
+  /\b[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+\b/g, // email address
   /\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/g, // UUID
+  /\b[A-Z]{2}\d{2}[A-Z0-9]{8,30}\b/g, // IBAN-like account string
+  /(?:[$€£¥]|(?:USD|EUR|GBP|CAD|AUD|CHF|JPY))\d(?:[\d,_]*\d)?(?:\.\d{2})?\b/g, // currency amount
   /(?:[\w@~+-]+)?(?:\/[\w.@+-]+)+\.[A-Za-z]\w{0,8}\b/g, // path with a file extension (multi-dot ok: .test.ts)
   /\/[\w.@+-]+(?:\/[\w.@+-]+)+\/?/g, // dir path (>=2 segments)
   /\b(?=[0-9a-f]*\d)[0-9a-f]{7,40}\b/g, // git sha / long hex (must contain a digit)
@@ -56,6 +59,9 @@ const MAX_CHUNK = 512; // whitespace-free chunks longer than this are blobs (bas
  *  identifiers outrank long URLs when the budget is tight. Pure + total → deterministic →
  *  cache-stable. Tiers: 0 = protect always, 1 = paths/versions/misc, 2 = URLs (cap + last). */
 const SHAPE_UUID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const SHAPE_EMAIL = /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$/;
+const SHAPE_IBAN = /^[A-Z]{2}\d{2}[A-Z0-9]{8,30}$/;
+const SHAPE_CURRENCY = /^(?:[$€£¥]|(?:USD|EUR|GBP|CAD|AUD|CHF|JPY))\d(?:[\d,_]*\d)?(?:\.\d{2})?$/;
 const SHAPE_HEX = /^(?=[0-9a-f]*\d)[0-9a-f]{7,40}$/; // git sha / opaque hex
 const SHAPE_CONST = /^[A-Z][A-Z0-9]{2,}(?:_[A-Z0-9]+)+$/; // CONST_IDS / env vars
 const SHAPE_TICKET = /^(?=[A-Z0-9-]*\d)[A-Z][A-Z0-9]+(?:-[A-Z0-9]+)+$/; // PROJ-1482 / CVE-2024-30078
@@ -71,6 +77,9 @@ function priorityTier(tok: string): 0 | 1 | 2 {
     SHAPE_ASSIGNMENT.test(tok) ||
     SHAPE_HEX.test(tok) ||
     SHAPE_UUID.test(tok) ||
+    SHAPE_EMAIL.test(tok) ||
+    SHAPE_IBAN.test(tok) ||
+    SHAPE_CURRENCY.test(tok) ||
     SHAPE_CONST.test(tok) ||
     SHAPE_TICKET.test(tok) ||
     SHAPE_FLAG.test(tok) ||

--- a/tests/factsheet.test.ts
+++ b/tests/factsheet.test.ts
@@ -22,6 +22,23 @@ describe('factsheet extraction', () => {
     expect(toks).toContain('97.82');
   });
 
+  it('captures issue 55 exact-token classes for transactional text', () => {
+    const replyTo = 'ops.reply+invoice-55@example.co.uk';
+    const iban = 'UA383220010000026008';
+    const invoiceAmount = '$14,360';
+    const text = [
+      `reply-to ${replyTo}`,
+      `settle IBAN ${iban}`,
+      `invoice total ${invoiceAmount}, due today`,
+    ].join('\n');
+
+    const toks = extractFactSheetTokens(text);
+
+    expect(toks).toContain(replyTo);
+    expect(toks).toContain(iban);
+    expect(toks).toContain(invoiceAmount);
+  });
+
   it('drops substrings of longer kept tokens', () => {
     const toks = extractFactSheetTokens('see https://github.com/o/r/pull/9 in repo');
     // The bare /github.com path must collapse into the full URL.


### PR DESCRIPTION
## Summary
- Extend factsheet extraction for issue 55 exact-token classes: email addresses, IBAN-like strings, and currency amounts such as `$14,360`.
- Keep those tokens in the protected priority tier alongside existing UUID, hex, flag, and number anchors.
- Add a focused factsheet regression test for transactional text.

Fix #55

## Test verification (RED -> GREEN)
RED, new test before production extractor change:
```text
> pxpipe-proxy@0.8.0 test
> vitest run tests/factsheet.test.ts

RUN  v4.1.6

❯ tests/factsheet.test.ts (15 tests | 1 failed) 65ms
    × captures issue 55 exact-token classes for transactional text 8ms

Test Files  1 failed (1)
Tests  1 failed | 14 passed (15)
```

RED, production factsheet changes temporarily reverted while keeping the test:
```text
> pxpipe-proxy@0.8.0 test
> vitest run tests/factsheet.test.ts

RUN  v4.1.6

❯ tests/factsheet.test.ts (15 tests | 1 failed) 51ms
    × captures issue 55 exact-token classes for transactional text 5ms

Test Files  1 failed (1)
Tests  1 failed | 14 passed (15)
```

GREEN, focused test after fix:
```text
> pxpipe-proxy@0.8.0 test
> vitest run tests/factsheet.test.ts

✓ tests/factsheet.test.ts (15 tests) 81ms

Test Files  1 passed (1)
Tests  15 passed (15)
```

GREEN, required checks:
```text
> pxpipe-proxy@0.8.0 typecheck
> tsc --noEmit

> pxpipe-proxy@0.8.0 test
> vitest run

Test Files  32 passed (32)
Tests  646 passed (646)

> pxpipe-proxy@0.8.0 build
> node scripts/build.mjs

✓ emitted dist/ library modules + declarations
✓ built dist/node.js
✓ version smoke check: --version prints 0.8.0
```