### PR TITLE
Add Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Deny by default so local credentials and untracked files never enter the
+# builder context. Re-include only inputs used by the Dockerfile.
+**
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!tsconfig.json
+!LICENSE
+!assets/
+!assets/*LICENSE.txt
+!bin/
+!bin/**
+!scripts/
+!scripts/build.mjs
+!src/
+!src/**

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: teamchong

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: read
+  contents: write # create the GitHub Release for the pushed tag
   id-token: write # npm provenance / trusted publishing
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
@@ -35,8 +35,14 @@ jobs:
           fi
       # prepublishOnly runs typecheck + tests + build as the gate
       # Auth via npm Trusted Publisher (OIDC) - no token needed.
-      # Requires npm >= 11.5; Node 22 ships older, so upgrade npm first.
+      # Requires npm >= 11.5; upgrade explicitly to avoid relying on the bundled version.
       - if: steps.check.outputs.skip == 'false'
         run: |
           npm install -g npm@latest
           npm publish --access public --provenance
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
+            gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS build
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+
+RUN corepack enable
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY bin ./bin
+COPY scripts ./scripts
+COPY src ./src
+COPY tsconfig.json ./
+
+RUN pnpm run build
+
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS runtime
+
+LABEL org.opencontainers.image.source="https://github.com/teamchong/pxpipe" \
+      org.opencontainers.image.description="Token-saving proxy for vision-capable LLMs" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=47821
+ENV PXPIPE_CONFIG=/data/config.json
+ENV PXPIPE_LOG=/data/events.jsonl
+
+WORKDIR /app
+
+COPY --from=build --chown=node:node /app/dist/node.js ./dist/node.js
+COPY --chown=node:node LICENSE ./licenses/LICENSE
+COPY --chown=node:node assets/*LICENSE.txt ./licenses/
+
+RUN mkdir /data && chown node:node /data
+
+USER node
+
+EXPOSE 47821
+VOLUME ["/data"]
+
+HEALTHCHECK --interval=5s --timeout=2s --start-period=2s --retries=3 \
+  CMD node -e "const s=require('node:net').connect(process.env.PORT,'127.0.0.1');s.setTimeout(1500);s.on('connect',()=>{s.destroy();process.exit(0)});s.on('timeout',()=>process.exit(1));s.on('error',()=>process.exit(1))"
+
+CMD ["node", "dist/node.js"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,35 @@
+services:
+  pxpipe:
+    build:
+      context: .
+    restart: unless-stopped
+    init: true
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - "127.0.0.1:${PXPIPE_PORT:-47821}:47821"
+    environment:
+      - PXPIPE_MODELS
+      - PXPIPE_DISABLE
+      - PXPIPE_UPSTREAM
+      - ANTHROPIC_UPSTREAM
+      - OPENAI_UPSTREAM
+      - OPENAI_API_KEY
+      - OPENAI_MODELS
+      - CLOUDFLARE_MODELS
+      - CLOUDFLARE_ACCOUNT_ID
+      - CLOUDFLARE_API_TOKEN
+      - PXPIPE_PROVIDER
+      - PXPIPE_GATEWAY_BASE_URL
+      - PXPIPE_GATEWAY_HEADERS
+      - PXPIPE_GPT_PROFILES
+      - PXPIPE_DUMP_DIR
+      - PXPIPE_DEBUG_CAPTURE_4XX
+    volumes:
+      - pxpipe-data:/data
+
+volumes:
+  pxpipe-data:


### PR DESCRIPTION
Adds a hardened Docker and Compose deployment.

Before:
- npm-only runtime
- tag workflow published npm only

After:
- non-root Node 24 Alpine container
- loopback-only Compose service with persistent `/data`
- tag workflow creates GitHub Releases
- GitHub Sponsors link

Closes #130