### PR TITLE
docs: clarify Claude client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ normally — pxpipe compresses the *request* only, never the model's output.
 Recent turns stay text; the system prompt, tool docs, and older bulk history
 are imaged.
 
+## Use with Claude clients
+
+Start the proxy in one terminal, then point the client at it.
+
+Claude Code CLI on macOS/Linux:
+
+```bash
+npx pxpipe-proxy
+ANTHROPIC_BASE_URL=http://127.0.0.1:47821 claude
+```
+
+Claude Code CLI on Windows PowerShell:
+
+```powershell
+npx pxpipe-proxy
+$env:ANTHROPIC_BASE_URL = "http://127.0.0.1:47821"
+claude
+```
+
+Claude Desktop can use the same `ANTHROPIC_BASE_URL` environment variable for
+its bundled Claude Code runtime. Start `pxpipe` first, then launch Claude
+Desktop from an environment where `ANTHROPIC_BASE_URL` is set to
+`http://127.0.0.1:47821`.
+
 ## The honest part
 
 - **It is lossy.** Exact 12-char hex strings in dense imaged content:

--- a/tests/readme-usage.test.ts
+++ b/tests/readme-usage.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+
+const README_PATH = 'README.md';
+const USAGE_HEADING = '## Use with Claude clients';
+const REQUIRED_USAGE_TEXT = [
+  'Claude Code CLI',
+  'ANTHROPIC_BASE_URL=http://127.0.0.1:47821 claude',
+  'Windows PowerShell',
+  '$env:ANTHROPIC_BASE_URL',
+  'Claude Desktop',
+  'ANTHROPIC_BASE_URL',
+] as const;
+
+describe('README usage documentation', () => {
+  it('documents CLI, Windows PowerShell, and Claude Desktop setup', () => {
+    const readme = fs.readFileSync(README_PATH, 'utf8');
+    const sectionStart = readme.indexOf(USAGE_HEADING);
+
+    expect(sectionStart).toBeGreaterThanOrEqual(0);
+
+    const nextSectionStart = readme.indexOf('\n## ', sectionStart + USAGE_HEADING.length);
+    const section =
+      nextSectionStart === -1 ? readme.slice(sectionStart) : readme.slice(sectionStart, nextSectionStart);
+
+    for (const requiredText of REQUIRED_USAGE_TEXT) {
+      expect(section).toContain(requiredText);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused README section for setting up pxpipe with Claude clients:

- Claude Code CLI on macOS/Linux
- Claude Code CLI on Windows PowerShell
- Claude Desktop via `ANTHROPIC_BASE_URL`

Also adds a README regression test so the setup instructions stay discoverable.

| Q | A |
| --- | --- |
| Issues | Fix #56 |
| Tests | `pnpm exec vitest run tests/readme-usage.test.ts`; `pnpm run typecheck`; `pnpm test`; `pnpm run build` |

## Test verification (RED → GREEN)

RED, with the README usage section absent:

```text
FAIL  tests/readme-usage.test.ts > README usage documentation > documents CLI, Windows PowerShell, and Claude Desktop setup
AssertionError: expected -1 to be greater than or equal to 0

Test Files  1 failed (1)
Tests  1 failed (1)
```

GREEN, with the README usage section restored:

```text
[targeted] pnpm exec vitest run tests/readme-usage.test.ts
Test Files  1 passed (1)
Tests  1 passed (1)

[typecheck] pnpm run typecheck
[test] pnpm test
Test Files  33 passed (33)
Tests  646 passed (646)

[build] pnpm run build
✓ emitted dist/ library modules + declarations
✓ built dist/node.js
✓ version smoke check: --version prints 0.8.0
```
