### PR TITLE
Compress completed tool-call rounds across Gemini, GPT, and OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ without running the proxy.
   inherit Sol's allowlist or render profile. `PXPIPE_MODELS=off` disables
   imaging. Everything else passes through byte-identical. On the GPT path,
   tool definitions stay native JSON and no Anthropic `cache_control`
-  markers are used. Responses history compression recognizes adjacent completed
-  `function_call`/`function_call_output` pairs: only old closed pairs are imaged;
+  markers are used. Responses history compression recognizes completed
+  `function_call`/`function_call_output` pairs, including OpenCode's parallel
+  calls-then-outputs rounds: only old closed rounds are imaged atomically;
   the newest six completed pairs, every open call, and malformed/orphan state
   remain native. The default history budget is 32 images; opt-in long-session
   coverage can be raised (defensive cap 100) with

--- a/src/core/google.ts
+++ b/src/core/google.ts
@@ -5,18 +5,41 @@
  * passes transformed payloads to Google AI Studio.
  */
 
-import { renderTextToPngs, shrinkColsToContent } from './render.js';
+import {
+  neutralizeSentinel,
+  reflow,
+  renderTextToPngs,
+  shrinkColsToContent,
+  type RenderedImage,
+} from './render.js';
 import { geminiVisionTokens, resolveGeminiProfile } from './gemini-model-profiles.js';
 import { bytesToBase64 } from './png.js';
-import { compactSlabWhitespace, type TransformInfo } from './transform.js';
-import { prepareImagedRenderText, CHAT_HEADER } from './openai.js';
+import { classifyContent, compactSlabWhitespace, type TransformInfo } from './transform.js';
+import {
+  prepareImagedRenderText,
+  CHAT_HEADER,
+  HISTORY_TRANSCRIPT_INTRO,
+  HISTORY_TRANSCRIPT_OUTRO,
+} from './openai.js';
 import { factSheetText } from './factsheet.js';
+import { stripSchemaDescriptions } from './schema-strip.js';
 
 export interface GooglePart {
   text?: string;
   inlineData?: {
     mimeType: string;
     data: string;
+  };
+  functionCall?: {
+    name?: string;
+    args?: unknown;
+    [key: string]: unknown;
+  };
+  functionResponse?: {
+    name?: string;
+    response?: unknown;
+    parts?: GooglePart[];
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -49,10 +72,443 @@ const SYSTEM_POINTER =
   'The original system instruction is rendered in the image at the start of the first user turn. ' +
   'Treat that image as this system instruction, with the same authority and priority.';
 
+const TOOL_POINTER_PREFIX = 'Full parameter docs: see "## Tool: ';
+
+interface GoogleFunctionDeclaration extends Record<string, unknown> {
+  name?: string;
+  description?: string;
+  parameters?: unknown;
+}
+
+interface GoogleToolRewrite {
+  tools: unknown[] | undefined;
+  docs: string;
+  originalTokens: number;
+  rewrittenTokens: number;
+}
+
+interface GoogleHistoryUnit {
+  index: number;
+  text: string;
+  baselineTokens: number;
+  source: GoogleContent;
+  opens: string[];
+  closes: string[];
+  opaque: boolean;
+}
+
+interface GoogleHistoryPlan {
+  start: number;
+  endExclusive: number;
+  images: RenderedImage[];
+  imageSources: string[];
+  text: string;
+  baselineTokens: number;
+  collapsedTurns: number;
+  droppedChars: number;
+  droppedCodepoints: Map<number, number>;
+}
+
+interface GoogleToolResultPlan {
+  contents: GoogleContent[];
+  images: RenderedImage[];
+  imageSources: string[];
+  baselineTokens: number;
+  nativeTokens: number;
+  compressedChars: number;
+  bucketChars: Partial<Record<'tool_result_json' | 'tool_result_log' | 'tool_result_prose', number>>;
+  droppedChars: number;
+  droppedCodepoints: Map<number, number>;
+}
+
 function record(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return String(value ?? '');
+  }
+}
+
+function googleTextTokens(text: string): number {
+  return text ? Math.ceil(text.length / 3.5) : 0;
+}
+
+function schemaAnnotationLines(node: unknown, path = '$', depth = 0): string[] {
+  if (!node || typeof node !== 'object' || depth > 20) return [];
+  if (Array.isArray(node)) {
+    return node.flatMap((value, i) => schemaAnnotationLines(value, `${path}[${i}]`, depth + 1));
+  }
+  const obj = node as Record<string, unknown>;
+  const out: string[] = [];
+  for (const key of ['description', 'title', 'examples', 'default', '$comment']) {
+    if (obj[key] !== undefined) out.push(`${path} ${key}: ${safeJson(obj[key])}`);
+  }
+  if (typeof obj.format === 'string' && obj.format.length > 32) {
+    out.push(`${path} format: ${safeJson(obj.format)}`);
+  }
+  for (const key of ['properties', 'patternProperties', 'definitions', '$defs']) {
+    const children = obj[key];
+    if (!children || typeof children !== 'object' || Array.isArray(children)) continue;
+    for (const [name, child] of Object.entries(children as Record<string, unknown>)) {
+      out.push(...schemaAnnotationLines(child, `${path}.${name}`, depth + 1));
+    }
+  }
+  for (const key of ['oneOf', 'anyOf', 'allOf']) {
+    const children = obj[key];
+    if (!Array.isArray(children)) continue;
+    children.forEach((child, i) => {
+      out.push(...schemaAnnotationLines(child, `${path}.${key}[${i}]`, depth + 1));
+    });
+  }
+  for (const key of [
+    'items', 'additionalProperties', 'not', 'contains', 'propertyNames',
+    'unevaluatedItems', 'unevaluatedProperties', 'if', 'then', 'else',
+  ]) {
+    if (obj[key] !== undefined) {
+      out.push(...schemaAnnotationLines(obj[key], `${path}.${key}`, depth + 1));
+    }
+  }
+  return out;
+}
+
+function rewriteGoogleTools(tools: unknown[] | undefined): GoogleToolRewrite {
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return { tools, docs: '', originalTokens: 0, rewrittenTokens: 0 };
+  }
+  const originalTokens = googleTextTokens(safeJson(tools));
+  const docs: string[] = [];
+  let changed = false;
+  const rewritten = tools.map((rawTool) => {
+    const tool = record(rawTool);
+    if (!tool || !Array.isArray(tool.functionDeclarations)) return rawTool;
+    let toolChanged = false;
+    const declarations = tool.functionDeclarations.map((rawDeclaration) => {
+      const declaration = record(rawDeclaration) as GoogleFunctionDeclaration | null;
+      if (!declaration || typeof declaration.name !== 'string') return rawDeclaration;
+      const annotations = schemaAnnotationLines(declaration.parameters);
+      const description = typeof declaration.description === 'string'
+        ? declaration.description
+        : '';
+      if (!description && annotations.length === 0) return rawDeclaration;
+      docs.push([
+        `## Tool: ${declaration.name}`,
+        description,
+        declaration.parameters === undefined
+          ? ''
+          : `\`\`\`json\n${safeJson(declaration.parameters)}\n\`\`\``,
+      ].filter(Boolean).join('\n'));
+      toolChanged = true;
+      return {
+        ...declaration,
+        description: `${TOOL_POINTER_PREFIX}${declaration.name}" in the rendered context image.`,
+        parameters: stripSchemaDescriptions(declaration.parameters),
+      };
+    });
+    if (!toolChanged) return rawTool;
+    changed = true;
+    return { ...tool, functionDeclarations: declarations };
+  });
+  const toolsOut = changed ? rewritten : tools;
+  return {
+    tools: toolsOut,
+    docs: docs.join('\n\n'),
+    originalTokens,
+    rewrittenTokens: googleTextTokens(safeJson(toolsOut)),
+  };
+}
+
+function googlePartText(part: GooglePart): string {
+  if (typeof part.text === 'string') return part.text;
+  if (part.functionCall) {
+    return `[tool_use ${part.functionCall.name ?? 'tool'}]\n${safeJson(part.functionCall.args ?? {})}`;
+  }
+  if (part.functionResponse) {
+    return `[tool_result ${part.functionResponse.name ?? 'tool'}]\n${safeJson(part.functionResponse.response ?? {})}`;
+  }
+  return '';
+}
+
+function googleHistoryUnit(content: GoogleContent, index: number): GoogleHistoryUnit {
+  if (!Array.isArray(content.parts)) {
+    return { index, text: '', baselineTokens: 0, source: content, opens: [], closes: [], opaque: true };
+  }
+  const text: string[] = [];
+  const opens: string[] = [];
+  const closes: string[] = [];
+  let opaque = false;
+  for (const rawPart of content.parts) {
+    const part = record(rawPart) as GooglePart | null;
+    if (!part) { opaque = true; continue; }
+    if (typeof part.text === 'string') {
+      text.push(part.text);
+      continue;
+    }
+    if (part.functionCall) {
+      const name = typeof part.functionCall.name === 'string' ? part.functionCall.name : 'tool';
+      opens.push(name);
+      text.push(googlePartText(part));
+      continue;
+    }
+    if (part.functionResponse) {
+      if (Array.isArray(part.functionResponse.parts) && part.functionResponse.parts.length > 0) {
+        opaque = true;
+      }
+      const name = typeof part.functionResponse.name === 'string' ? part.functionResponse.name : 'tool';
+      closes.push(name);
+      text.push(googlePartText(part));
+      continue;
+    }
+    // Thought signatures, images, server tool state, and unknown parts must stay native.
+    opaque = true;
+  }
+  const role = content.role === 'model' ? 'assistant' : 'user';
+  const body = text.filter(Boolean).join('\n\n');
+  const transcript = body ? `<${role} t="${index}">\n${body}\n</${role}>` : '';
+  return {
+    index,
+    text: transcript,
+    baselineTokens: googleTextTokens(body),
+    source: content,
+    opens,
+    closes,
+    opaque,
+  };
+}
+
+async function compressGoogleToolResults(
+  contents: GoogleContent[],
+  modelName: string,
+  options: {
+    compressToolResults?: boolean;
+    minToolResultChars?: number;
+    maxImagesPerToolResult?: number;
+    reflow?: boolean;
+  },
+): Promise<GoogleToolResultPlan> {
+  const empty = (): GoogleToolResultPlan => ({
+    contents,
+    images: [],
+    imageSources: [],
+    baselineTokens: 0,
+    nativeTokens: 0,
+    compressedChars: 0,
+    bucketChars: {},
+    droppedChars: 0,
+    droppedCodepoints: new Map(),
+  });
+  if (options.compressToolResults === false) return empty();
+
+  const profile = resolveGeminiProfile();
+  const minChars = Math.max(0, options.minToolResultChars ?? 6000);
+  const perResultCap = Math.max(1, options.maxImagesPerToolResult ?? 10);
+  const allImages: RenderedImage[] = [];
+  const imageSources: string[] = [];
+  const bucketChars: GoogleToolResultPlan['bucketChars'] = {};
+  const droppedCodepoints = new Map<number, number>();
+  let baselineTokens = 0;
+  let nativeTokens = 0;
+  let compressedChars = 0;
+  let droppedChars = 0;
+  let changed = false;
+
+  const rewrittenContents: GoogleContent[] = [];
+  for (const content of contents) {
+    if (!Array.isArray(content.parts)) {
+      rewrittenContents.push(content);
+      continue;
+    }
+    let contentChanged = false;
+    const rewrittenParts: GooglePart[] = [];
+    for (const rawPart of content.parts) {
+      const part = record(rawPart) as GooglePart | null;
+      const response = part?.functionResponse;
+      const responseBody = record(response?.response);
+      const raw = typeof responseBody?.content === 'string' ? responseBody.content : '';
+      if (
+        !part || !response || !responseBody || raw.length < minChars ||
+        (Array.isArray(response.parts) && response.parts.length > 0)
+      ) {
+        rewrittenParts.push(rawPart);
+        continue;
+      }
+
+      const name = typeof response.name === 'string' ? response.name : 'tool';
+      const compact = compactSlabWhitespace(raw);
+      const safe = neutralizeSentinel(compact);
+      const packed = options.reflow !== false ? reflow(safe) ?? safe : safe;
+      const rendered = prepareImagedRenderText(
+        `================= RENDERED TOOL RESULT: ${name} =================\n` +
+        'pxpipe rendered this completed tool result into image pages to reduce input tokens. Read it as the exact result returned by the tool.\n' +
+        packed,
+        false,
+      );
+      const images = await renderTextToPngs(
+        rendered,
+        profile.stripCols,
+        profile.style,
+        profile.maxHeightPx,
+      );
+      if (images.length === 0 || images.length > perResultCap) {
+        rewrittenParts.push(rawPart);
+        continue;
+      }
+      const imageTokens = images.reduce(
+        (sum, image) => sum + geminiVisionTokens(modelName, image.width, image.height),
+        0,
+      );
+      const sheet = factSheetText(raw, profile.factSheetFormat);
+      const pointer = `The completed ${name} tool result is rendered in the attached image part(s).` +
+        (sheet ? `\n${sheet}` : '');
+      const textTokens = googleTextTokens(raw);
+      const pointerTokens = googleTextTokens(pointer);
+      if (imageTokens + pointerTokens >= textTokens) {
+        rewrittenParts.push(rawPart);
+        continue;
+      }
+
+      rewrittenParts.push({
+        ...part,
+        functionResponse: {
+          ...response,
+          response: { ...responseBody, content: pointer },
+          parts: images.map(imagePart),
+        },
+      });
+      contentChanged = true;
+      changed = true;
+      allImages.push(...images);
+      imageSources.push(...images.map(() => raw));
+      baselineTokens += textTokens;
+      nativeTokens += pointerTokens;
+      compressedChars += raw.length;
+      const shape = classifyContent(compact);
+      const bucket = shape === 'structured'
+        ? 'tool_result_json'
+        : shape === 'log' ? 'tool_result_log' : 'tool_result_prose';
+      bucketChars[bucket] = (bucketChars[bucket] ?? 0) + raw.length;
+      for (const image of images) {
+        droppedChars += image.droppedChars;
+        for (const [codepoint, count] of image.droppedCodepoints) {
+          droppedCodepoints.set(codepoint, (droppedCodepoints.get(codepoint) ?? 0) + count);
+        }
+      }
+    }
+    rewrittenContents.push(contentChanged ? { ...content, parts: rewrittenParts } : content);
+  }
+
+  return {
+    contents: changed ? rewrittenContents : contents,
+    images: allImages,
+    imageSources,
+    baselineTokens,
+    nativeTokens,
+    compressedChars,
+    bucketChars,
+    droppedChars,
+    droppedCodepoints,
+  };
+}
+
+function googleClosedBoundary(
+  units: GoogleHistoryUnit[],
+  fromInclusive: number,
+  cutoffExclusive: number,
+): number {
+  const open = new Map<string, number>();
+  let lastClosed = fromInclusive - 1;
+  for (let i = fromInclusive; i < Math.min(cutoffExclusive, units.length); i++) {
+    const unit = units[i]!;
+    if (unit.opaque) break;
+    for (const name of unit.opens) open.set(name, (open.get(name) ?? 0) + 1);
+    for (const name of unit.closes) {
+      const count = open.get(name) ?? 0;
+      // An output whose call sits before the selected range is a protocol barrier.
+      if (count === 0) return lastClosed;
+      if (count === 1) open.delete(name);
+      else open.set(name, count - 1);
+    }
+    if (open.size === 0) lastClosed = i;
+  }
+  return lastClosed;
+}
+
+async function planGoogleHistory(
+  contents: GoogleContent[],
+  modelName: string,
+  reflowEnabled: boolean,
+): Promise<GoogleHistoryPlan | null> {
+  const profile = resolveGeminiProfile();
+  const units = contents.map(googleHistoryUnit);
+  const cutoff = Math.max(0, units.length - profile.history.keepTail);
+  // In autonomous OpenCode turns the user's live task can be the oldest item,
+  // followed by a long tool loop. Keep that request native instead of making it OCR-only.
+  let latestPlainUser = -1;
+  for (let i = units.length - 1; i >= 0; i--) {
+    const content = contents[i]!;
+    if (content.role !== 'user' || !Array.isArray(content.parts)) continue;
+    if (content.parts.some((part) => typeof part.text === 'string' && part.text.trim())) {
+      latestPlainUser = i;
+      break;
+    }
+  }
+  const start = latestPlainUser >= 0 && latestPlainUser < cutoff
+    ? latestPlainUser + 1
+    : 0;
+  const boundary = googleClosedBoundary(units, start, cutoff);
+  if (boundary < start || boundary + 1 - start < 10) return null;
+  const selected = units.slice(start, boundary + 1);
+  const text = selected.map((unit) => unit.text).filter(Boolean).join('\n\n');
+  const baselineTokens = selected.reduce((sum, unit) => sum + unit.baselineTokens, 0);
+  if (!text || baselineTokens < profile.history.minCollapseTokens) return null;
+  const safe = neutralizeSentinel(text);
+  const renderedText = reflowEnabled ? reflow(safe) ?? safe : safe;
+  const images = await renderTextToPngs(
+    renderedText,
+    profile.stripCols,
+    profile.style,
+    profile.maxHeightPx,
+  );
+  if (images.length === 0 || images.length > profile.history.maxImages) return null;
+  const imageTokens = images.reduce(
+    (sum, image) => sum + geminiVisionTokens(modelName, image.width, image.height),
+    0,
+  );
+  const framingTokens = googleTextTokens(HISTORY_TRANSCRIPT_INTRO + HISTORY_TRANSCRIPT_OUTRO);
+  if (imageTokens + framingTokens >= baselineTokens) return null;
+  const droppedCodepoints = new Map<number, number>();
+  let droppedChars = 0;
+  for (const image of images) {
+    droppedChars += image.droppedChars;
+    for (const [codepoint, count] of image.droppedCodepoints) {
+      droppedCodepoints.set(codepoint, (droppedCodepoints.get(codepoint) ?? 0) + count);
+    }
+  }
+  return {
+    start,
+    endExclusive: boundary + 1,
+    images,
+    imageSources: images.map(() => text),
+    text,
+    baselineTokens,
+    collapsedTurns: boundary + 1 - start,
+    droppedChars,
+    droppedCodepoints,
+  };
+}
+
+function imagePart(image: RenderedImage): GooglePart {
+  return {
+    inlineData: {
+      mimeType: 'image/png',
+      data: bytesToBase64(image.png),
+    },
+  };
 }
 
 export async function transformGoogleGenerateContent(
@@ -60,6 +516,11 @@ export async function transformGoogleGenerateContent(
   modelName: string,
   options: {
     compress?: boolean;
+    compressTools?: boolean;
+    compressToolResults?: boolean;
+    collapseHistory?: boolean;
+    minToolResultChars?: number;
+    maxImagesPerToolResult?: number;
     cols?: number;
     reflow?: boolean;
   } = {},
@@ -99,7 +560,17 @@ export async function transformGoogleGenerateContent(
     }
   }
 
-  const combinedRaw = systemTexts.join('\n\n');
+  const toolRewrite = options.compressTools === false
+    ? {
+        tools: req.tools,
+        docs: '',
+        originalTokens: googleTextTokens(safeJson(req.tools ?? [])),
+        rewrittenTokens: googleTextTokens(safeJson(req.tools ?? [])),
+      }
+    : rewriteGoogleTools(req.tools);
+  if (toolRewrite.docs) info.toolDocsChars = toolRewrite.docs.length;
+  const authorityText = systemTexts.join('\n\n');
+  const combinedRaw = [authorityText, toolRewrite.docs].filter(Boolean).join('\n\n');
   info.origChars = combinedRaw.length;
   if (!combinedRaw) {
     info.reason = 'no_static_context';
@@ -125,7 +596,11 @@ export async function transformGoogleGenerateContent(
     (total, image) => total + geminiVisionTokens(modelName, image.width, image.height),
     0,
   );
-  const textTokens = Math.max(1, Math.ceil(combinedRaw.length / 3.5));
+  const textTokens = Math.max(
+    1,
+    googleTextTokens(authorityText)
+      + Math.max(0, toolRewrite.originalTokens - toolRewrite.rewrittenTokens),
+  );
   const fsText = factSheetText(combinedRaw, profile.factSheetFormat);
   const nativeText = SYSTEM_POINTER + (fsText ?? '');
   const nativeInjectedTokens = Math.ceil(nativeText.length / 3.5);
@@ -136,31 +611,68 @@ export async function transformGoogleGenerateContent(
     textTokens,
     burnImageSide: nativeInjectedTokens,
     burnTextSide: 0,
-    profitable: true,
+    profitable: imageTokens + nativeInjectedTokens < textTokens,
   };
+  if (!info.gateEval.profitable) {
+    info.reason = 'not_profitable';
+    return { body: bodyBytes, info };
+  }
 
   // Build image parts
-  const imageParts: GooglePart[] = images.map((img) => ({
-    inlineData: {
-      mimeType: 'image/png',
-      data: bytesToBase64(img.png),
-    },
-  }));
+  const imageParts: GooglePart[] = images.map(imagePart);
 
   if (fsText) {
     imageParts.push({ text: fsText });
   }
 
-  // Prepare transformed request
+  // Prepare transformed request. Plan history against the ORIGINAL contents;
+  // inserting the slab image first would make content[0] an opaque image barrier.
   if (req.contents !== undefined && !Array.isArray(req.contents)) {
     return { body: bodyBytes, info: createDefaultInfo(modelName) };
   }
-  const contents = Array.isArray(req.contents) ? [...req.contents] : [];
-  if (contents.length > 0 && contents[0] && contents[0].role === 'user') {
-    const firstTurn = contents[0];
-    if (firstTurn.parts !== undefined && !Array.isArray(firstTurn.parts)) {
+  const originalContents = Array.isArray(req.contents) ? [...req.contents] : [];
+  for (const content of originalContents) {
+    if (!record(content) || (content.parts !== undefined && !Array.isArray(content.parts))) {
       return { body: bodyBytes, info: createDefaultInfo(modelName) };
     }
+  }
+
+  const historyPlan = options.collapseHistory === false
+    ? null
+    : await planGoogleHistory(originalContents, modelName, options.reflow !== false);
+  let contents = originalContents;
+  if (historyPlan) {
+    const historyParts: GooglePart[] = [
+      { text: HISTORY_TRANSCRIPT_INTRO },
+      ...historyPlan.images.map(imagePart),
+    ];
+    const historySheet = factSheetText(historyPlan.text, profile.factSheetFormat);
+    if (historySheet) historyParts.push({ text: historySheet });
+    historyParts.push({ text: HISTORY_TRANSCRIPT_OUTRO });
+    if (historyPlan.start > 0 && contents[historyPlan.start - 1]?.role === 'user') {
+      // Keep Gemini's alternating role shape: append the synthetic prior-context
+      // parts to the preceding live user turn rather than emitting user→user.
+      const carrier = contents[historyPlan.start - 1]!;
+      contents = [
+        ...contents.slice(0, historyPlan.start - 1),
+        { ...carrier, parts: [...(carrier.parts ?? []), ...historyParts] },
+        ...contents.slice(historyPlan.endExclusive),
+      ];
+    } else {
+      contents = [
+        ...contents.slice(0, historyPlan.start),
+        { role: 'user', parts: historyParts },
+        ...contents.slice(historyPlan.endExclusive),
+      ];
+    }
+  }
+
+  const toolResultPlan = await compressGoogleToolResults(contents, modelName, options);
+  contents = toolResultPlan.contents;
+
+  // Static context goes first in the first user turn, matching the Anthropic path.
+  if (contents.length > 0 && contents[0] && contents[0].role === 'user') {
+    const firstTurn = contents[0];
     contents[0] = {
       ...firstTurn,
       parts: [...imageParts, ...(firstTurn.parts || [])],
@@ -177,6 +689,7 @@ export async function transformGoogleGenerateContent(
   const transformedReq: GoogleGenerateContentRequest = {
     ...req,
     contents,
+    ...(toolRewrite.tools !== undefined ? { tools: toolRewrite.tools } : {}),
     systemInstruction: {
       ...req.systemInstruction,
       parts: [{ text: SYSTEM_POINTER }],
@@ -189,6 +702,76 @@ export async function transformGoogleGenerateContent(
   info.imageTokens = imageTokens;
   info.baselineImagedTokens = textTokens;
   info.nativeInjectedTokens = nativeInjectedTokens;
+  info.compressedChars = combinedRaw.length;
+  info.bucketChars = { static_slab: combinedRaw.length };
+  info.firstImagePng = images[0]?.png;
+  info.firstImageWidth = images[0]?.width;
+  info.firstImageHeight = images[0]?.height;
+  info.imagePngs = images.map((image) => image.png);
+  info.imageDims = images.map((image) => ({ width: image.width, height: image.height }));
+  info.imageSourceText = renderedText.slice(0, 65_536);
+  // Google renders a single combined text slab into page images; share source text across pages.
+  info.imageSourceTexts = images.map(() => info.imageSourceText);
+
+  if (historyPlan) {
+      const historySheet = factSheetText(historyPlan.text, profile.factSheetFormat);
+      const historyImageTokens = historyPlan.images.reduce(
+        (sum, image) => sum + geminiVisionTokens(modelName, image.width, image.height),
+        0,
+      );
+      info.imageTokens += historyImageTokens;
+      info.baselineImagedTokens += historyPlan.baselineTokens;
+      info.nativeInjectedTokens += googleTextTokens(
+        HISTORY_TRANSCRIPT_INTRO + historySheet + HISTORY_TRANSCRIPT_OUTRO,
+      );
+      info.imageCount += historyPlan.images.length;
+      info.imageBytes += historyPlan.images.reduce((sum, image) => sum + image.png.byteLength, 0);
+      info.imagePngs.push(...historyPlan.images.map((image) => image.png));
+      info.imageDims.push(...historyPlan.images.map((image) => ({ width: image.width, height: image.height })));
+      info.imageSourceTexts.push(...historyPlan.imageSources);
+      info.compressedChars += historyPlan.text.length;
+      info.bucketChars = { ...info.bucketChars, history: historyPlan.text.length };
+      info.historyTextChars = historyPlan.text.length;
+      info.collapsedTurns = historyPlan.collapsedTurns;
+      info.collapsedChars = historyPlan.text.length;
+      info.collapsedImages = historyPlan.images.length;
+      info.historyReason = 'collapsed';
+      info.droppedChars = (info.droppedChars ?? 0) + historyPlan.droppedChars;
+      if (historyPlan.droppedCodepoints.size > 0) {
+        info.droppedCodepointsTop = Object.fromEntries(
+          [...historyPlan.droppedCodepoints.entries()]
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 20)
+            .map(([codepoint, count]) => [
+              `U+${codepoint.toString(16).toUpperCase().padStart(4, '0')}`,
+              count,
+            ]),
+        );
+      }
+  } else if (options.collapseHistory !== false) {
+    info.historyReason = originalContents.length > profile.history.keepTail
+      ? 'not_profitable'
+      : 'no_history';
+  }
+
+  if (toolResultPlan.images.length > 0) {
+    const resultImageTokens = toolResultPlan.images.reduce(
+      (sum, image) => sum + geminiVisionTokens(modelName, image.width, image.height),
+      0,
+    );
+    info.imageTokens += resultImageTokens;
+    info.baselineImagedTokens += toolResultPlan.baselineTokens;
+    info.nativeInjectedTokens += toolResultPlan.nativeTokens;
+    info.imageCount += toolResultPlan.images.length;
+    info.imageBytes += toolResultPlan.images.reduce((sum, image) => sum + image.png.byteLength, 0);
+    info.imagePngs.push(...toolResultPlan.images.map((image) => image.png));
+    info.imageDims.push(...toolResultPlan.images.map((image) => ({ width: image.width, height: image.height })));
+    info.imageSourceTexts.push(...toolResultPlan.imageSources);
+    info.compressedChars += toolResultPlan.compressedChars;
+    info.toolResultImgs = toolResultPlan.images.length;
+    info.bucketChars = { ...info.bucketChars, ...toolResultPlan.bucketChars };
+    info.droppedChars = (info.droppedChars ?? 0) + toolResultPlan.droppedChars;
+  }
 
   const transformedBytes = new TextEncoder().encode(JSON.stringify(transformedReq));
   return { body: transformedBytes, info };

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -124,7 +124,10 @@ export interface HistoryCollapseInfo {
 /**
  * Return the last index ≤ cutoffExclusive at which all tool_use_ids are matched
  * by tool_results in [0..i]. Returns -1 if no closed boundary exists.
- * Robust to interleaved/parallel tool calls via openSet tracking.
+ * Robust to interleaved/parallel tool calls via openSet tracking. Consecutive
+ * assistant-tool/user-result pairs are treated as one tool round: some Anthropic
+ * clients serialize a parallel batch that way, so the apparently-closed gap
+ * between two pairs is not a safe collapse boundary.
  */
 export function findClosedPrefixBoundary(
   messages: Message[],
@@ -133,19 +136,37 @@ export function findClosedPrefixBoundary(
   if (cutoffExclusive <= 0) return -1;
   const openSet = new Set<string>();
   let lastClosed = -1;
+  let inToolRound = false;
   const limit = Math.min(cutoffExclusive, messages.length);
   for (let i = 0; i < limit; i++) {
     const msg = messages[i]!;
+
+    const assistantToolUses =
+      msg.role === 'assistant' && Array.isArray(msg.content)
+        ? msg.content.filter(
+            (blk): blk is ToolUseBlock =>
+              !!blk && (blk as ToolUseBlock).type === 'tool_use',
+          )
+        : [];
+
+    // A closed tool pair is only provisional until we see what follows. OpenCode
+    // commonly emits a parallel Anthropic round as A-call/A-result,
+    // B-call/B-result. Do not expose the gap between those adjacent pairs as a
+    // collapse boundary.
+    if (inToolRound && openSet.size === 0 && assistantToolUses.length === 0) {
+      lastClosed = i - 1;
+      inToolRound = false;
+    }
+
     if (!Array.isArray(msg.content)) {
-      if (openSet.size === 0) lastClosed = i; // plain string — no tool blocks
+      if (openSet.size === 0 && !inToolRound) lastClosed = i;
       continue;
     }
     if (msg.role === 'assistant') {
-      for (const blk of msg.content) {
-        if (blk && (blk as ToolUseBlock).type === 'tool_use') {
-          const id = (blk as ToolUseBlock).id;
-          if (typeof id === 'string') openSet.add(id);
-        }
+      if (assistantToolUses.length > 0) inToolRound = true;
+      for (const blk of assistantToolUses) {
+        const id = blk.id;
+        if (typeof id === 'string') openSet.add(id);
       }
     } else if (msg.role === 'user') {
       for (const blk of msg.content) {
@@ -155,7 +176,21 @@ export function findClosedPrefixBoundary(
         }
       }
     }
-    if (openSet.size === 0) lastClosed = i;
+    if (openSet.size === 0 && !inToolRound) lastClosed = i;
+  }
+
+  // The end of a closed round is safe only if the actual next message does not
+  // continue it with another serialized tool call. Looking one message past the
+  // cutoff changes no collapsed index; it merely prevents splitting the round.
+  if (inToolRound && openSet.size === 0) {
+    const next = messages[limit];
+    const nextContinuesRound =
+      next?.role === 'assistant' &&
+      Array.isArray(next.content) &&
+      next.content.some(
+        (blk) => !!blk && (blk as ToolUseBlock).type === 'tool_use',
+      );
+    if (!nextContinuesRound) lastClosed = limit - 1;
   }
   return lastClosed;
 }

--- a/src/core/openai-history.ts
+++ b/src/core/openai-history.ts
@@ -544,6 +544,20 @@ interface ResponsesCompletedPair {
   outputTokens: number;
 }
 
+/** One protocol-atomic tool round. OpenCode emits parallel tools as
+ * call A, call B, …, output A, output B, …; removing only one pair would leave
+ * the native round structurally incomplete. A round is therefore the smallest
+ * unit the planner may select. */
+interface ResponsesCompletedRound {
+  pairs: ResponsesCompletedPair[];
+  indices: number[];
+  startIndex: number;
+  endIndex: number;
+  text: string;
+  callTokens: number;
+  outputTokens: number;
+}
+
 function responseItemType(item: unknown): string {
   const o = item as Record<string, unknown> | null;
   return o && typeof o.type === 'string' ? o.type : '';
@@ -605,12 +619,13 @@ function responseReferencedIds(items: unknown[]): Set<string> {
 }
 
 /** Classify Responses tool state without interpreting recency from raw item count.
- * Only an unambiguous adjacent call/output pair is collapsible. Native items
- * between the call and output would be reordered by a single image replacement. */
+ * Accept both adjacent pairs and protocol-atomic parallel rounds:
+ * `call A, call B, output A, output B`. Unknown/intervening native items remain
+ * hard barriers, and duplicate/reversed/orphan state is never selected. */
 function classifyResponsesPairs(
   items: unknown[],
   keepRecentPairs: number,
-): { old: ResponsesCompletedPair[]; state: ResponsesPairState } {
+): { old: ResponsesCompletedRound[]; state: ResponsesPairState } {
   const calls = new Map<string, number[]>();
   const outputs = new Map<string, number[]>();
   let missingIdItems = 0;
@@ -625,7 +640,7 @@ function classifyResponsesPairs(
     map.set(id, at);
   }
 
-  const completed: ResponsesCompletedPair[] = [];
+  const pairByCallIndex = new Map<number, ResponsesCompletedPair>();
   let openCalls = 0;
   let orphanOutputs = 0;
   let malformedItems = missingIdItems;
@@ -633,12 +648,12 @@ function classifyResponsesPairs(
   for (const id of ids) {
     const cs = calls.get(id) ?? [];
     const os = outputs.get(id) ?? [];
-    if (cs.length === 1 && os.length === 1 && os[0] === cs[0]! + 1) {
+    if (cs.length === 1 && os.length === 1 && cs[0]! < os[0]!) {
       const callIndex = cs[0]!;
       const outputIndex = os[0]!;
       const call = items[callIndex] as Record<string, unknown>;
       const output = items[outputIndex] as Record<string, unknown>;
-      completed.push({
+      pairByCallIndex.set(callIndex, {
         callIndex,
         outputIndex,
         text: `${responseCallText(call)}\n${responseOutputText(output)}`,
@@ -649,24 +664,84 @@ function classifyResponsesPairs(
           typeof output.output === 'string' ? output.output : safeJson(output.output),
         ),
       });
-      continue;
-    }
-    if (cs.length > 0 && os.length === 0) openCalls += cs.length;
+    } else if (cs.length > 0 && os.length === 0) openCalls += cs.length;
     else if (os.length > 0 && cs.length === 0) orphanOutputs += os.length;
     else malformedItems += cs.length + os.length;
   }
-  completed.sort((a, b) => a.outputIndex - b.outputIndex);
+
+  // Discover contiguous calls* + outputs* rounds. A candidate unique pair that
+  // does not fit one of these rounds is non-adjacent protocol state and remains
+  // native. This is the shape OpenCode uses for parallel tool calls.
+  const completed: ResponsesCompletedRound[] = [];
+  const acceptedCallIndices = new Set<number>();
+  for (let i = 0; i < items.length;) {
+    if (responseItemType(items[i]) !== 'function_call' || !pairByCallIndex.has(i)) {
+      i++;
+      continue;
+    }
+    const calls: ResponsesCompletedPair[] = [];
+    let j = i;
+    while (responseItemType(items[j]) === 'function_call' && pairByCallIndex.has(j)) {
+      calls.push(pairByCallIndex.get(j)!);
+      j++;
+    }
+    const roundOutputIndices = new Set(calls.map((pair) => pair.outputIndex));
+    const outputs: number[] = [];
+    // Do not absorb an output belonging to orphan/other state into this round.
+    while (
+      responseItemType(items[j]) === 'function_call_output'
+      && roundOutputIndices.has(j)
+    ) {
+      outputs.push(j);
+      j++;
+    }
+    const outputSet = new Set(outputs);
+    const valid = calls.length > 0
+      && outputs.length === calls.length
+      && calls.every((pair) => outputSet.has(pair.outputIndex));
+    if (!valid) {
+      i++;
+      continue;
+    }
+    const byOutput = [...calls].sort((a, b) => a.outputIndex - b.outputIndex);
+    const indices = [
+      ...calls.map((pair) => pair.callIndex),
+      ...byOutput.map((pair) => pair.outputIndex),
+    ];
+    completed.push({
+      pairs: calls,
+      indices,
+      startIndex: i,
+      endIndex: j - 1,
+      text: byOutput.map((pair) => pair.text).join('\n\n'),
+      callTokens: calls.reduce((sum, pair) => sum + pair.callTokens, 0),
+      outputTokens: calls.reduce((sum, pair) => sum + pair.outputTokens, 0),
+    });
+    for (const pair of calls) acceptedCallIndices.add(pair.callIndex);
+    i = j;
+  }
+  for (const pair of pairByCallIndex.values()) {
+    if (!acceptedCallIndices.has(pair.callIndex)) malformedItems += 2;
+  }
+
   const keep = Math.max(0, Math.floor(keepRecentPairs));
-  const oldCount = Math.max(0, completed.length - keep);
-  const old = completed.slice(0, oldCount);
-  const imageableFunctionCallTokens = old.reduce((n, p) => n + p.callTokens, 0);
-  const imageableFunctionOutputTokens = old.reduce((n, p) => n + p.outputTokens, 0);
+  let recentStart = completed.length;
+  let recentPairs = 0;
+  while (recentStart > 0 && recentPairs < keep) {
+    recentStart--;
+    recentPairs += completed[recentStart]!.pairs.length;
+  }
+  const old = completed.slice(0, recentStart);
+  const completedPairs = completed.reduce((n, round) => n + round.pairs.length, 0);
+  const oldPairs = old.reduce((n, round) => n + round.pairs.length, 0);
+  const imageableFunctionCallTokens = old.reduce((n, round) => n + round.callTokens, 0);
+  const imageableFunctionOutputTokens = old.reduce((n, round) => n + round.outputTokens, 0);
   return {
     old,
     state: {
-      completedPairs: completed.length,
-      recentCompletedPairs: completed.length - old.length,
-      oldCompletedPairs: old.length,
+      completedPairs,
+      recentCompletedPairs: completedPairs - oldPairs,
+      oldCompletedPairs: oldPairs,
       openCalls,
       orphanOutputs,
       malformedItems,
@@ -699,13 +774,13 @@ interface ResponsesMixedUnit {
  * Every other item is a hard barrier, preserving native protocol order/state. */
 async function planResponsesMixedCollapse(
   items: unknown[],
-  old: ResponsesCompletedPair[],
+  old: ResponsesCompletedRound[],
   state: ResponsesPairState,
   isProfitable: GptProfitableFn,
   o: GptHistoryOptions,
 ): Promise<ResponsesPairCollapsePlan> {
   const base = emptyResponsesPairPlan(state);
-  const oldByCall = new Map(old.map((pair) => [pair.callIndex, pair]));
+  const oldByCall = new Map(old.map((round) => [round.startIndex, round]));
   const messageIndices: number[] = [];
   const referencedIds = responseReferencedIds(items);
   let latestUserIndex = -1;
@@ -727,18 +802,18 @@ async function planResponsesMixedCollapse(
     current = [];
   };
   for (let i = 0; i < items.length; i++) {
-    const pair = oldByCall.get(i);
-    const pairCall = pair ? items[pair.callIndex] as Record<string, unknown> | null : null;
-    const pairOutput = pair ? items[pair.outputIndex] as Record<string, unknown> | null : null;
-    const pairReferenced = !!pair && [pairCall?.id, pairOutput?.id]
+    const round = oldByCall.get(i);
+    const roundReferenced = !!round && round.indices
+      .map((index) => items[index] as Record<string, unknown> | null)
+      .map((item) => item?.id)
       .some((id) => typeof id === 'string' && referencedIds.has(id));
-    if (pair && !pairReferenced) {
+    if (round && !roundReferenced) {
       current.push({
-        indices: [pair.callIndex, pair.outputIndex],
-        text: pair.text,
-        baselineTokens: pair.callTokens + pair.outputTokens,
+        indices: round.indices,
+        text: round.text,
+        baselineTokens: round.callTokens + round.outputTokens,
       });
-      i = pair.outputIndex;
+      i = round.endIndex;
       continue;
     }
     const item = items[i] as Record<string, unknown> | null;
@@ -820,12 +895,10 @@ async function planResponsesMixedCollapse(
   }
   const selectedIndices = segments.flatMap((segment) => segment.selectedIndices).sort((a, b) => a - b);
   const selectedIds = new Set(selectedIndices);
-  const selectedPairs = old.filter(
-    (pair) => selectedIds.has(pair.callIndex) && selectedIds.has(pair.outputIndex),
-  );
-  state.collapsedPairs = selectedPairs.length;
-  state.collapsedFunctionCallTokens = selectedPairs.reduce((n, pair) => n + pair.callTokens, 0);
-  state.collapsedFunctionOutputTokens = selectedPairs.reduce((n, pair) => n + pair.outputTokens, 0);
+  const selectedRounds = old.filter((round) => round.indices.every((index) => selectedIds.has(index)));
+  state.collapsedPairs = selectedRounds.reduce((n, round) => n + round.pairs.length, 0);
+  state.collapsedFunctionCallTokens = selectedRounds.reduce((n, round) => n + round.callTokens, 0);
+  state.collapsedFunctionOutputTokens = selectedRounds.reduce((n, round) => n + round.outputTokens, 0);
   const images = segments.flatMap((segment) => segment.images);
   const imageSources = segments.flatMap((segment) => segment.imageSources);
   const text = segments.map((segment) => segment.text).join('\n\n');
@@ -856,9 +929,9 @@ async function planResponsesMixedCollapse(
   };
 }
 
-/** Render only old, unambiguously completed Responses call/output pairs.
- * Native messages, reasoning, recent pairs, open calls, and malformed state stay
- * in place. Consecutive pairs may share pages, but no segment crosses native state. */
+/** Render only old, unambiguously completed Responses call/output rounds.
+ * Native messages, reasoning, recent rounds, open calls, and malformed state stay
+ * in place. Consecutive rounds may share pages, but no segment crosses native state. */
 export async function planResponsesPairCollapse(
   items: unknown[],
   isProfitable: GptProfitableFn,
@@ -882,15 +955,15 @@ export async function planResponsesPairCollapse(
     return { ...base, reason: 'too_many_images', collapsedChars: allText.length };
   }
 
-  const runs: ResponsesCompletedPair[][] = [];
-  for (const pair of old) {
+  const runs: ResponsesCompletedRound[][] = [];
+  for (const round of old) {
     const run = runs.at(-1);
-    if (run && pair.callIndex === run.at(-1)!.outputIndex + 1) run.push(pair);
-    else runs.push([pair]);
+    if (run && round.startIndex === run.at(-1)!.endIndex + 1) run.push(round);
+    else runs.push([round]);
   }
 
-  const renderPairs = async (pairs: ResponsesCompletedPair[]) => {
-    const source = pairs.map((pair) => pair.text).join('\n\n');
+  const renderPairs = async (rounds: ResponsesCompletedRound[]) => {
+    const source = rounds.map((round) => round.text).join('\n\n');
     const safe = neutralizeSentinel(source);
     let renderedText = o.reflow ? reflow(safe) ?? safe : safe;
     const images = await renderTextToPngs(
@@ -923,10 +996,10 @@ export async function planResponsesPairCollapse(
 
     const selected = run.slice(0, low);
     const selectedIndices = selected
-      .flatMap((pair) => [pair.callIndex, pair.outputIndex])
+      .flatMap((round) => round.indices)
       .sort((a, b) => a - b);
     segments.push({
-      insertAt: selected[0]!.callIndex,
+      insertAt: selected[0]!.startIndex,
       selectedIndices,
       images: best.images,
       imageSources: best.images.map(() => best.source),
@@ -951,12 +1024,10 @@ export async function planResponsesPairCollapse(
   const imageSources = segments.flatMap((segment) => segment.imageSources);
   const text = segments.map((segment) => segment.text).join('\n\n');
   const selectedIds = new Set(selectedIndices);
-  const selectedPairs = old.filter(
-    (pair) => selectedIds.has(pair.callIndex) && selectedIds.has(pair.outputIndex),
-  );
-  state.collapsedPairs = selectedPairs.length;
-  state.collapsedFunctionCallTokens = selectedPairs.reduce((n, pair) => n + pair.callTokens, 0);
-  state.collapsedFunctionOutputTokens = selectedPairs.reduce((n, pair) => n + pair.outputTokens, 0);
+  const selectedRounds = old.filter((round) => round.indices.every((index) => selectedIds.has(index)));
+  state.collapsedPairs = selectedRounds.reduce((n, round) => n + round.pairs.length, 0);
+  state.collapsedFunctionCallTokens = selectedRounds.reduce((n, round) => n + round.callTokens, 0);
+  state.collapsedFunctionOutputTokens = selectedRounds.reduce((n, round) => n + round.outputTokens, 0);
 
   const droppedCodepoints = new Map<number, number>();
   let droppedChars = 0;

--- a/src/core/openai.ts
+++ b/src/core/openai.ts
@@ -400,9 +400,9 @@ function isFlatFunctionTool(tool: unknown): tool is ResponsesFlatTool {
   );
 }
 
-/** Render only schema annotations removed from the native tool definition.
- * Structural JSON and the top-level tool description remain native, so putting
- * them in the image too spends vision tokens without replacing any text. */
+/** Render schema annotations removed from the native tool definition. The full
+ * top-level description rides in the same image and is replaced by a short
+ * per-tool pointer, matching the Anthropic tool-reference approach. */
 function schemaAnnotationLines(node: unknown, path = '$', depth = 0): string[] {
   if (!node || typeof node !== 'object' || depth > 20) return [];
   if (Array.isArray(node)) {
@@ -444,15 +444,15 @@ function schemaAnnotationLines(node: unknown, path = '$', depth = 0): string[] {
 function renderToolDoc(tool: OpenAIFunctionTool): string {
   const f = tool.function;
   const annotations = schemaAnnotationLines(f.parameters);
-  return annotations.length
-    ? [`## Tool parameter annotations: ${f.name ?? '?'}`, ...annotations].join('\n')
+  return f.description || annotations.length
+    ? [`## Tool: ${f.name ?? '?'}`, f.description ?? '', ...annotations].filter(Boolean).join('\n')
     : '';
 }
 
 function renderFlatToolDoc(tool: ResponsesFlatTool): string {
   const annotations = schemaAnnotationLines(tool.parameters);
-  return annotations.length
-    ? [`## Tool parameter annotations: ${tool.name ?? '?'}`, ...annotations].join('\n')
+  return tool.description || annotations.length
+    ? [`## Tool: ${tool.name ?? '?'}`, tool.description ?? '', ...annotations].filter(Boolean).join('\n')
     : '';
 }
 
@@ -473,6 +473,7 @@ function rewriteToolsForGpt(tools: unknown[] | undefined): {
       ...tool,
       function: {
         ...tool.function,
+        description: `Full docs: see "## Tool: ${tool.function.name ?? '?'}" in the rendered context image.`,
         parameters: stripSchemaDescriptions(tool.function.parameters),
       },
     };
@@ -495,6 +496,7 @@ function rewriteFlatToolsForGpt(tools: unknown[] | undefined): {
     changed = true;
     return {
       ...tool,
+      description: `Full docs: see "## Tool: ${tool.name ?? '?'}" in the rendered context image.`,
       parameters: stripSchemaDescriptions(tool.parameters),
     };
   });

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -1023,21 +1023,23 @@ export function createProxy(config: ProxyConfig = {}) {
             countGoogleTokensUpstream(countUrl.toString(), bodyIn, countHeaders, model!),
             countGoogleTokensUpstream(countUrl.toString(), r.body, countHeaders, model!),
           ]);
-          if (baseline === null || transformed === null || transformed >= baseline) {
+          if (baseline === null || transformed === null) {
+            // countTokens is optional measurement, not a delivery dependency.
+            // The transformer already applied a conservative local gate.
+            r.info.baselineProbeStatus = 'failed';
+          } else if (transformed >= baseline) {
             r = {
               body: bodyIn,
               info: {
                 ...r.info,
                 compressed: false,
-                reason: baseline === null || transformed === null
-                  ? 'baseline_probe_failed'
-                  : `not_profitable (${transformed} >= ${baseline} tokens)`,
+                reason: `not_profitable (${transformed} >= ${baseline} tokens)`,
                 imageCount: 0,
                 imageBytes: 0,
                 imageTokens: undefined,
                 baselineImagedTokens: undefined,
                 nativeInjectedTokens: undefined,
-                baselineProbeStatus: baseline === null || transformed === null ? 'failed' : 'ok',
+                baselineProbeStatus: 'ok',
               },
             };
           } else {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -241,6 +241,11 @@ interface Totals {
    *  doesn't touch output). Without this the headline ignores half the
    *  bill on output-heavy sessions. */
   outputWeighted: number;
+  /** Claude-priced subset of the measured totals. Google rows contribute to
+   * token savings above, but not to dollar estimates based on Claude rates. */
+  pricedActualInputWeighted: number;
+  pricedBaselineInputWeighted: number;
+  pricedOutputWeighted: number;
   /** Sum of weighted COUNTERFACTUAL input tokens across ALL requests
    *  with a usage block. For measured rows: cache-aware baseline (what the
    *  unproxied path would have billed). For unmeasured/probe-failed rows:
@@ -308,6 +313,9 @@ function emptyTotals(startedAt = Date.now() / 1000): Totals {
     actualInputWeighted: 0,
     baselineInputWeighted: 0,
     outputWeighted: 0,
+    pricedActualInputWeighted: 0,
+    pricedBaselineInputWeighted: 0,
+    pricedOutputWeighted: 0,
     allBaselineEquivalentWeighted: 0,
     allActualInputWeighted: 0,
     allOutputWeighted: 0,
@@ -383,6 +391,44 @@ function isOpenAIEvent(
   if (accountingProvider) return accountingProvider === 'openai';
   if (!path) return false;
   return path.includes('responses') || path.includes('chat/completions');
+}
+
+function googleEff(args: {
+  inputTokens: number;
+  outputTokens: number;
+  compressed: boolean;
+  baselineTokens: number;
+  baselineProbeStatus: string | undefined;
+  imageTokens: number;
+  baselineImagedTokens: number;
+  nativeInjectedTokens: number;
+}): {
+  haveUsage: boolean;
+  haveBaseline: boolean;
+  creditSaving: boolean;
+  actualInputEff: number;
+  baselineInputEff: number;
+} {
+  const { inputTokens: inp, outputTokens: out, compressed } = args;
+  const haveUsage = inp > 0 || out > 0;
+  const measuredBaseline = args.baselineProbeStatus === 'ok' && args.baselineTokens > 0
+    ? args.baselineTokens
+    : 0;
+  const estimatedBaseline = compressed
+    && args.imageTokens > 0
+    && args.baselineImagedTokens > 0
+    ? Math.max(0, inp - args.imageTokens - args.nativeInjectedTokens + args.baselineImagedTokens)
+    : 0;
+  const baseline = measuredBaseline || estimatedBaseline;
+  const haveBaseline = baseline > 0;
+  const creditSaving = haveBaseline && haveUsage && compressed;
+  return {
+    haveUsage,
+    haveBaseline,
+    creditSaving,
+    actualInputEff: inp,
+    baselineInputEff: creditSaving ? baseline : inp,
+  };
 }
 
 /** Cache-aware eff bundle for one GPT event. Shared by the live `update()`
@@ -597,14 +643,14 @@ export class DashboardState {
   /** Fold one event into the running totals + ring buffer.
    *
    *  Savings math is gated on a per-request `baseline_tokens` measurement
-   *  from the parallel count_tokens probe AND an upstream usage block.
-   *  When either is missing, we still count the request but skip its
-   *  savings contribution — no estimation. */
+   *  from the parallel count_tokens probe or model-profile estimation (Google/GPT),
+   *  plus an upstream usage block. When both probe and estimation are missing,
+   *  we still count the request but skip its savings contribution. */
   update(ev: ProxyEvent): void {
     // Stash the image bytes before they get GC'd by the request finishing.
     // The returned id (if any) is stamped onto this request's RecentRow so
     // the dashboard can pull the exact image that request rendered.
-    const imgIds = ev.info ? this.captureImage(ev.info) : [];
+    const imgIds = ev.info?.compressed ? this.captureImage(ev.info) : [];
     const imgId = imgIds[0];
 
     const u = ev.usage;
@@ -639,20 +685,29 @@ export class DashboardState {
     // Anthropic cr>0 or GPT cached_tokens>0. Drives Context Map narration.
 
     if (google) {
-      haveUsage = u !== undefined && (inp > 0 || out > 0);
-      const baseline = info?.baselineTokens;
-      haveBaseline = info?.baselineProbeStatus === 'ok'
-        && typeof baseline === 'number' && baseline > 0;
-      creditSaving = haveBaseline && haveUsage && compressed;
-      const measuredBaseline = haveBaseline ? baseline as number : inp;
-      actualInputEff = inp;
-      baselineInputEff = creditSaving ? measuredBaseline : inp;
+      const e = googleEff({
+        inputTokens: inp,
+        outputTokens: out,
+        compressed,
+        baselineTokens: info?.baselineTokens ?? 0,
+        baselineProbeStatus: info?.baselineProbeStatus,
+        imageTokens: info?.imageTokens ?? 0,
+        baselineImagedTokens: info?.baselineImagedTokens ?? 0,
+        nativeInjectedTokens: info?.nativeInjectedTokens ?? 0,
+      });
+      haveUsage = e.haveUsage;
+      haveBaseline = e.haveBaseline;
+      creditSaving = e.creditSaving;
+      actualInputEff = e.actualInputEff;
+      baselineInputEff = e.baselineInputEff;
       outputEquiv = out;
       rawActual = inp;
-      rawBaseline = creditSaving ? measuredBaseline : inp;
-      baselineForRow = creditSaving ? measuredBaseline : 0;
+      rawBaseline = creditSaving ? baselineInputEff : inp;
+      baselineForRow = creditSaving ? baselineInputEff : 0;
       cacheReadForRow = u?.cached_tokens ?? 0;
-      warmForRow = cacheReadForRow > 0;
+      // Google fallback savings are raw provider-token deltas; do not imply
+      // that an unknown cache discount was applied to the counterfactual.
+      warmForRow = false;
     } else if (gpt) {
       // GPT cost model: no count_tokens probe, no cache-create premium, no
       // per-session warmth — the discount is automatic and folded into the
@@ -821,14 +876,20 @@ export class DashboardState {
     totals.requests += 1;
     if (compressed) totals.compressedRequests += 1;
 
-    // Measured headline: only compressed rows with a usable probe. An
+    // Token headline: compressed rows with a usable measured or local
+    // baseline. An
     // uncompressed row contributes zero saved (baseline === actual), so
     // including it here would only dilute the "saved on rows we moved" %.
     const dollarEligible = !google;
-    if (creditSaving && dollarEligible) {
+    if (creditSaving) {
       totals.baselineInputWeighted += baselineInputEff;
       totals.actualInputWeighted += actualInputEff;
       totals.outputWeighted += outputEquiv;
+      if (dollarEligible) {
+        totals.pricedBaselineInputWeighted += baselineInputEff;
+        totals.pricedActualInputWeighted += actualInputEff;
+        totals.pricedOutputWeighted += outputEquiv;
+      }
     }
     // All-rows COUNTERFACTUAL spend, ungated on the probe — the honest
     // denominator for "did pxpipe move my real bill". Measured rows
@@ -1006,19 +1067,29 @@ export class DashboardState {
       let warmForRow: boolean; // text-baseline warmth for the Context Map narration
 
       if (google) {
-        haveUsage = inp > 0 || out > 0;
-        const baseline = (t as { baseline_tokens?: number }).baseline_tokens;
-        haveBaseline = (t as { baseline_probe_status?: string }).baseline_probe_status === 'ok'
-          && typeof baseline === 'number' && baseline > 0;
-        creditSaving = haveBaseline && haveUsage && compressed;
-        const measuredBaseline = haveBaseline ? baseline as number : inp;
-        actualInputEff = inp;
-        baselineInputEff = creditSaving ? measuredBaseline : inp;
+        const e = googleEff({
+          inputTokens: inp,
+          outputTokens: out,
+          compressed,
+          baselineTokens: (t as { baseline_tokens?: number }).baseline_tokens ?? 0,
+          baselineProbeStatus:
+            (t as { baseline_probe_status?: string }).baseline_probe_status,
+          imageTokens: (t as { image_tokens?: number }).image_tokens ?? 0,
+          baselineImagedTokens:
+            (t as { baseline_imaged_tokens?: number }).baseline_imaged_tokens ?? 0,
+          nativeInjectedTokens:
+            (t as { native_injected_tokens?: number }).native_injected_tokens ?? 0,
+        });
+        haveUsage = e.haveUsage;
+        haveBaseline = e.haveBaseline;
+        creditSaving = e.creditSaving;
+        actualInputEff = e.actualInputEff;
+        baselineInputEff = e.baselineInputEff;
         rawActual = inp;
-        rawBaseline = creditSaving ? measuredBaseline : inp;
-        baselineForRow = creditSaving ? measuredBaseline : 0;
+        rawBaseline = creditSaving ? baselineInputEff : inp;
+        baselineForRow = creditSaving ? baselineInputEff : 0;
         cacheReadForRow = (t as { cached_tokens?: number }).cached_tokens ?? 0;
-        warmForRow = cacheReadForRow > 0;
+        warmForRow = false;
       } else if (gpt) {
         const e = gptEff({
           model: t.model,
@@ -1240,10 +1311,15 @@ export class DashboardState {
     const actual = totals.actualInputWeighted;
     const output = totals.outputWeighted; // already × OUTPUT_TOKEN_RATE
     const saved = baseline - actual;
+    const pricedBaseline = totals.pricedBaselineInputWeighted;
+    const pricedActual = totals.pricedActualInputWeighted;
+    const pricedOutput = totals.pricedOutputWeighted;
+    const pricedSaved = pricedBaseline - pricedActual;
     const pctInput = baseline > 0 ? (saved / baseline) * 100 : 0;
     const baselineTotal = baseline + output;
     const actualTotal = actual + output;
-    const pctTotal = baselineTotal > 0 ? (saved / baselineTotal) * 100 : 0;
+    const pricedBaselineTotal = pricedBaseline + pricedOutput;
+    const pctTotal = pricedBaselineTotal > 0 ? (pricedSaved / pricedBaselineTotal) * 100 : 0;
 
     // Share-of-all-spend: honest denominator. The numerator can only credit
     // savings against rows where we have a probe baseline (otherwise it's
@@ -1261,7 +1337,7 @@ export class DashboardState {
     // not 280%.
     const allCounterfactualBill = allBaselineEquiv + allOutput;
     const pctAllSpend =
-      allCounterfactualBill > 0 ? (saved / allCounterfactualBill) * 100 : 0;
+      allCounterfactualBill > 0 ? (pricedSaved / allCounterfactualBill) * 100 : 0;
 
     // Direct observed split — actual $ per request, partitioned by which
     // path ran. Token-equivalent (input × 1.0 + cache_create × 1.25 +
@@ -1333,7 +1409,7 @@ export class DashboardState {
       compressed_minus_passthrough_avg_usd: round4(splitDeltaUsd),
       split_sufficient_sample: splitSufficient,
       split_min_sample_per_bucket: SUFFICIENT,
-      saved_usd: round4((saved * ASSUMED_INPUT_USD_PER_MTOK) / 1e6),
+      saved_usd: round4((pricedSaved * ASSUMED_INPUT_USD_PER_MTOK) / 1e6),
       output_weighted: Math.round(output),
       baseline_token_equivalent: Math.round(baselineTotal),
       actual_token_equivalent: Math.round(actualTotal),

--- a/src/dashboard/fragments.ts
+++ b/src/dashboard/fragments.ts
@@ -212,14 +212,13 @@ export function renderSessionSummaryFragment(s: StatsPayload): string {
   return (
     `<div class="hero${positive ? '' : ' hero-neg'}">` +
     `<div class="hero-eyebrow">Since start · ${numFmt(measured)} request${measured === 1 ? '' : 's'} imaged</div>` +
-    `<div class="hero-headline"><span class="hero-num">${bigNum}</span> ${word} after caching</div>` +
+    `<div class="hero-headline"><span class="hero-num">${bigNum}</span> ${word}</div>` +
     `<div class="hero-sub">` +
-    `<strong>${kFmt(actualW)}</strong> effective tokens vs <strong>${kFmt(baselineW)}</strong> if this same context ` +
-    `stayed plain text — both counted after normal cache discounts since this proxy started. ` +
-    `Your latest messages and Claude's live output are never compressed.` +
+    `<strong>${kFmt(actualW)}</strong> provider-accounted input tokens vs <strong>${kFmt(baselineW)}</strong> if this same context ` +
+    `stayed plain text. Your latest messages and model output are never compressed.` +
     `</div>` +
     `<div class="hero-meta">` +
-    `Cache-aware — cached reads counted at their real ~0.1× weight, not full price · ` +
+    `Provider-token basis; cache discounts applied where measurable · ` +
     `output untouched (${kFmt(rawOutput)}) · no $ assumptions` +
     `</div>` +
     `</div>`
@@ -259,6 +258,11 @@ function statTile(
 
 export function renderHeaderFragment(s: StatsPayload, port: number): string {
   const pa = s.pricing_assumptions;
+  const unpricedImaged = Math.max(
+    0,
+    (s.compressed_requests ?? 0) - (s.compressed_paid_requests ?? 0),
+  );
+  const onlyUnpriced = unpricedImaged > 0 && (s.compressed_paid_requests ?? 0) === 0;
 
   // Compare the same imaged requests on both sides. Passthrough requests are
   // generally smaller because the profitability gate selected them, so their
@@ -274,12 +278,38 @@ export function renderHeaderFragment(s: StatsPayload, port: number): string {
         cAvg <= withoutAvg ? 'pos' : 'neg',
         'Average cost of paid imaged requests versus the cache-aware text counterfactual for those same requests. Unmeasured requests are assigned zero savings.',
       )
-    : statTile(
+    : onlyUnpriced
+      ? statTile(
+          'Cost per request',
+          '—',
+          'provider pricing not configured',
+          'muted-val',
+          'Token savings are available, but this provider is excluded from Claude-priced dollar estimates.',
+        )
+      : statTile(
         'Cost per request',
         'collecting…',
         'waiting for a paid imaged request',
         'muted-val',
         'The comparison appears after an imaged request returns provider usage.',
+      );
+
+  const savedUsdTile = onlyUnpriced
+    ? statTile(
+        'Estimated saved',
+        '—',
+        'provider pricing not configured',
+        'muted-val',
+        'Token savings are shown separately. Dollar estimates require provider-specific pricing and are not inferred from Claude rates.',
+      )
+    : statTile(
+        'Estimated saved',
+        `$${(s.saved_usd ?? 0).toFixed(2)}`,
+        unpricedImaged > 0
+          ? `${numFmt(unpricedImaged)} provider-priced request${unpricedImaged === 1 ? '' : 's'} excluded`
+          : `at $${pa.input_per_mtok}/M base input price`,
+        '',
+        'Cache-aware estimate for requests covered by the configured pricing assumptions. Other providers remain excluded.',
       );
 
   const strip =
@@ -290,15 +320,9 @@ export function renderHeaderFragment(s: StatsPayload, port: number): string {
       numFmt(s.saved_input_tokens),
       'vs sending the same context as text',
       'pos',
-      'Bulky context (system prompt, tool output, old turns) sent as compact images instead of text. Cache-aware, input side only — recent turns and the live output stay text.',
-    ) +
-    statTile(
-      'Estimated saved',
-      `$${(s.saved_usd ?? 0).toFixed(2)}`,
-      `at $${pa.input_per_mtok}/M base input price`,
-      '',
-      'Cache-aware estimate using the server-reported 5-minute/1-hour write split when available (1.25×/2×), cache reads (0.10×), and the base input price.',
-    ) +
+       'Bulky context sent as compact images instead of text. Uses provider-reported input tokens and a measured or model-profile text counterfactual; recent turns and output stay text.',
+     ) +
+    savedUsdTile +
     costTile +
     `</div>`;
 
@@ -312,7 +336,10 @@ export function renderHeaderFragment(s: StatsPayload, port: number): string {
     mathRow('saved', s.saved_input_tokens, `<span class="op">=</span> baseline − actual`) +
     `<span class="src">output excluded — identical with/without compression</span>`;
 
-  const usdMath =
+  const usdMath = onlyUnpriced
+    ? `<div><span class="v">Unavailable for this provider.</span></div>` +
+      `<span class="src">Token savings are still reported; Claude pricing is not applied across providers.</span>`
+    :
     `<div><span class="k">formula:</span> <span class="v">$ saved = saved_tokens × $${pa.input_per_mtok}/Mtok</span></div>` +
     `<div class="sp"></div>` +
     mathRow('saved_tokens', s.saved_input_tokens, '(cache-aware, input-side)') +
@@ -475,7 +502,7 @@ export function renderContextMapFragment(
         `<div class="ctx-row"><span class="ctx-lbl">${label}</span><span class="ctx-val">${kFmt(n)} tok</span></div>`,
       ).join('') +
       `<div class="ctx-row"><span class="ctx-lbl">Imageable text baseline</span><span class="ctx-val">${kFmt(c.baselineImagedTokens ?? 0)} tok</span></div>` +
-      `<div class="ctx-row"><span class="ctx-lbl">Adjacent completed pairs (old / recent native / imaged)</span><span class="ctx-val">${rc.completedFunctionPairs ?? 0} (${rc.oldFunctionPairs ?? 0} / ${rc.recentNativeFunctionPairs ?? 0} / ${rc.collapsedFunctionPairs ?? 0})</span></div>` +
+      `<div class="ctx-row"><span class="ctx-lbl">Completed tool pairs (old / recent native / imaged)</span><span class="ctx-val">${rc.completedFunctionPairs ?? 0} (${rc.oldFunctionPairs ?? 0} / ${rc.recentNativeFunctionPairs ?? 0} / ${rc.collapsedFunctionPairs ?? 0})</span></div>` +
       `<div class="ctx-row"><span class="ctx-lbl">Open calls kept native</span><span class="ctx-val">${rc.openFunctionCalls ?? 0}</span></div>` +
       `<div class="ctx-row"><span class="ctx-lbl">Native image parts</span><span class="ctx-val">${rc.imageParts}</span></div>` +
       `<div class="ctx-row"><span class="ctx-lbl">Provider tokens not explained locally</span><span class="ctx-val">${kFmt(c.responsesUnexplainedTokens ?? 0)} tok</span></div>` +
@@ -502,6 +529,7 @@ export function renderContextMapFragment(
   // request's observed cache state: cache_read > 0 means warm, cache_read === 0
   // means cold. No wall-clock-only counterfactual is credited.
   const warm = showCompare && c.warm;
+  const google = c.model?.startsWith('gemini-') === true;
   const textNoun = warm ? 'cached text' : 'text';
   // Raw count_tokens can grow (imaging bloated a short prompt), so say so rather
   // than rendering a nonsensical "shrank -36%".
@@ -510,13 +538,19 @@ export function renderContextMapFragment(
   const headline = !showCompare
     ? `<strong>${kFmt(c.actualInputEff || c.realInput)}</strong> billing-equivalent input tokens sent`
     : pct >= 0
-      ? `<span class="ctx-big">${pct}%</span> smaller — ${textNoun} would bill as <strong>${kFmt(base)}</strong> input tokens; images billed as <strong>${kFmt(real)}</strong>`
-      : `<span class="ctx-big">${-pct}%</span> bigger — images billed as <strong>${kFmt(real)}</strong> input tokens vs <strong>${kFmt(base)}</strong> for ${textNoun}`;
+      ? google
+        ? `<span class="ctx-big">${pct}%</span> smaller — text would account as <strong>${kFmt(base)}</strong> input tokens; images account as <strong>${kFmt(real)}</strong>`
+        : `<span class="ctx-big">${pct}%</span> smaller — ${textNoun} would bill as <strong>${kFmt(base)}</strong> input tokens; images billed as <strong>${kFmt(real)}</strong>`
+      : google
+        ? `<span class="ctx-big">${-pct}%</span> bigger — images account as <strong>${kFmt(real)}</strong> input tokens vs <strong>${kFmt(base)}</strong> for text`
+        : `<span class="ctx-big">${-pct}%</span> bigger — images billed as <strong>${kFmt(real)}</strong> input tokens vs <strong>${kFmt(base)}</strong> for ${textNoun}`;
   // Clarifying sub-line. It must match the actual request's cache state: claiming
   // a 0.1× read discount when cache_read===0 would count hypothetical cache as a
   // pxpipe effect, so cold rows price both paths cold.
   const subnote = !showCompare
     ? 'Billed tokens count cache discounts (reads at 0.1×) — no trustworthy text baseline for this request yet.'
+    : google
+      ? `Same provider-token basis as the Saved column. The gap is token count. ${rawPhrase}`
     : !warm
       ? `No warm text cache this turn — the text counterfactual's prefix is priced at the 1.25× create rate (the same event the imaged path pays), identical basis to the Saved column. The gap is purely token count. ${rawPhrase}`
       : pct < 0 && rawShrink > 0
@@ -615,7 +649,7 @@ export function renderRecentFragment(p: RecentPayload): string {
     `<th>Endpoint</th>` +
     `<th>Model</th>` +
     `<th title="Was this request's context compressed into an image?">Sent as</th>` +
-    `<th class="num" title="Tokens served from Claude's cache (cheap)">Cache hits</th>` +
+    `<th class="num" title="Tokens the provider reported as served from cache">Cache hits</th>` +
     `<th class="num" title="Billing-equivalent input if kept as plain text, after cache create/read rates">As text</th>` +
     `<th class="num" title="Actual billing-equivalent input after imaging, after cache create/read rates">Sent</th>` +
     `<th class="num" title="As-text minus Sent; negative means imaging cost more">Saved/lost</th>` +
@@ -674,7 +708,7 @@ export function renderLatestFragment(inp: LatestFragmentInput): string {
       sourceText == null
         ? `<div class="evicted">source text wasn't captured for this image</div>`
         : `<div class="pairing">` +
-          `<div class="pair-col"><div class="pair-head pair-img">What Claude sees · image</div><div class="frame frame-sm"><img src="${imgSrc}" alt="rendered page" /></div></div>` +
+          `<div class="pair-col"><div class="pair-head pair-img">What the model sees · image</div><div class="frame frame-sm"><img src="${imgSrc}" alt="rendered page" /></div></div>` +
           `<div class="pair-mid">made from ↓</div>` +
           `<div class="pair-col"><div class="pair-head pair-txt">The original text · byte-exact</div><pre class="src-pane">${escapeHtml(sourceText)}</pre></div>` +
           `</div>`;

--- a/tests/dashboard-api.test.ts
+++ b/tests/dashboard-api.test.ts
@@ -314,7 +314,7 @@ describe('serveFragment', () => {
     expect(html).toContain('Native tool JSON');
     expect(html).toContain('Function outputs eligible in old closed pairs');
     expect(html).toContain('Function outputs actually imaged this request');
-    expect(html).toContain('Adjacent completed pairs');
+    expect(html).toContain('Completed tool pairs');
     expect(html).toContain('Open calls kept native');
     expect(html).toContain('56.0k tok');
     expect(html).toContain('sent to gpt-5.6-sol');
@@ -654,12 +654,57 @@ describe('Gemini savings split', () => {
     } as never);
 
     const stats = (await dash.serveStats().json()) as StatsPayload;
-    expect(stats.saved_input_tokens).toBe(0);
+    expect(stats.saved_input_tokens).toBe(280);
     expect(stats.saved_usd).toBe(0);
     const recent = (await dash.serveRecent().json()) as RecentPayload;
     expect(recent.recent.at(-1)?.baseline_input).toBe(400);
     expect(recent.recent.at(-1)?.actual_input).toBe(120);
     expect(recent.recent.at(-1)?.session_saved_so_far_delta).toBe(280);
+  });
+
+  it('shows estimated savings when optional Gemini measurement fails', async () => {
+    dash.update({
+      method: 'POST',
+      path: '/google-ai-studio/v1beta/models/gemini-3.6-flash:generateContent',
+      model: 'gemini-3.6-flash',
+      accountingProvider: 'google',
+      status: 200,
+      durationMs: 100,
+      usage: { input_tokens: 1200, output_tokens: 10 },
+      info: {
+        compressed: true,
+        baselineProbeStatus: 'failed',
+        imageCount: 1,
+        imagePngs: [new Uint8Array([137, 80, 78, 71])],
+        imageDims: [{ width: 312, height: 728 }],
+        bucketChars: { static_slab: 14000 },
+        imageTokens: 1000,
+        baselineImagedTokens: 4000,
+        nativeInjectedTokens: 100,
+      },
+    } as never);
+
+    const recent = (await dash.serveRecent().json()) as RecentPayload;
+    const row = recent.recent.at(-1)!;
+    expect(row.baseline_input).toBe(4100);
+    expect(row.actual_input).toBe(1200);
+    expect(row.session_saved_so_far_delta).toBe(2900);
+    expect(row.img_id).toBeDefined();
+    const stats = (await dash.serveStats().json()) as StatsPayload;
+    expect(stats.saved_input_tokens).toBe(2900);
+    expect(stats.saved_usd).toBe(0);
+    const header = await (await dash.serveFragment('header', new URL('http://localhost/fragments/header'), 1)).text();
+    expect(header).toContain('provider pricing not configured');
+    expect(header).not.toContain('at $10/M base input price');
+    const html = await (await dash.serveFragment('recent', new URL('http://localhost/fragments/recent'), 1)).text();
+    expect(html).toContain('Details →');
+    const details = await (await dash.serveFragment(
+      'context-map',
+      new URL(`http://localhost/fragments/context-map?req=${row.img_id}`),
+      1,
+    )).text();
+    expect(details).toContain('gemini-3.6-flash');
+    expect(details).toContain('System prompt + tool docs');
   });
 
   it('preserves Gemini cached-token rows during replay', async () => {
@@ -681,6 +726,28 @@ describe('Gemini savings split', () => {
     expect(recent.recent.at(-1)?.cache_read).toBe(40);
     expect(recent.recent.at(-1)?.baseline_input).toBe(400);
     expect(recent.recent.at(-1)?.actual_input).toBe(120);
+  });
+
+  it('replays estimated Gemini savings after an optional probe failure', async () => {
+    writeEvents(tmp, [ev({
+      path: '/google-ai-studio/v1beta/models/gemini-3.6-flash:generateContent',
+      model: 'gemini-3.6-flash',
+      accounting_provider: 'google',
+      compressed: true,
+      input_tokens: 1200,
+      output_tokens: 10,
+      image_tokens: 1000,
+      baseline_imaged_tokens: 4000,
+      native_injected_tokens: 100,
+      baseline_probe_status: 'failed',
+      image_count: 1,
+    })]);
+
+    await dash.replay(tmp.eventsFile);
+    const recent = (await dash.serveRecent().json()) as RecentPayload;
+    expect(recent.recent.at(-1)?.baseline_input).toBe(4100);
+    expect(recent.recent.at(-1)?.actual_input).toBe(1200);
+    expect(recent.recent.at(-1)?.session_saved_so_far_delta).toBe(2900);
   });
 });
 

--- a/tests/google.test.ts
+++ b/tests/google.test.ts
@@ -35,6 +35,10 @@ describe('transformGoogleGenerateContent', () => {
     expect(result.info.imageTokens).toBe(1078 * result.info.imageCount);
     expect(result.info.baselineImagedTokens).toBeGreaterThan(1078);
     expect(result.info.nativeInjectedTokens).toBeGreaterThan(0);
+    expect(result.info.imagePngs).toHaveLength(result.info.imageCount);
+    expect(result.info.imageDims).toHaveLength(result.info.imageCount);
+    expect(result.info.imageSourceTexts).toHaveLength(result.info.imageCount);
+    expect(result.info.firstImagePng).toBe(result.info.imagePngs?.[0]);
 
     const outReq = JSON.parse(new TextDecoder().decode(result.body));
     expect(outReq.systemInstruction.parts[0].text).toContain('same authority and priority');
@@ -42,7 +46,7 @@ describe('transformGoogleGenerateContent', () => {
     expect(outReq.contents[0].parts[0].inlineData.mimeType).toBe('image/png');
   });
 
-  it('defers the profitability decision to the upstream countTokens probes', async () => {
+  it('keeps a short system instruction as text', async () => {
     const sampleBody = {
       systemInstruction: {
         parts: [{ text: 'Short system prompt.' }],
@@ -52,8 +56,183 @@ describe('transformGoogleGenerateContent', () => {
     const bodyBytes = new TextEncoder().encode(JSON.stringify(sampleBody));
     const result = await transformGoogleGenerateContent(bodyBytes, 'gemini-3.6-flash', { compress: true });
 
+    expect(result.info.compressed).toBe(false);
+    expect(result.info.reason).toBe('not_profitable');
+    expect(result.info.gateEval?.profitable).toBe(false);
+    expect(new TextDecoder().decode(result.body)).toBe(JSON.stringify(sampleBody));
+  });
+
+  it('moves Gemini tool descriptions and schema annotations into the static image', async () => {
+    const description = 'Read files with detailed operational guidance. '.repeat(180);
+    const sampleBody = {
+      systemInstruction: {
+        parts: [{ text: 'You are a coding agent. '.repeat(120) }],
+      },
+      tools: [{
+        functionDeclarations: [{
+          name: 'read',
+          description,
+          parameters: {
+            type: 'object',
+            properties: {
+              filePath: { type: 'string', description: 'Absolute file path to read.' },
+            },
+            required: ['filePath'],
+          },
+        }],
+      }],
+      contents: [{ role: 'user', parts: [{ text: 'Read the repository.' }] }],
+    };
+    const result = await transformGoogleGenerateContent(
+      new TextEncoder().encode(JSON.stringify(sampleBody)),
+      'gemini-3.6-flash',
+      { compress: true },
+    );
+
     expect(result.info.compressed).toBe(true);
-    expect(result.info.gateEval?.profitable).toBe(true);
+    expect(result.info.toolDocsChars).toBeGreaterThan(description.length);
+    expect(result.info.imageSourceText).toContain('## Tool: read');
+    expect(result.info.imageSourceText).toContain('Absolute file path to read.');
+    const out = JSON.parse(new TextDecoder().decode(result.body));
+    const tool = out.tools[0].functionDeclarations[0];
+    expect(tool.description).toContain('## Tool: read');
+    expect(tool.description).not.toContain(description.slice(0, 100));
+    expect(tool.parameters.properties.filePath.description).toBeUndefined();
+    expect(tool.parameters.required).toEqual(['filePath']);
+  });
+
+  it('collapses old closed Gemini tool history while keeping the live request and recent tail native', async () => {
+    const contents: Array<Record<string, unknown>> = [
+      { role: 'user', parts: [{ text: 'LIVE TASK: inspect this repository carefully.' }] },
+    ];
+    for (let i = 0; i < 24; i++) {
+      contents.push({
+        role: 'model',
+        parts: [{ functionCall: { name: 'read', args: { filePath: `/tmp/file-${i}.ts` } } }],
+      });
+      contents.push({
+        role: 'user',
+        parts: [{
+          functionResponse: {
+            name: 'read',
+            response: { name: 'read', content: `result-${i} `.repeat(180) },
+          },
+        }],
+      });
+    }
+    const sampleBody = {
+      systemInstruction: { parts: [{ text: 'You are a coding agent. '.repeat(300) }] },
+      contents,
+    };
+    const result = await transformGoogleGenerateContent(
+      new TextEncoder().encode(JSON.stringify(sampleBody)),
+      'gemini-3.6-flash',
+      { compress: true, compressToolResults: false },
+    );
+
+    expect(result.info.compressed).toBe(true);
+    expect(result.info.historyReason).toBe('collapsed');
+    expect(result.info.collapsedImages ?? 0).toBeGreaterThan(0);
+    expect(result.info.imageCount).toBeGreaterThan(1);
+    expect(result.info.baselineImagedTokens ?? 0).toBeGreaterThan(result.info.imageTokens ?? 0);
+    const out = JSON.parse(new TextDecoder().decode(result.body));
+    const serialized = JSON.stringify(out.contents);
+    expect(serialized).toContain('LIVE TASK: inspect this repository carefully.');
+    expect(serialized).toContain('Earlier turns of THIS conversation');
+    expect(serialized).toContain('result-23');
+    expect(serialized).not.toContain('result-0 result-0 result-0');
+  });
+
+  it('collapses completed parallel Gemini function-call rounds', async () => {
+    const contents: Array<Record<string, unknown>> = [
+      { role: 'user', parts: [{ text: 'LIVE TASK: inspect files in parallel.' }] },
+    ];
+    for (let i = 0; i < 12; i++) {
+      contents.push({
+        role: 'model',
+        parts: [
+          { functionCall: { name: `read_left_${i}`, args: { filePath: `/tmp/left-${i}.ts` } } },
+          { functionCall: { name: `read_right_${i}`, args: { filePath: `/tmp/right-${i}.ts` } } },
+        ],
+      });
+      contents.push({
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: `read_right_${i}`,
+              response: { content: `right-result-${i} `.repeat(220) },
+            },
+          },
+          {
+            functionResponse: {
+              name: `read_left_${i}`,
+              response: { content: `left-result-${i} `.repeat(220) },
+            },
+          },
+        ],
+      });
+    }
+    const sampleBody = {
+      systemInstruction: { parts: [{ text: 'You are a coding agent. '.repeat(300) }] },
+      contents,
+    };
+    const result = await transformGoogleGenerateContent(
+      new TextEncoder().encode(JSON.stringify(sampleBody)),
+      'gemini-3.6-flash',
+      { compress: true, compressToolResults: false },
+    );
+
+    expect(result.info.historyReason).toBe('collapsed');
+    expect(result.info.collapsedTurns ?? 0).toBeGreaterThanOrEqual(10);
+    const out = JSON.parse(new TextDecoder().decode(result.body));
+    const serialized = JSON.stringify(out.contents);
+    expect(serialized).toContain('LIVE TASK: inspect files in parallel.');
+    expect(serialized).toContain('Earlier turns of THIS conversation');
+    expect(serialized).not.toContain('left-result-0 left-result-0');
+    expect(serialized).not.toContain('right-result-0 right-result-0');
+    expect(serialized).toContain('left-result-11');
+    expect(serialized).toContain('right-result-11');
+  });
+
+  it('compresses a large completed Gemini function response in place', async () => {
+    const longResult = Array.from(
+      { length: 1200 },
+      (_, i) => `src/file-${i}.ts:${i + 1}: exported value ${i}`,
+    ).join('\n');
+    const sampleBody = {
+      systemInstruction: { parts: [{ text: 'You are a coding agent. '.repeat(300) }] },
+      contents: [
+        { role: 'user', parts: [{ text: 'Inspect the output.' }] },
+        { role: 'model', parts: [{ functionCall: { name: 'search', args: { pattern: 'export' } } }] },
+        {
+          role: 'user',
+          parts: [{
+            functionResponse: {
+              name: 'search',
+              response: { name: 'search', content: longResult },
+            },
+          }],
+        },
+      ],
+    };
+    const result = await transformGoogleGenerateContent(
+      new TextEncoder().encode(JSON.stringify(sampleBody)),
+      'gemini-3.6-flash',
+      { compress: true, collapseHistory: false },
+    );
+
+    expect(result.info.toolResultImgs ?? 0).toBeGreaterThan(0);
+    expect(result.info.imageCount).toBeGreaterThan(1);
+    const toolResultChars = (result.info.bucketChars?.tool_result_log ?? 0)
+      + (result.info.bucketChars?.tool_result_prose ?? 0)
+      + (result.info.bucketChars?.tool_result_json ?? 0);
+    expect(toolResultChars).toBe(longResult.length);
+    const out = JSON.parse(new TextDecoder().decode(result.body));
+    const response = out.contents[2].parts[0].functionResponse;
+    expect(response.response.content).toContain('rendered in the attached image');
+    expect(response.parts[0].inlineData.mimeType).toBe('image/png');
+    expect(JSON.stringify(out)).not.toContain('src/file-1199.ts:1200');
   });
 
   it.each([

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -53,7 +53,7 @@ describe('findClosedPrefixBoundary', () => {
     expect(findClosedPrefixBoundary(msgs, 3)).toBe(2);
   });
 
-  it('returns the last-closed boundary, not the cutoff itself, when there are mid-flight tool_uses', () => {
+  it('keeps an adjacent closed pair with the following mid-flight tool_use', () => {
     const msgs: Message[] = [
       usr('do thing'),
       asst([{ type: 'tool_use', id: 'A', name: 't', input: {} }]),
@@ -62,10 +62,9 @@ describe('findClosedPrefixBoundary', () => {
       asst([{ type: 'tool_use', id: 'B', name: 't', input: {} }]),
       usr('plain text'), // no tool_result for B → B is open
     ];
-    // Cutoff exclusive=5 → scan all 5 messages. After msg 2, openSet={}.
-    // After msg 3, openSet={B}. After msg 4 (plain user, no tool_result),
-    // openSet still {B}. Last closed index = 2.
-    expect(findClosedPrefixBoundary(msgs, 5)).toBe(2);
+    // The closed A pair is immediately followed by B. That shape may be a
+    // serialized parallel round, so only the pre-round user message is safe.
+    expect(findClosedPrefixBoundary(msgs, 5)).toBe(0);
   });
 
   it('handles parallel tool calls in one assistant turn', () => {
@@ -85,6 +84,25 @@ describe('findClosedPrefixBoundary', () => {
     // reverse order — order doesn't matter for openSet). After msg 3: still
     // closed. Last index = 3.
     expect(findClosedPrefixBoundary(msgs, 4)).toBe(3);
+  });
+
+  it('does not split a parallel round serialized as adjacent call/result pairs', () => {
+    const msgs: Message[] = [
+      usr('parallel work'),
+      asst([{ type: 'tool_use', id: 'A', name: 't', input: {} }]),
+      usr([{ type: 'tool_result', tool_use_id: 'A', content: 'a' }]),
+      asst([{ type: 'tool_use', id: 'B', name: 't', input: {} }]),
+      usr([{ type: 'tool_result', tool_use_id: 'B', content: 'b' }]),
+      asst('done'),
+    ];
+
+    // Although A is closed at index 2, index 3 continues the same serialized
+    // parallel round. The only safe prefix before a cutoff there is index 0.
+    expect(findClosedPrefixBoundary(msgs, 3)).toBe(0);
+    expect(findClosedPrefixBoundary(msgs, 4)).toBe(0);
+    // Once B is answered, the complete round may be collapsed.
+    expect(findClosedPrefixBoundary(msgs, 5)).toBe(4);
+    expect(findClosedPrefixBoundary(msgs, 6)).toBe(5);
   });
 
   it('returns -1 when the very first message opens a tool_use that never closes', () => {

--- a/tests/openai-gpt5.test.ts
+++ b/tests/openai-gpt5.test.ts
@@ -115,8 +115,8 @@ describe('visionTokensForModel (Claude on the Responses path)', () => {
 const BIG_SYSTEM = 'System instruction with lots of detail. '.repeat(500); // ~20k chars
 const BIG_TOOL_DESC = 'Tool description with lots of context. '.repeat(200); // ~8k chars
 const CHAT_TOOL_PARAMS = { type: 'object', description: 'Param root.', properties: { x: { type: 'string', description: 'x param' } } };
-const CHAT_TOOL_DOC = '## Tool parameter annotations: do_thing\n' +
-  '$ description: "Param root."\n$.x description: "x param"';
+const CHAT_TOOL_DOC = '## Tool: do_thing\n' + BIG_TOOL_DESC +
+  '\n$ description: "Param root."\n$.x description: "x param"';
 
 // Real `task`/`question` tools have a required parameter literally NAMED `description`
 // (others collide with `title`/`default`). The strip must drop the annotation but KEEP
@@ -179,13 +179,13 @@ describe('transformOpenAIChatCompletions (gpt-5.6-sol)', () => {
       ? sysMsg.content
       : (sysMsg.content as Array<{ text?: string }>)[0]?.text ?? '').toContain('rendered into image');
 
-    // Tool selection stays native; verbose schema prose moved into the image.
+    // Tool selection stays native; verbose description/schema prose moved into the image.
     const tools = out.tools as Array<{ function: { description?: string; parameters?: { description?: string; properties?: { x?: { description?: string } } } } }>;
-    expect(tools[0]!.function.description).toBe(BIG_TOOL_DESC);
+    expect(tools[0]!.function.description).toContain('## Tool: do_thing');
     expect(tools[0]!.function.parameters?.description).toBeUndefined();
     expect(tools[0]!.function.parameters?.properties?.x?.description).toBeUndefined();
     expect(result.info.imageSourceText).toContain('$.x description: "x param"');
-    expect(result.info.imageSourceText).not.toContain(BIG_TOOL_DESC.slice(0, 100));
+    expect(result.info.imageSourceText).toContain(BIG_TOOL_DESC.slice(0, 100));
     expect(result.info.imageSourceText).not.toContain('"properties"');
     expect(result.info.imageSourceText).not.toContain('full tool');
     expect(result.info.imageSourceText).toContain('native JSON tool definitions');
@@ -219,7 +219,7 @@ describe('transformOpenAIChatCompletions (gpt-5.6-sol)', () => {
     expect(source).not.toMatch(/↵$/);
   });
 
-  it('does not image duplicated native tool structure without instruction context', async () => {
+  it('compresses tool descriptions without separate instruction context', async () => {
     const body = enc.encode(JSON.stringify({
       model: 'gpt-5.6-sol',
       messages: [{ role: 'user', content: 'hello' }],
@@ -234,12 +234,12 @@ describe('transformOpenAIChatCompletions (gpt-5.6-sol)', () => {
     }));
 
     const result = await transformOpenAIChatCompletions(body, { charsPerToken: 1, minCompressChars: 1 });
-    expect(result.info.compressed).toBe(false);
+    expect(result.info.compressed).toBe(true);
     expect(result.info.origChars).toBe(CHAT_TOOL_DOC.length);
-    expect(result.info.compressedChars).toBe(0);
+    expect(result.info.compressedChars).toBe(CHAT_TOOL_DOC.length);
     const out = JSON.parse(dec.decode(result.body)) as any;
-    expect(out.tools[0].function.description).toBe(BIG_TOOL_DESC);
-    expect(out.tools[0].function.parameters.description).toBe('Param root.');
+    expect(out.tools[0].function.description).toContain('## Tool: do_thing');
+    expect(out.tools[0].function.parameters.description).toBeUndefined();
   });
 
   it('keeps a parameter literally named "description" (task-tool regression)', async () => {
@@ -253,7 +253,7 @@ describe('transformOpenAIChatCompletions (gpt-5.6-sol)', () => {
     }));
 
     const result = await transformOpenAIChatCompletions(body, { charsPerToken: 1, minCompressChars: 1 });
-    expect(result.info.compressed).toBe(false);
+    expect(result.info.compressed).toBe(true);
     const out = JSON.parse(dec.decode(result.body)) as any;
     const params = out.tools[0].function.parameters;
     // Property NAMES survive — including ones that collide with annotation keywords.
@@ -261,10 +261,10 @@ describe('transformOpenAIChatCompletions (gpt-5.6-sol)', () => {
     // `required` still points at real, present properties (this is what GPT failed before).
     expect(params.required).toEqual(['description', 'prompt']);
     for (const name of params.required) expect(params.properties[name]).toBeDefined();
-    // The annotation-only image was not profitable, so the original schema is untouched.
+    // The property contract remains even though annotations moved into the image.
     expect(params.properties.description.type).toBe('string');
-    expect(params.properties.description.description).toBeDefined();
-    expect(params.properties.title.description).toBeDefined();
+    expect(params.properties.description.description).toBeUndefined();
+    expect(params.properties.title.description).toBeUndefined();
   });
 
   it('returns compressed=false with not_profitable reason for small input', async () => {
@@ -287,8 +287,8 @@ describe('transformOpenAIChatCompletions (gpt-5.6-sol)', () => {
 const BIG_INSTRUCTIONS = 'These are detailed instructions. '.repeat(600); // ~20k chars
 const BIG_FLAT_TOOL_DESC = 'Flat tool description with lots of context. '.repeat(200); // ~8k chars
 const RESPONSES_TOOL_PARAMS = { type: 'object', description: 'Param root.', properties: { x: { type: 'string', description: 'x param' } } };
-const RESPONSES_TOOL_DOC = '## Tool parameter annotations: do_thing\n' +
-  '$ description: "Param root."\n$.x description: "x param"';
+const RESPONSES_TOOL_DOC = '## Tool: do_thing\n' + BIG_FLAT_TOOL_DESC +
+  '\n$ description: "Param root."\n$.x description: "x param"';
 
 describe('transformOpenAIResponses (gpt-5.6-sol)', () => {
   it('records original Responses composition with local o200k buckets', async () => {
@@ -355,12 +355,12 @@ describe('transformOpenAIResponses (gpt-5.6-sol)', () => {
     expect(parts[0]!.type).toBe('input_image');
     expect(parts[0]!.image_url).toMatch(/^data:image\/png;base64,/);
 
-    // Tool selection stays native; verbose schema prose moved into the image.
+    // Tool selection stays native; verbose description/schema prose moved into the image.
     const tools = out.tools as Array<{ description?: string; parameters?: { description?: string; properties?: { x?: { description?: string } } } }>;
-    expect(tools[0]!.description).toBe(BIG_FLAT_TOOL_DESC);
+    expect(tools[0]!.description).toContain('## Tool: do_thing');
     expect(tools[0]!.parameters?.description).toBeUndefined();
     expect(tools[0]!.parameters?.properties?.x?.description).toBeUndefined();
-    expect(result.info.imageSourceText).not.toContain('full tool');
+    expect(result.info.imageSourceText).toContain(BIG_FLAT_TOOL_DESC.slice(0, 100));
     expect(result.info.imageSourceText).toContain('native JSON tool definitions');
     expect(result.info.imageSourceText).toContain('name and description');
   });
@@ -417,7 +417,7 @@ describe('transformOpenAIResponses (gpt-5.6-sol)', () => {
     expect(JSON.stringify(dev.content)).not.toContain('These are detailed');
   });
 
-  it('does not image duplicated native Responses tool structure without instructions', async () => {
+  it('compresses Responses tool descriptions without separate instructions', async () => {
     const body = enc.encode(JSON.stringify({
       model: 'gpt-5.6-sol',
       input: [{ role: 'user', content: 'Please do the thing.' }],
@@ -430,12 +430,12 @@ describe('transformOpenAIResponses (gpt-5.6-sol)', () => {
     }));
 
     const result = await transformOpenAIResponses(body, { charsPerToken: 1, minCompressChars: 1 });
-    expect(result.info.compressed).toBe(false);
+    expect(result.info.compressed).toBe(true);
     expect(result.info.origChars).toBe(RESPONSES_TOOL_DOC.length);
-    expect(result.info.compressedChars).toBe(0);
+    expect(result.info.compressedChars).toBe(RESPONSES_TOOL_DOC.length);
     const out = JSON.parse(dec.decode(result.body)) as any;
-    expect(out.tools[0].description).toBe(BIG_FLAT_TOOL_DESC);
-    expect(out.tools[0].parameters.description).toBe('Param root.');
+    expect(out.tools[0].description).toContain('## Tool: do_thing');
+    expect(out.tools[0].parameters.description).toBeUndefined();
   });
 
   it('keeps a parameter literally named "description" (task-tool regression)', async () => {
@@ -446,14 +446,14 @@ describe('transformOpenAIResponses (gpt-5.6-sol)', () => {
     }));
 
     const result = await transformOpenAIResponses(body, { charsPerToken: 1, minCompressChars: 1 });
-    expect(result.info.compressed).toBe(false);
+    expect(result.info.compressed).toBe(true);
     const out = JSON.parse(dec.decode(result.body)) as any;
     const params = out.tools[0].parameters;
     expect(Object.keys(params.properties).sort()).toEqual(['description', 'prompt', 'title']);
     expect(params.required).toEqual(['description', 'prompt']);
     for (const name of params.required) expect(params.properties[name]).toBeDefined();
     expect(params.properties.description.type).toBe('string');
-    expect(params.properties.description.description).toBeDefined();
+    expect(params.properties.description.description).toBeUndefined();
   });
 
   it('handles bare string input (wraps into user item with images)', async () => {

--- a/tests/openai-history.test.ts
+++ b/tests/openai-history.test.ts
@@ -453,6 +453,59 @@ describe('planResponsesPairCollapse — native state classification', () => {
     expect(plan.pairState.malformedItems).toBe(2);
   });
 
+  it('collapses OpenCode parallel call/output rounds atomically', async () => {
+    const items: Array<Record<string, unknown>> = [];
+    for (let round = 0; round < 6; round++) {
+      for (let call = 0; call < 4; call++) {
+        const id = `round_${round}_${call}`;
+        items.push({
+          type: 'function_call', id: `fc_${id}`, call_id: id,
+          name: 'read', arguments: `{"path":"${id}"}`,
+        });
+      }
+      for (let call = 0; call < 4; call++) {
+        const id = `round_${round}_${call}`;
+        items.push({
+          type: 'function_call_output', call_id: id,
+          output: `${id} ${'large output '.repeat(300)}`,
+        });
+      }
+    }
+    const plan = await planResponsesPairCollapse(items, yes, {
+      responsesMode: 'mixed', keepRecentPairs: 4,
+      minCollapseTokens: 1, maxImages: 100,
+    });
+    expect(plan.pairState).toMatchObject({
+      completedPairs: 24,
+      oldCompletedPairs: 20,
+      recentCompletedPairs: 4,
+      malformedItems: 0,
+      collapsedPairs: 20,
+    });
+    const selected = new Set(plan.selectedIndices);
+    for (let round = 0; round < 6; round++) {
+      const roundIndices = Array.from({ length: 8 }, (_, i) => round * 8 + i);
+      const selectedCount = roundIndices.filter((i) => selected.has(i)).length;
+      expect([0, 8]).toContain(selectedCount);
+    }
+    expect(plan.pairState.collapsedFunctionOutputTokens).toBeGreaterThan(0);
+  });
+
+  it('keeps an incomplete parallel round entirely native', async () => {
+    const items: Array<Record<string, unknown>> = [
+      { type: 'function_call', call_id: 'a', name: 'read', arguments: '{}' },
+      { type: 'function_call', call_id: 'b', name: 'read', arguments: '{}' },
+      { type: 'function_call_output', call_id: 'a', output: 'a result' },
+    ];
+    const plan = await planResponsesPairCollapse(items, yes, {
+      responsesMode: 'mixed', keepRecentPairs: 0,
+      minCollapseTokens: 1, maxImages: 100,
+    });
+    expect(plan.selectedIndices).toEqual([]);
+    expect(plan.pairState.openCalls).toBe(1);
+    expect(plan.pairState.malformedItems).toBe(2);
+  });
+
   it('keeps orphan, duplicate, reversed, and missing-id items native', async () => {
     const items: Array<Record<string, unknown>> = [];
     for (let i = 0; i < 12; i++) items.push(...pair(`good_${i}`));

--- a/tests/proxy-usage.test.ts
+++ b/tests/proxy-usage.test.ts
@@ -184,7 +184,7 @@ describe('proxy usage extraction', () => {
     expect(captured?.info?.baselineProbeStatus).toBe('ok');
   });
 
-  it('passes Gemini through when countTokens fails', async () => {
+  it('keeps Gemini compression when optional countTokens measurement fails', async () => {
     const forwardedBodies: string[] = [];
     const restore = mockUpstream(async (req) => {
       if (req.url.includes(':countTokens')) return new Response('no', { status: 503 });
@@ -212,9 +212,10 @@ describe('proxy usage extraction', () => {
     await new Promise((resolve) => setTimeout(resolve, 20));
     restore();
 
-    expect(forwardedBodies).toEqual([body]);
-    expect(captured?.info?.compressed).toBe(false);
-    expect(captured?.info?.reason).toBe('baseline_probe_failed');
+    expect(forwardedBodies).toHaveLength(1);
+    expect(forwardedBodies[0]).toContain('inlineData');
+    expect(captured?.info?.compressed).toBe(true);
+    expect(captured?.info?.reason).toBeUndefined();
     expect(captured?.info?.baselineProbeStatus).toBe('failed');
   });
 

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -379,7 +379,7 @@ describe('public library API', () => {
     expect(firstUser.content[0].type).toBe('image_url');
     expect(firstUser.content[0].image_url.url).toMatch(/^data:image\/png;base64,/);
     expect(out.messages[0].content).toContain('rendered into image');
-    expect(out.tools[0].function.description).toBe('Read a file from disk. '.repeat(100));
+    expect(out.tools[0].function.description).toBe('Full docs: see "## Tool: read_file" in the rendered context image.');
     expect(out.tools[0].function.parameters.description).toBeUndefined();
     expect(out.tools[0].function.parameters.properties.path.description).toBeUndefined();
     expect(JSON.stringify(out)).not.toContain('cache_control');


### PR DESCRIPTION
Compresses completed tool-call history, including parallel calls, for Gemini and OpenAI/Responses paths while preserving live/recent tool protocol state.

- Recognizes completed parallel function call/response rounds atomically
- Expands Gemini tool-result and history context compression with profitability gates
- Updates token-savings metrics and dashboard accounting without applying Claude rates across non-Anthropic providers
- Adds comprehensive test coverage across Gemini, Chat Completions, and Responses

Validation: 45 test files, 840 tests passing; tsc --noEmit and build clean.