### PR TITLE
Strip scope from relocated cache_control markers

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -693,6 +693,24 @@ function lastStaticSystemCacheControl(sys: SystemField | undefined): TextBlock['
   return cacheControl;
 }
 
+/**
+ * pxpipe relocates caller cache_control markers onto rendered image blocks.
+ * A relocated position is never a guaranteed "global prefix": pages 1..N-1 of
+ * a slab run and other pxpipe-injected blocks carry no marker, so a relocated
+ * `scope:"global"` violates Anthropic's "every preceding block must be
+ * globally scoped" rule and the whole request 400s (#95). Downgrade to plain
+ * ephemeral by dropping `scope` — a single trailing marker is always valid for
+ * ordinary ephemeral caching. `type`/`ttl` are preserved, and markers without
+ * `scope` pass through untouched (identity, so byte-stability is unaffected).
+ */
+function demoteRelocatedCacheControl<T>(cc: T): T {
+  if (cc && typeof cc === 'object' && 'scope' in (cc as object)) {
+    const { scope: _scope, ...rest } = cc as Record<string, unknown>;
+    return rest as T;
+  }
+  return cc;
+}
+
 // Per-turn dynamic blocks injected by Claude Code. These drift turn-to-turn and
 // must not be baked into the cached image. Split out so only the stable static
 // slab (CLAUDE.md + tool docs) carries cache_control.
@@ -933,7 +951,7 @@ function relocateAnchorToHistoryImage(messages: Message[] | undefined, anchorOrd
   }
   if (!slabAnchor) return; // nothing to relocate → never add a marker
 
-  historyImg.cache_control = slabAnchor.cache_control;
+  historyImg.cache_control = demoteRelocatedCacheControl(slabAnchor.cache_control);
   delete slabAnchor.cache_control;
 }
 
@@ -1963,7 +1981,7 @@ export async function transformRequest(
     const imageBlock = makeImageBlock(b64, i === images.length - 1);
     imageBlocks.push(
       i === images.length - 1 && systemStaticCacheControl !== undefined
-        ? { ...imageBlock, cache_control: systemStaticCacheControl }
+        ? { ...imageBlock, cache_control: demoteRelocatedCacheControl(systemStaticCacheControl) }
         : imageBlock,
     );
   }
@@ -2076,7 +2094,7 @@ export async function transformRequest(
             await textToImageBlocks(reminderText, o.cols, numCols);
           (info.imagePngs ??= []).push(...rawPngs);
           (info.imageDims ??= []).push(...rawDims);
-          const srcCacheControl = (blk as { cache_control?: unknown }).cache_control;
+          const srcCacheControl = demoteRelocatedCacheControl((blk as { cache_control?: unknown }).cache_control);
           for (let i = 0; i < imgs.length; i++) {
             const img = imgs[i]!;
             const out =
@@ -2225,7 +2243,7 @@ export async function transformRequest(
                   await textToImageBlocks(paged.text, o.cols, numCols);
                 (info.imagePngs ??= []).push(...rawPngs);
                 (info.imageDims ??= []).push(...rawDims);
-                const srcCacheControl = (ib as { cache_control?: unknown }).cache_control;
+                const srcCacheControl = demoteRelocatedCacheControl((ib as { cache_control?: unknown }).cache_control);
                 for (let i = 0; i < imgs.length; i++) {
                   const img = imgs[i]!;
                   const out =

--- a/tests/anthropic-cache-align.test.ts
+++ b/tests/anthropic-cache-align.test.ts
@@ -152,3 +152,59 @@ describe('Anthropic cache contract — gate never produces negative savings', ()
     expect(info.collapsedImages ?? 0).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe('Anthropic cache contract — #95 scope:"global" must not survive relocation', () => {
+  function emittedMarkers(req: any): any[] {
+    const out: any[] = [];
+    const visit = (blocks: unknown) => {
+      if (!Array.isArray(blocks)) return;
+      for (const b of blocks as any[]) {
+        if (b && typeof b === 'object' && b.cache_control != null) out.push(b.cache_control);
+        if (b && typeof b === 'object' && Array.isArray(b.content)) visit(b.content); // tool_result inner blocks
+      }
+    };
+    visit(req.system);
+    for (const m of req.messages ?? []) visit(m.content);
+    return out;
+  }
+
+  it('multi-page slab: relocated marker drops scope, keeps type/ttl, never adds markers', async () => {
+    const body = enc({
+      model: 'claude-3-5-sonnet',
+      system: [
+        {
+          type: 'text',
+          text: big(300_000),
+          cache_control: { type: 'ephemeral', ttl: '1h', scope: 'global' },
+        },
+      ],
+      messages: convo(15),
+    });
+    const inMarks = countCacheControlMarkers(body);
+    const { body: out } = await transformRequest(body);
+    expect(countCacheControlMarkers(out)).toBeLessThanOrEqual(inMarks);
+
+    const req = dec(out);
+    const marks = emittedMarkers(req);
+    // Pages 1..N-1 of a slab run are unmarked, so any surviving scope:"global"
+    // violates Anthropic's every-preceding-block-globally-scoped rule → 400.
+    for (const cc of marks) expect(cc.scope).toBeUndefined();
+    // The marker itself is conserved (relocated, not dropped) with type/ttl intact.
+    expect(marks.length).toBeGreaterThanOrEqual(1);
+    expect(marks).toContainEqual({ type: 'ephemeral', ttl: '1h' });
+  });
+
+  it('marker without scope passes through relocation unchanged (identity)', async () => {
+    const body = enc({
+      model: 'claude-3-5-sonnet',
+      system: [
+        { type: 'text', text: big(80_000), cache_control: { type: 'ephemeral', ttl: '1h' } },
+      ],
+      messages: convo(15),
+    });
+    const { body: out } = await transformRequest(body);
+    const marks = emittedMarkers(dec(out));
+    expect(marks).toContainEqual({ type: 'ephemeral', ttl: '1h' });
+    for (const cc of marks) expect(cc.scope).toBeUndefined();
+  });
+});


### PR DESCRIPTION
When pxpipe compresses the system slab into images, it relocates the trailing `cache_control` marker onto the last image block. The marker was copied verbatim, so Claude Code's `scope: "global"` came along with it. But `scope: "global"` is positional — valid only when every preceding block is also globally scoped — so the relocated copy broke that rule and Anthropic rejected the whole request with a 400.

All four relocation sites in `src/core/transform.ts` now emit only `type` and `ttl` when moving a marker. Markers that don't relocate pass through byte-identical, and no new markers are ever created.

Added contract tests in `tests/anthropic-cache-align.test.ts`: relocated markers lose `scope` but keep `type`/`ttl`, and markers without `scope` are unchanged. Both fail on unfixed main. Full suite passes (713/713).

Fixes #95