### PR TITLE
fix(anthropic): preserve Claude Code OAuth identity

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -151,6 +151,14 @@ const DEFAULTS: Required<TransformOptions> = {
   gptHistory: {},
 };
 
+/**
+ * Subscription OAuth requests are classified as Claude Code traffic only when
+ * this exact identity remains the first, separate top-level system block.
+ * Never render it into an image or concatenate other text into its block.
+ */
+export const CLAUDE_CODE_OAUTH_IDENTITY =
+  "You are Claude Code, Anthropic's official CLI for Claude.";
+
 // --- per-block break-even check ---
 //
 // Image token cost is computed from pixel area (Anthropic formula: w×h/750,
@@ -1492,13 +1500,13 @@ export async function transformRequest(
   // Pull the volatile `# Environment` markdown section out BEFORE the
   // static/dynamic split so per-session git state never reaches the slab image.
   const { kept: envMarkdown, body: sysBody } = stripMarkdownEnvSection(sysBodyWithEnv);
-  const {
-    staticText,
-    dynamicText,
-    blockCount: dynBlocks,
-    unknownTags,
-    staticTagContents,
-  } = splitStaticDynamic(sysBody);
+  const splitSystem = splitStaticDynamic(sysBody);
+  let staticText = splitSystem.staticText;
+  const { dynamicText, blockCount: dynBlocks, unknownTags, staticTagContents } = splitSystem;
+  const preserveClaudeCodeIdentity = staticText.startsWith(CLAUDE_CODE_OAUTH_IDENTITY);
+  if (preserveClaudeCodeIdentity) {
+    staticText = staticText.slice(CLAUDE_CODE_OAUTH_IDENTITY.length).replace(/^\s+/, '');
+  }
   info.staticChars = staticText.length;
   info.dynamicChars = dynamicText.length + envMarkdown.length;
   info.dynamicBlockCount = dynBlocks;
@@ -1749,6 +1757,9 @@ export async function transformRequest(
   // Images go into first user message — system field rejects images (400 system.N.type).
   {
     const sysTail: SystemField = [];
+    if (preserveClaudeCodeIdentity) {
+      sysTail.push({ type: 'text', text: CLAUDE_CODE_OAUTH_IDENTITY });
+    }
     // billingLine is session-stable (warm reads through the anchored prefix
     // confirm it; a per-turn value here would zero every cache read).
     if (billingLine) sysTail.push({ type: 'text', text: billingLine });

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -281,6 +281,38 @@ describe('public library API', () => {
     expect(transformed.cache.markerCount).toBe(0);
   });
 
+  it('preserves the exact Claude Code OAuth identity as the first system block', async () => {
+    const identity = "You are Claude Code, Anthropic's official CLI for Claude.";
+    const body = enc.encode(JSON.stringify({
+      model: 'claude-fable-5',
+      system: [
+        { type: 'text', text: identity },
+        {
+          type: 'text',
+          text: 'Detailed Claude Code operating instructions. '.repeat(1200),
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      tools: [{
+        name: 'read_file',
+        description: 'Read a file from disk. '.repeat(200),
+        input_schema: { type: 'object', properties: { path: { type: 'string' } } },
+      }],
+      messages: [{ role: 'user', content: 'hello' }],
+    }));
+
+    const transformed = await transformAnthropicMessages({ body, model: 'claude-fable-5' });
+    expect(transformed.applied).toBe(true);
+    expect(transformed.info.imageCount).toBeGreaterThan(0);
+
+    const out = JSON.parse(dec.decode(transformed.body)) as {
+      system?: Array<{ type: string; text?: string; cache_control?: unknown }>;
+    };
+    expect(out.system?.[0]).toEqual({ type: 'text', text: identity });
+    expect(out.system?.[0]?.cache_control).toBeUndefined();
+    expect(transformed.info.imageSourceText).not.toContain(identity);
+  });
+
   it('transforms GPT 5.5 chat completions using OpenAI image_url blocks', async () => {
     const body = enc.encode(JSON.stringify({
       model: 'gpt-5.5',


### PR DESCRIPTION
## Summary
- preserve the exact Claude Code OAuth identity as the first, separate top-level system block
- exclude that identity from the image-bound static slab while continuing to compress the remaining context
- add regression coverage proving compression still applies and the identity is neither concatenated nor rendered

Subscription OAuth traffic can be classified outside the included Claude Code lane when the identity is moved into an image. In a live enterprise OAuth reproduction, compressed requests returned a generic 429 with no normal rate-limit headers while passthrough succeeded. Saved transformed bodies confirmed the identity was absent from top-level `system`.

With this change, the same session produced two compressed 200 responses (`4` images, approximately `95k` compressed chars) after previously returning deterministic 429s.

Closes #100.

## Test plan
- [x] `pnpm exec vitest run tests/public-api.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm test` (32 files, 646 tests)
- [x] `pnpm run build`
- [x] live enterprise OAuth validation: compressed requests return 200