### PR TITLE
docs: document offline export workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ normally — pxpipe compresses the *request* only, never the model's output.
 Recent turns stay text; the system prompt, tool docs, and older bulk history
 are imaged.
 
+## Offline export (no proxy)
+
+You can render text, files, or diffs to PNG pages without running the proxy or
+connecting Claude Code:
+
+```bash
+pxpipe export src/
+cat prompt.txt | pxpipe export --stdin
+pxpipe export --git
+```
+
+The command writes an output folder containing `page-*.png`, `factsheet.txt`,
+`manifest.json`, and `prompt.txt`. Upload the PNG pages and paste the prompt
+into image-upload clients such as Cursor when you want dense visual context
+without running the proxy.
+
 ## The honest part
 
 - **It is lossy.** Exact 12-char hex strings in dense imaged content:

--- a/tests/readme-offline-export.test.ts
+++ b/tests/readme-offline-export.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+
+const README_PATH = 'README.md';
+const OFFLINE_EXPORT_HEADING = '## Offline export (no proxy)';
+const REQUIRED_OFFLINE_EXPORT_TEXT = [
+  'pxpipe export',
+  '--stdin',
+  '--git',
+  'page-*.png',
+  'factsheet.txt',
+  'prompt.txt',
+  'Cursor',
+  'without running the proxy',
+] as const;
+
+describe('README offline export documentation', () => {
+  it('documents the proxy-free image export workflow', () => {
+    const readme = fs.readFileSync(README_PATH, 'utf8');
+    const sectionStart = readme.indexOf(OFFLINE_EXPORT_HEADING);
+
+    expect(sectionStart).toBeGreaterThanOrEqual(0);
+
+    const nextSectionStart = readme.indexOf('\n## ', sectionStart + OFFLINE_EXPORT_HEADING.length);
+    const section =
+      nextSectionStart === -1 ? readme.slice(sectionStart) : readme.slice(sectionStart, nextSectionStart);
+
+    for (const requiredText of REQUIRED_OFFLINE_EXPORT_TEXT) {
+      expect(section).toContain(requiredText);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a concise README section for using `pxpipe export` without running the proxy or connecting Claude Code.
- Document `--stdin`, `--git`, and the generated `page-*.png`, `factsheet.txt`, `manifest.json`, and `prompt.txt` files for image-upload clients such as Cursor.
- Add a README regression test for the documented offline export workflow.

Fixes #47

## Test verification (RED -> GREEN)
This is a docs-only change, so the RED/GREEN proof is a README regression test: the test fails when the documented section is absent and passes when the section is present.

RED, new test before README change:
```text
pnpm exec vitest run tests/readme-offline-export.test.ts

FAIL tests/readme-offline-export.test.ts > README offline export documentation > documents the proxy-free image export workflow
AssertionError: expected -1 to be greater than or equal to 0
Test Files 1 failed (1)
Tests 1 failed (1)
```

Docs-revert RED, README section temporarily removed while keeping the test:
```text
pnpm exec vitest run tests/readme-offline-export.test.ts

FAIL tests/readme-offline-export.test.ts > README offline export documentation > documents the proxy-free image export workflow
AssertionError: expected -1 to be greater than or equal to 0
Test Files 1 failed (1)
Tests 1 failed (1)
```

GREEN, README section restored:
```text
pnpm exec vitest run tests/readme-offline-export.test.ts

Test Files 1 passed (1)
Tests 1 passed (1)
Duration 261ms
```

Required validation:
```text
pnpm run typecheck
> tsc --noEmit

pnpm test
Test Files 33 passed (33)
Tests 646 passed (646)
Duration 13.63s

pnpm run build
✓ emitted dist/ library modules + declarations
✓ built dist/node.js
✓ version smoke check: --version prints 0.8.0
```
