### PR TITLE
fix(logs): tag skip reasons as savings:skip(...) (#114) (#115)

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -1043,7 +1043,9 @@ async function main(): Promise<void> {
       const extraTag = extra.length > 0 ? ` (${extra.join(' ')})` : '';
       const tag = e.info?.compressed
         ? `compressed ${e.info.origChars}ch → ${e.info.imageCount}img/${e.info.imageBytes}B${extraTag}`
-        : (e.info?.reason ?? '');
+        : e.info?.reason
+          ? `savings:skip(${e.info.reason})`
+          : '';
       const cacheRead = e.usage?.cache_read_input_tokens ?? 0;
       const inputTokens = e.usage?.input_tokens ?? 0;
       const usageTag =

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -148,7 +148,9 @@ export default {
         // shows up in `wrangler tail`).
         const tag = e.info?.compressed
           ? `compressed ${e.info.origChars}ch → ${e.info.imageCount}img/${e.info.imageBytes}B`
-          : (e.info?.reason ?? '');
+          : e.info?.reason
+            ? `savings:skip(${e.info.reason})`
+            : '';
         const cacheRead = e.usage?.cache_read_input_tokens ?? 0;
         console.log(`${e.method} ${e.path} → ${e.status} (${e.durationMs}ms) ${tag} cache_read=${cacheRead}`);
 


### PR DESCRIPTION
Log-only change, no behavior change.
The skip reason was printed bare next to the HTTP status, so users read it as the error cause (#114, #115).

**Before** (looks like pxpipe rejected the model):

    POST /v1/messages → 429 (755ms) unsupported_model cache_read=0

**After** (clearly just a compression-scope note):

    POST /v1/messages → 429 (755ms) savings:skip(unsupported_model) cache_read=0

`unsupported_model` here only means the request's model is outside the `PXPIPE_MODELS` savings scope (default: Fable 5 only), so pxpipe skipped compression and passed the request through to Anthropic untouched.

The 429/529 response bodies reported in the issues are verbatim Anthropic upstream errors, pxpipe does not generate them.

Applied to both log paths (`src/node.ts`, `src/worker.ts`).
Successful compressions still log `compressed 30761ch → 4img/98060B` as before.

Fixes #114
Fixes #115