### PR TITLE
test: allow slower render e2e cases

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vitest/config';
 
+const TEST_FILE_PATTERNS = ['tests/**/*.test.ts'];
+const TEST_TIMEOUT_MS = 30_000;
+
 export default defineConfig({
   test: {
-    include: ['tests/**/*.test.ts'],
+    include: TEST_FILE_PATTERNS,
     environment: 'node',
+    testTimeout: TEST_TIMEOUT_MS,
   },
 });


### PR DESCRIPTION
Closes #81.

## Summary

- Adds named Vitest config constants for the test include glob and render/E2E timeout.
- Raises the per-test timeout to 30s so render-heavy proxy E2E cases do not fail under Vitest's 5s default.

## Test verification

- `pnpm run typecheck` — passed
- `pnpm test` — passed: 32 files, 645 tests
- `pnpm vitest run tests/cache-stability-e2e.test.ts tests/design-behavior-e2e.test.ts` — passed: 2 files, 20 tests

## RED → GREEN note

Local baseline previously reported timeout failures in the render-heavy E2E specs under the default 5s Vitest timeout. Re-running those specs with a realistic timeout passed, confirming this patch addresses the harness timing rather than changing product behavior.