### PR TITLE
feat: publish codex profile telemetry

### DIFF
--- a/src/codex-telemetry.ts
+++ b/src/codex-telemetry.ts
@@ -1,0 +1,65 @@
+/** Minimal, metadata-only telemetry bridge for codex-switch. Node host only. */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const ALIAS_RE = /^[a-z0-9][a-z0-9._-]{0,31}$/;
+const SAFE_HEADER_RE = /^(?:x-)?(?:rate[-_]?limit|usage)(?:[-_].*)?$/i;
+
+export interface CodexProfileRoute {
+  alias: string;
+  upstreamPath: string;
+}
+
+/** Parse /p/<alias>/... and return the path which the upstream already expects. */
+export function codexProfileRoute(pathname: string, search = ''): CodexProfileRoute | undefined {
+  const match = /^\/p\/([^/]+)(\/.*)$/.exec(pathname);
+  if (!match) return undefined;
+  let alias: string;
+  try { alias = decodeURIComponent(match[1]!); } catch { return undefined; }
+  if (alias === 'direct' || !ALIAS_RE.test(alias)) return undefined;
+  return { alias, upstreamPath: match[2]! + search };
+}
+
+export function telemetryDimensions(response: Response): Record<string, string | number> | undefined {
+  const dimensions: Record<string, string | number> = {};
+  response.headers.forEach((value, name) => {
+    if (SAFE_HEADER_RE.test(name)) dimensions[name.toLowerCase()] = value;
+  });
+  if (response.status === 429) dimensions.http_status = 429;
+  return Object.keys(dimensions).length > 0 ? dimensions : undefined;
+}
+
+/** Wholesale atomic snapshot. Absence stays unknown; no missing value is synthesized as zero. */
+export async function writeCodexTelemetry(
+  alias: string,
+  response: Response,
+  dir = process.env.CODEX_SWITCH_TELEMETRY_DIR
+    || path.join(os.homedir(), '.codex-switch', 'telemetry'),
+): Promise<boolean> {
+  if (alias === 'direct' || !ALIAS_RE.test(alias)) return false;
+  const dimensions = telemetryDimensions(response);
+  if (!dimensions) return false;
+  const snapshot = {
+    schema_version: 1,
+    alias,
+    updated_at: new Date().toISOString(),
+    dimensions,
+  };
+  await fs.mkdir(dir, { recursive: true });
+  const target = path.join(dir, `${alias}.json`);
+  const tmp = path.join(dir, `.${alias}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`);
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(tmp, 'wx', 0o600);
+    await handle.writeFile(JSON.stringify(snapshot) + '\n', 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await fs.rename(tmp, target);
+    return true;
+  } finally {
+    await handle?.close().catch(() => {});
+    await fs.unlink(tmp).catch(() => {});
+  }
+}

--- a/src/node.ts
+++ b/src/node.ts
@@ -7,6 +7,7 @@
  */
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { codexProfileRoute, writeCodexTelemetry } from './codex-telemetry.js';
 import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -1044,8 +1045,17 @@ async function main(): Promise<void> {
             return;
           }
         }
+        const profileRoute = codexProfileRoute(url.pathname, url.search);
+        if (profileRoute) req.url = profileRoute.upstreamPath;
         const webReq = toWebRequest(req);
         const webRes = await handle(webReq);
+        if (profileRoute) {
+          // Best-effort and deliberately off the response path. Only allowlisted
+          // quota metadata is persisted; bodies, request headers and auth never are.
+          void writeCodexTelemetry(profileRoute.alias, webRes).catch((err) => {
+            console.warn(`[pxpipe] codex telemetry write failed: ${(err as Error).message}`);
+          });
+        }
         await writeWebResponse(webRes, res);
       })
       .catch((err) => {

--- a/tests/codex-telemetry.test.ts
+++ b/tests/codex-telemetry.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { codexProfileRoute, writeCodexTelemetry } from '../src/codex-telemetry.js';
+
+const dirs: string[] = [];
+afterEach(async () => Promise.all(dirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true }))));
+
+describe('codex-switch telemetry integration', () => {
+  it('routes a profile prefix while preserving query parameters', () => {
+    expect(codexProfileRoute('/p/work_1/v1/responses', '?stream=true')).toEqual({
+      alias: 'work_1', upstreamPath: '/v1/responses?stream=true',
+    });
+    expect(codexProfileRoute('/p/direct/v1/responses')).toBeUndefined();
+    expect(codexProfileRoute('/p/INVALID/v1/responses')).toBeUndefined();
+  });
+
+  it('atomically writes only quota metadata and never invents unknown zeroes', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pxpipe-telemetry-')); dirs.push(dir);
+    const response = new Response('SECRET RESPONSE CONTENT', { status: 200, headers: {
+      'x-ratelimit-remaining-requests': '17',
+      'x-usage-window': '5h',
+      authorization: 'Bearer SECRET',
+      'x-unrelated': 'do-not-store',
+    }});
+    expect(await writeCodexTelemetry('work', response, dir)).toBe(true);
+    const raw = await fs.readFile(path.join(dir, 'work.json'), 'utf8');
+    const value = JSON.parse(raw);
+    expect(value).toMatchObject({ schema_version: 1, alias: 'work', dimensions: {
+      'x-ratelimit-remaining-requests': '17', 'x-usage-window': '5h',
+    }});
+    expect(raw).not.toContain('SECRET');
+    expect(raw).not.toContain('unrelated');
+    expect(value.dimensions.remaining).toBeUndefined();
+    expect((await fs.readdir(dir)).filter((n) => n.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('records a bare 429 but skips responses with no quota signal', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pxpipe-telemetry-')); dirs.push(dir);
+    expect(await writeCodexTelemetry('rate', new Response('nope', { status: 429 }), dir)).toBe(true);
+    expect(JSON.parse(await fs.readFile(path.join(dir, 'rate.json'), 'utf8')).dimensions).toEqual({ http_status: 429 });
+    expect(await writeCodexTelemetry('quiet', new Response('ok'), dir)).toBe(false);
+    await expect(fs.access(path.join(dir, 'quiet.json'))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Adds metadata-only per-profile Codex quota telemetry for /p/<alias> routes, using atomic snapshots and preserving unknown values. Includes focused integration tests.