### PR TITLE
fix: detect model when a large field pushes it past the 8 KiB head

### DIFF
--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -71,13 +71,20 @@ export interface ProxyEvent {
 /** Max chars of 4xx error body captured on ProxyEvent — enough for Anthropic's full error JSON. */
 const ERROR_BODY_MAX = 2048;
 
-/** Read the top-level `model` field from a /v1/messages body without parsing the full JSON.
- *  Returns null when not found — callers treat null as outside supported scope (fail-closed). */
+/** Read the top-level `model` field from a /v1/messages body.
+ *  Fast path: regex over the first 8 KiB. Fallback: full JSON parse, for bodies
+ *  that serialize a large field (e.g. `system`) ahead of `model` — otherwise a
+ *  supported model would silently fail closed into passthrough and lose
+ *  compression. Returns null when the body is unreadable or `model` is absent —
+ *  callers treat null as outside supported scope (fail-closed). */
 function readModelField(body: Uint8Array): string | null {
   try {
     const head = new TextDecoder().decode(body.subarray(0, 8192));
     const m = /"model"\s*:\s*"([^"]{1,80})"/.exec(head);
-    return m ? m[1]! : null;
+    if (m) return m[1]!;
+    const obj = JSON.parse(new TextDecoder().decode(body)) as { model?: unknown } | null;
+    const v = obj?.model;
+    return typeof v === 'string' && v.length <= 80 ? v : null;
   } catch {
     return null;
   }

--- a/tests/proxy-usage.test.ts
+++ b/tests/proxy-usage.test.ts
@@ -173,6 +173,49 @@ describe('proxy usage extraction', () => {
     ).toBe(true);
   });
 
+  it('finds the model when a large field pushes it past the 8 KiB head', async () => {
+    const upstreamRequests: Request[] = [];
+    const restore = mockUpstream(async (req) => {
+      upstreamRequests.push(req.clone());
+      if (req.url.endsWith('/count_tokens')) {
+        return new Response(JSON.stringify({ input_tokens: 9000 }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({
+        id: 'msg_1', type: 'message', role: 'assistant',
+        content: [{ type: 'text', text: 'hello' }],
+        usage: { input_tokens: 120, output_tokens: 7 },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    let captured: ProxyEvent | undefined;
+    const proxy = createProxy({
+      upstream: 'http://upstream.test', apiKey: 'k',
+      transform: { charsPerToken: 1, minCompressChars: 1 },
+      onRequest: (e) => { captured = e; },
+    });
+    // JSON.stringify key order follows insertion order: a >8 KiB `system`
+    // serialized ahead of `model` starves the head-only regex.
+    const body = JSON.stringify({
+      system: 'System instruction. '.repeat(900),
+      model: 'claude-fable-5',
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    const res = await proxy(new Request('http://localhost/v1/messages', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body,
+    }));
+    await res.text();
+    await new Promise((r) => setTimeout(r, 20));
+    restore();
+
+    expect(captured?.model).toBe('claude-fable-5');
+    // Supported model recognized -> compression applies instead of the
+    // unsupported_model fail-closed passthrough.
+    expect(captured?.info?.reason).not.toBe('unsupported_model');
+    expect(captured?.info?.compressed).toBe(true);
+  });
+
   it('passes Claude Code Messages + Sol through without Anthropic count_tokens', async () => {
     const upstreamRequests: Request[] = [];
     const restore = mockUpstream(async (req) => {


### PR DESCRIPTION
## Problem

`readModelField` only regex-scans the first 8 KiB of a `/v1/messages` body to find the top-level `model` field. When a large field — e.g. a long `system` prompt — serializes ahead of `model`, the regex never sees it. The request then silently fails closed into the `unsupported_model` passthrough and loses compression, even though the model is fully supported.

This is easy to hit in practice: agent frameworks routinely send multi-KiB system prompts, and JSON key order follows insertion order, so `system` frequently lands before `model` in the serialized body.

## Fix

Keep the existing fast path (regex over the first 8 KiB), and only when it misses, fall back to a full `JSON.parse` of the body to read `model`. Fail-closed behavior is preserved:

- unreadable / non-JSON bodies → `null`
- absent `model` → `null`
- non-string or >80-char `model` values → `null`

The common case (model near the head) pays no extra cost — the fallback parse only runs when the regex misses.

## Tests

Adds a regression test that serializes a >8 KiB `system` field ahead of `model` and asserts:

- `captured.model` is detected (`claude-fable-5`)
- the request is **not** routed to the `unsupported_model` passthrough
- compression applies

`npx vitest run tests/proxy-usage.test.ts` → 30 passed (30).