### PR TITLE
fix: pass native typed tools through untouched (#43)

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1807,6 +1807,15 @@ export async function transformRequest(
   if (o.compressTools && Array.isArray(req.tools) && req.tools.length > 0) {
     const docs: string[] = [];
     toolsRewritten = req.tools.map((t) => {
+      // #43: native server-side tools (versioned `type`, e.g. advisor_20260301,
+      // web_search_20250305) have a fixed API schema that rejects a `description`
+      // field on the entry ("Extra inputs are not permitted" → 400). Only
+      // client-defined tools — no `type`, or the explicit type:"custom" shape —
+      // accept description/input_schema, so everything else passes through
+      // byte-identical and stays out of the imaged reference (its docs live
+      // server-side; there is nothing to compress). Mirrors the OpenAI-path
+      // guard (openai.ts isFunctionTool).
+      if (t.type !== undefined && t.type !== 'custom') return t;
       docs.push(renderToolDoc(t));
       // tools[] keeps the annotation-STRIPPED schema: structure (type/properties/
       // required/enum/items) stays for Anthropic's tool-use validator — a bare

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -49,6 +49,10 @@ export interface Message {
 }
 
 export interface ToolDef {
+  /** Absent or "custom" = client-defined tool (description/input_schema allowed).
+   *  Any other value is a native server-side tool with a fixed API schema that
+   *  rejects extra fields — pxpipe must pass those entries through untouched (#43). */
+  type?: string;
   name: string;
   description?: string;
   input_schema?: unknown;

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -898,6 +898,73 @@ describe('transform', () => {
     expect('input_schema' in out.tools[0]).toBe(false);
   });
 
+  // #43: Anthropic's native server-side tools (versioned `type`, e.g.
+  // advisor_20260301, web_search_20250305) have a fixed API schema that rejects
+  // a `description` field on the tool entry ("Extra inputs are not permitted"
+  // → 400). Only client-defined tools (no `type`, or explicit type:"custom")
+  // may be stubbed and imaged; everything else must pass through byte-identical.
+  it('passes native typed tools through untouched and keeps them out of the imaged reference (#43)', async () => {
+    const nativeAdvisor = { type: 'advisor_20260301', name: 'advisor' };
+    const nativeSearch = { type: 'web_search_20250305', name: 'web_search', max_uses: 3 };
+    const req = JSON.stringify({
+      model: 'claude-3-5-sonnet',
+      messages: [{ role: 'user', content: 'hi' }],
+      system: 'x'.repeat(30000),
+      tools: [
+        {
+          name: 'BigTool',
+          description: 'A very long tool description. '.repeat(500),
+          input_schema: { type: 'object', properties: { x: { type: 'string' } } },
+        },
+        nativeAdvisor,
+        nativeSearch,
+      ],
+    });
+    const { body, info } = await transformRequest(new TextEncoder().encode(req));
+    expect(info.compressed).toBe(true);
+    const out = JSON.parse(new TextDecoder().decode(body));
+
+    // Client tool alongside is still compressed — the guard must not disable
+    // the rewrite for the rest of the array.
+    expect(out.tools[0].description).toContain('"## Tool: BigTool"');
+
+    // Native typed entries: byte-identical passthrough. Any injected key
+    // (description, input_schema, …) is a 400 upstream.
+    expect(out.tools[1]).toEqual(nativeAdvisor);
+    expect(out.tools[2]).toEqual(nativeSearch);
+
+    // And they contribute nothing to the imaged Tool Reference — their docs
+    // live server-side; an empty "## Tool: <name>" heading is pure noise.
+    const imgSrc = info.imageSourceText ?? '';
+    expect(imgSrc).toContain('## Tool: BigTool');
+    expect(imgSrc).not.toContain('## Tool: advisor');
+    expect(imgSrc).not.toContain('## Tool: web_search');
+  });
+
+  it('still rewrites explicit type:"custom" tools (#43 guard must not over-block)', async () => {
+    const req = JSON.stringify({
+      model: 'claude-3-5-sonnet',
+      messages: [{ role: 'user', content: 'hi' }],
+      system: 'x'.repeat(30000),
+      tools: [
+        {
+          type: 'custom',
+          name: 'CustomTool',
+          description: 'A very long tool description. '.repeat(500),
+          input_schema: { type: 'object', properties: { x: { type: 'string' } } },
+        },
+      ],
+    });
+    const { body, info } = await transformRequest(new TextEncoder().encode(req));
+    expect(info.compressed).toBe(true);
+    const out = JSON.parse(new TextDecoder().decode(body));
+    // type:"custom" is the client-defined shape — it accepts description, so it
+    // gets the same stub-and-image treatment as untyped entries.
+    expect(out.tools[0].type).toBe('custom');
+    expect(out.tools[0].description).toContain('"## Tool: CustomTool"');
+    expect(info.imageSourceText ?? '').toContain('## Tool: CustomTool');
+  });
+
   // Snapshot-style tests against real-world Claude Code tool schemas.
   // These exercise the full preservation contract of stripSchemaDescriptions —
   // now used ONLY by the GPT path (tools[] ships a stripped skeleton while the


### PR DESCRIPTION
## Problem
Native server-side tools (`advisor_20260301`, `web_search_20250305`, etc.) were run through the same rewrite map as client tools, which injected a `description: "ⓘ Full docs: …"` field and added them to the imaged Tool Reference. Anthropic rejects unknown fields on native typed tool schemas → 400 `Extra inputs are not permitted`.

## Fix
Early-return guard in the rewrite map: any tool with `type` set and `!== "custom"` passes through byte-identical and is excluded from the imaged reference. Mirrors the existing OpenAI-path `isFunctionTool` guard.

- `src/core/transform.ts` +9 — the guard
- `src/core/types.ts` +4 — model `ToolDef.type?: string`
- `tests/render.test.ts` +67 — (1) native typed tools byte-identical + excluded from imaged ref while client tools alongside still compress; (2) explicit `type:"custom"` still rewritten (no over-blocking)

## Verification
- New contract test fails on unfixed main with exactly the injected-description diff
- After fix: clean passthrough; client tool alongside still compresses (`toolDocsChars: 15084`)
- Full suite **715/715**, `tsc --noEmit` clean

Fixes #43