### PR TITLE
docs(readme): add Related projects section linking pxpipe-windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,9 @@ the real content in the same 1M window), and whether a smaller active
 context improves long-task accuracy. Hypotheses, not claims — they ship as
 numbers with an n or they get cut.
 
-## Related projects
+## Community projects
+
+Third-party projects listed here are not maintained or supported by pxpipe.
 
 - [pxpipe-windows](https://github.com/DivyeshPatro/pxpipe-windows) — Windows support for `pxpipe mitm` (node-forge CA in place of openssl, Task Scheduler autostart).
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ the real content in the same 1M window), and whether a smaller active
 context improves long-task accuracy. Hypotheses, not claims — they ship as
 numbers with an n or they get cut.
 
+## Related projects
+
+- [pxpipe-windows](https://github.com/DivyeshPatro/pxpipe-windows) — Windows support for `pxpipe mitm` (node-forge CA in place of openssl, Task Scheduler autostart).
+
 ## License
 
 MIT.


### PR DESCRIPTION
Re: #88.

You offered to add a Related projects link for the Windows fork — here's a ready-made PR so it's a one-click merge instead of something on your plate. Totally understand if you'd rather add it yourself or skip it (saw the maintenance notice in #107 — no pressure at all).

Docs-only: a single line under a new **Related projects** section, above License. No code, no behavior change.

- [pxpipe-windows](https://github.com/DivyeshPatro/pxpipe-windows) — Windows support for `pxpipe mitm` (node-forge CA in place of openssl, Task Scheduler autostart; macOS/Linux paths untouched).

Thanks again for pxpipe.