### PR TITLE
fix(responses-bridge): treat empty tool-call arguments as {} instead of crashing

### DIFF
--- a/src/core/messages-responses-bridge.ts
+++ b/src/core/messages-responses-bridge.ts
@@ -200,7 +200,11 @@ function anthropicUsage(raw: unknown): JsonObject {
 }
 
 function parseArguments(value: unknown): unknown {
-  if (typeof value !== 'string') return {};
+  // Empty string = a no-argument tool call; treat as {} rather than throwing.
+  // Mirrors the Chat bridge (messages-chat-bridge.ts) and the streaming path,
+  // which both yield input:{} for empty args. Without this, JSON.parse('')
+  // throws and fails the whole turn on a benign no-arg tool call.
+  if (typeof value !== 'string' || value.trim() === '') return {};
   try { return JSON.parse(value); } catch {
     throw new Error('OpenAI returned malformed function-call arguments');
   }

--- a/tests/responses-bridge-roles.test.ts
+++ b/tests/responses-bridge-roles.test.ts
@@ -8,7 +8,10 @@
  * Run just this file:  pnpm vitest run tests/responses-bridge-roles.test.ts
  */
 import { describe, expect, it } from 'vitest';
-import { anthropicMessagesToOpenAIResponses } from '../src/core/messages-responses-bridge.js';
+import {
+  anthropicMessagesToOpenAIResponses,
+  openAIResponseToAnthropicMessage,
+} from '../src/core/messages-responses-bridge.js';
 
 const enc = (obj: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(obj));
 const dec = (b: Uint8Array): any => JSON.parse(new TextDecoder().decode(b));
@@ -61,5 +64,21 @@ describe('anthropicMessagesToOpenAIResponses — message roles', () => {
     expect(() =>
       toResponses({ model: 'm', messages: [{ role: 'tool', content: 'x' }] }),
     ).toThrow(/user, assistant, or system role/);
+  });
+});
+
+describe('openAIResponseToAnthropicMessage — function-call arguments', () => {
+  it('treats an empty arguments string as {} instead of throwing', () => {
+    // A no-arg tool call can arrive as arguments:"" — JSON.parse('') would
+    // throw and fail the whole turn. Must degrade to empty input.
+    const msg = openAIResponseToAnthropicMessage(
+      { id: 'resp_1', model: 'gpt', output: [
+        { type: 'function_call', call_id: 'c1', name: 'now', arguments: '' },
+      ] },
+      'fallback',
+    );
+    const toolUse = (msg.content as any[]).find((b) => b.type === 'tool_use');
+    expect(toolUse).toMatchObject({ type: 'tool_use', id: 'c1', name: 'now', input: {} });
+    expect(msg.stop_reason).toBe('tool_use');
   });
 });


### PR DESCRIPTION
### Problem
On the non-streaming Responses to Messages conversion (`openAIResponseToAnthropicMessage`), a `function_call` with `arguments: ""` (what some models emit for a no-argument tool call) reaches `JSON.parse("")`, which throws. The error propagates out and fails the whole turn.

This is inconsistent with two sibling paths that handle it fine:
- The Chat bridge guards it explicitly (`value.trim() === '' -> return {}`, `messages-chat-bridge.ts`).
- The Responses **streaming** path already yields `input: {}` for empty args.

### Fix
Mirror the Chat bridge's guard in the Responses `parseArguments`: empty/blank string maps to `{}`. Added a regression test (the non-streaming converter had no direct coverage).

Full suite passes (807/807); `typecheck` clean.

Generated with [Claude Code](https://claude.com/claude-code)
