### PR TITLE
fix(build): resolve pnpm.cmd on Windows so `pnpm run build` works

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -17,9 +17,12 @@ const OUT = 'dist';
 if (existsSync(OUT)) await rm(OUT, { recursive: true, force: true });
 await mkdir(OUT, { recursive: true });
 
+// shell:true so Windows resolves `pnpm` to `pnpm.cmd`. Node's spawn without a
+// shell only launches bare executables (not .cmd/.bat shims), so on Windows
+// this call fails with ENOENT and the build aborts as if tsc had errored.
 const tsc = spawnSync('pnpm', ['exec', 'tsc', '-p', 'tsconfig.json'], {
   stdio: 'inherit',
-  shell: false,
+  shell: true,
 });
 if (tsc.status !== 0) process.exit(tsc.status ?? 1);
 console.log('✓ emitted dist/ library modules + declarations');


### PR DESCRIPTION
## Problem

On Windows, `pnpm run build` fails before it produces `dist/`:

```
> node scripts/build.mjs
 ELIFECYCLE  Command failed with exit code 1.
```

The build aborts at the tsc step even though `tsc` itself is fine (`pnpm exec tsc -p tsconfig.json` succeeds when run directly).

## Root cause

```js
const tsc = spawnSync('pnpm', ['exec', 'tsc', '-p', 'tsconfig.json'], {
  stdio: 'inherit',
  shell: false,
});
if (tsc.status !== 0) process.exit(tsc.status ?? 1);
```

With `shell: false`, Node's `spawnSync` only launches bare executables — it does **not** resolve Windows `.cmd`/`.bat` shims. On Windows `pnpm` is `pnpm.cmd`, so the spawn fails with `ENOENT`, `tsc.status` is `null`, and `null !== 0` triggers `process.exit(1)` — the build dies as if tsc had errored, before esbuild ever runs.

## Fix

Set `shell: true` so the platform shell resolves the `pnpm.cmd` shim. POSIX behavior is unchanged (`pnpm` resolves either way there). One line + an explanatory comment.

## Verified on

- Windows 11, Node v22.20.0, pnpm 10.21.0 — `pnpm run build` now completes both steps (tsc + esbuild) and emits `dist/node.js`, and `node bin/cli.js` starts the proxy normally.

No functional/runtime change — build script only.