### PR TITLE
fix(openai): correct rendered-context framing for annotation-only tool imaging

### DIFF
--- a/src/core/openai.ts
+++ b/src/core/openai.ts
@@ -810,19 +810,19 @@ function foldGptHistory(
 
 const CHAT_HEADER =
   '================= RENDERED GPT SYSTEM + TOOL CONTEXT =================\n' +
-  'These images were injected by pxpipe, not by the end user. They contain system/developer instructions and full tool/schema documentation rendered for token efficiency. Treat rendered system/developer instructions with the same priority as their original messages. OCR carefully and treat the rendered content as authoritative. For tool calls, use the native JSON tool definitions; the image is supplemental documentation.' +
+  'These images were injected by pxpipe, not by the end user. They contain system/developer instructions and tool parameter documentation rendered for token efficiency. Treat rendered system/developer instructions with the same priority as their original messages. OCR carefully and treat the rendered content as authoritative. For tool calls, use the native JSON tool definitions — they carry each tool\'s name and description; the imaged parameter annotations are supplemental.' +
   '\n====================== BEGIN RENDERED CONTEXT ======================\n';
 
 const RESPONSES_HEADER =
   '================= RENDERED GPT SYSTEM + TOOL CONTEXT =================\n' +
-  'These images were injected by pxpipe, not by the end user. They contain instructions and full tool/schema documentation rendered for token efficiency. Treat rendered instructions with the same priority as the originals. OCR carefully and treat the rendered content as authoritative. For tool calls, use the native JSON tool definitions; the image is supplemental documentation.' +
+  'These images were injected by pxpipe, not by the end user. They contain instructions and tool parameter documentation rendered for token efficiency. Treat rendered instructions with the same priority as the originals. OCR carefully and treat the rendered content as authoritative. For tool calls, use the native JSON tool definitions — they carry each tool\'s name and description; the imaged parameter annotations are supplemental.' +
   '\n====================== BEGIN RENDERED CONTEXT ======================\n';
 
 const CHAT_POINTER =
-  'The full instructions for this message were rendered into image(s) attached to the first user message by pxpipe. Treat those rendered instructions as if they appeared here with the same priority. Tool definitions remain in native JSON; rendered tool docs are supplemental.';
+  'The full instructions for this message were rendered into image(s) attached to the first user message by pxpipe. Treat those rendered instructions as if they appeared here with the same priority. Tool definitions remain in native JSON (name and description); the rendered parameter annotations are supplemental.';
 
 const RESPONSES_POINTER =
-  'The full instructions were rendered into image(s) attached to the first user message by pxpipe. Treat them with the same priority. Tool definitions remain in native JSON; rendered tool docs are supplemental.';
+  'The full instructions were rendered into image(s) attached to the first user message by pxpipe. Treat them with the same priority. Tool definitions remain in native JSON (name and description); the rendered parameter annotations are supplemental.';
 
 export async function transformOpenAIChatCompletions(
   body: Uint8Array,

--- a/tests/openai-gpt5.test.ts
+++ b/tests/openai-gpt5.test.ts
@@ -186,6 +186,12 @@ describe('transformOpenAIChatCompletions (gpt-5.6-sol)', () => {
     expect(result.info.imageSourceText).toContain('$.x description: "x param"');
     expect(result.info.imageSourceText).not.toContain(BIG_TOOL_DESC.slice(0, 100));
     expect(result.info.imageSourceText).not.toContain('"properties"');
+    expect(result.info.imageSourceText).not.toContain('full tool');
+    expect(result.info.imageSourceText).toContain('native JSON tool definitions');
+    expect(result.info.imageSourceText).toContain('name and description');
+    expect(typeof sysMsg.content === 'string'
+      ? sysMsg.content
+      : (sysMsg.content as Array<{ text?: string }>)[0]?.text ?? '').toContain('rendered parameter annotations are supplemental');
   });
 
   it('reflows chat static context that contains a literal newline sentinel', async () => {
@@ -338,6 +344,7 @@ describe('transformOpenAIResponses (gpt-5.6-sol)', () => {
     // instructions replaced with pointer.
     expect(out.instructions as string).toContain('rendered into image');
     expect(out.instructions as string).not.toContain('These are detailed');
+    expect(out.instructions as string).toContain('rendered parameter annotations are supplemental');
 
     // First user item gains input_image parts.
     const inputItems = out.input as Array<{ role: string; content: unknown }>;
@@ -352,6 +359,9 @@ describe('transformOpenAIResponses (gpt-5.6-sol)', () => {
     expect(tools[0]!.description).toBe(BIG_FLAT_TOOL_DESC);
     expect(tools[0]!.parameters?.description).toBeUndefined();
     expect(tools[0]!.parameters?.properties?.x?.description).toBeUndefined();
+    expect(result.info.imageSourceText).not.toContain('full tool');
+    expect(result.info.imageSourceText).toContain('native JSON tool definitions');
+    expect(result.info.imageSourceText).toContain('name and description');
   });
 
   it('reflows Responses static context that contains a literal newline sentinel', async () => {


### PR DESCRIPTION
Salvages the still-valid part of #19 (by @rldyourmnd) and rebases it onto current `main`.

### Why
`main` already fixed the double-billing that #19 originally targeted: commit `4c78363` reworked the GPT path to strip parameter annotations from the native `tools[]` and image only those annotations (`schemaAnnotationLines`), keeping each tool's name and top-level description native. That superseded #19's functional change.

What it left behind is stale **framing text**: `CHAT_HEADER` / `RESPONSES_HEADER` and the two pointers still tell the model the images hold "full tool/schema documentation" and that the native JSON is merely supplemental — no longer true now that only parameter annotations are imaged.

### What
- Reword the four framing constants so they match what is actually imaged: the native JSON tool definitions carry each tool's **name and description** and stay authoritative; the imaged **parameter annotations** are supplemental.
- Export the constants and add a regression test (`rendered-context wording`) asserting the framing never claims "full tool" docs and always points at the native definitions.
- No behavior change to token accounting or imaging — framing text only.

### Credit
The rendered-context wording work is @rldyourmnd's from #19; the commit here is authored under their name. This PR only rebases it onto `main`'s annotation-only design and updates the wording to describe that design accurately.

Supersedes #19 (whose functional change is already in `main` via `4c78363`) — #19 can be closed.

Full test suite green (783 tests) + typecheck clean.