### PR TITLE
fix(#92): stop ServerResponse listener leak in waitForDrain

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -253,12 +253,30 @@ function isConnectionAbort(err: unknown): boolean {
     causeMessage.includes('other side closed');
 }
 
-async function waitForDrain(out: ServerResponse): Promise<void> {
-  const event = await Promise.race([
-    once(out, 'drain').then(() => 'drain'),
-    once(out, 'close').then(() => 'close'),
-  ]);
-  if (event === 'close') throw new Error('client response closed');
+function waitForDrain(out: ServerResponse): Promise<void> {
+  // Do NOT use Promise.race([once(out,'drain'), once(out,'close')]): the losing
+  // once() never detaches its listener, and events.once() also attaches an
+  // implicit 'error' listener. On a long streamed response every backpressure
+  // cycle would then leak one 'close' + one 'error' listener on the same
+  // ServerResponse, triggering MaxListenersExceededWarning, unbounded heap
+  // growth, and eventually a silent OOM exit of the proxy. Manage the listeners
+  // manually and remove both on whichever event fires first.
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      out.off('drain', onDrain);
+      out.off('close', onClose);
+    };
+    const onDrain = () => {
+      cleanup();
+      resolve();
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error('client response closed'));
+    };
+    out.once('drain', onDrain);
+    out.once('close', onClose);
+  });
 }
 
 async function writeWebResponse(res: Response, out: ServerResponse): Promise<void> {

--- a/src/node.ts
+++ b/src/node.ts
@@ -260,11 +260,14 @@ function waitForDrain(out: ServerResponse): Promise<void> {
   // cycle would then leak one 'close' + one 'error' listener on the same
   // ServerResponse, triggering MaxListenersExceededWarning, unbounded heap
   // growth, and eventually a silent OOM exit of the proxy. Manage the listeners
-  // manually and remove both on whichever event fires first.
+  // manually and remove all of them on whichever event fires first. 'error' must
+  // be handled too: with no 'error' listener attached, an error emitted while we
+  // wait would crash the process as an unhandled 'error' event.
   return new Promise<void>((resolve, reject) => {
     const cleanup = () => {
       out.off('drain', onDrain);
       out.off('close', onClose);
+      out.off('error', onError);
     };
     const onDrain = () => {
       cleanup();
@@ -274,8 +277,13 @@ function waitForDrain(out: ServerResponse): Promise<void> {
       cleanup();
       reject(new Error('client response closed'));
     };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
     out.once('drain', onDrain);
     out.once('close', onClose);
+    out.once('error', onError);
   });
 }
 


### PR DESCRIPTION
Fixes #92  
# Fix ServerResponse listener leak in `waitForDrain` during long streams

## Problem

On long streaming responses, `pxpipe-proxy` can exit silently or drop the client
connection mid-response.

Observed symptom:

- Client (Claude Code) reports: `API Error: Connection closed mid-response`
- The proxy usually logs `POST /v1/messages -> 200` and then disappears
- No `[pxpipe] SIGINT — shutting down`
- No `[pxpipe] handler error:`
- No fatal line

It is far more likely on long SSE responses / long coding sessions and is preceded
by `MaxListenersExceededWarning` on `[ServerResponse]`.

## Root cause

`waitForDrain(out)` (`src/node.ts`) races two `once()` promises:

```js
const event = await Promise.race([
  once(out, 'drain').then(() => 'drain'),
  once(out, 'close').then(() => 'close'),
]);
```

`Promise.race` settles on the winner but never removes the **loser's** listener, and
`events.once()` additionally attaches an implicit `error` listener. Each backpressure
cycle (`out.write()` returns `false`) therefore leaks **one `close` + one `error`
listener** on the same `ServerResponse`. Across a long stream these accumulate
without bound → `MaxListenersExceededWarning` → heap growth → eventual OOM → silent
proxy exit.

### Reproduction

A client that reads part of a streamed response and then sends a TCP RST mid-stream
drives a single `ServerResponse` to:

```
MaxListenersExceededWarning: 11 close listeners added to [ServerResponse]
MaxListenersExceededWarning: 11 error listeners added to [ServerResponse]
```

The simultaneous growth of both `close` and `error` listeners is the signature of
`events.once`'s implicit error listener leaking alongside the named one.

## Fix

Replace the `Promise.race(events.once(...))` implementation with manually managed
listeners and a `cleanup()` that removes both on whichever event fires first.

Behaviour is preserved:

- `drain` → resolve
- `close` → reject with `client response closed`

```js
function waitForDrain(out: ServerResponse): Promise<void> {
  return new Promise<void>((resolve, reject) => {
    const cleanup = () => {
      out.off('drain', onDrain);
      out.off('close', onClose);
    };
    const onDrain = () => { cleanup(); resolve(); };
    const onClose = () => { cleanup(); reject(new Error('client response closed')); };
    out.once('drain', onDrain);
    out.once('close', onClose);
  });
}
```

## Scope / safety

- No change to request transformation, image rendering, compression, model
  allowlist, profitability gate, cache accounting, or token math — this is purely
  the response-streaming write path.
- No public API change.

## Validation

- Reproduced unbounded `close`/`error` listener growth on a single `ServerResponse`
  via a mid-stream TCP RST, and confirmed the patched version does not leak.
- `node --check` on the built output; `tsc --noEmit` on the source.