### PR TITLE
feat: add Claude Opus 5 as validated opt-in vision reader

### DIFF
--- a/eval/opus-density/results.json
+++ b/eval/opus-density/results.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-05T10:23:38.073Z",
+  "generatedAt": "2026-07-25T14:04:54.558Z",
   "textTokens": 1335,
   "variants": [
     {
@@ -11,6 +11,96 @@
       "imageTokens": 280,
       "savingsPct": 79,
       "models": {
+        "claude-opus-5": {
+          "exactCorrect": 3,
+          "exactTotal": 4,
+          "confab": 1,
+          "abstain": 1,
+          "refused": 0,
+          "refusalCat": null,
+          "gistOk": true,
+          "guardOk": true,
+          "answers": [
+            {
+              "id": "hex",
+              "kind": "exact",
+              "expected": "a3f9c1e0b7d2",
+              "got": "`a3f9c1e0b7d2`",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 4375
+            },
+            {
+              "id": "camel",
+              "kind": "exact",
+              "expected": "tokenLedgerShard",
+              "got": "`tokenLedgerShard`",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 4682
+            },
+            {
+              "id": "path",
+              "kind": "exact",
+              "expected": "src/core/anthropic-vision.ts",
+              "got": "`src/core/anthropic-vision.ts`",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 3669
+            },
+            {
+              "id": "port",
+              "kind": "exact",
+              "expected": "47821",
+              "got": "",
+              "stop": "max_tokens",
+              "cat": null,
+              "ok": false,
+              "abstained": false,
+              "confab": true,
+              "refused": false,
+              "ms": 9961
+            },
+            {
+              "id": "gist",
+              "kind": "gist",
+              "expected": "3",
+              "got": "**3**",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 4720
+            },
+            {
+              "id": "guard",
+              "kind": "guard",
+              "expected": "NOT STATED",
+              "got": "NOT STATED",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": true,
+              "confab": false,
+              "refused": false,
+              "ms": 4194
+            }
+          ]
+        },
         "claude-opus-4-8": {
           "exactCorrect": 1,
           "exactTotal": 4,
@@ -202,6 +292,96 @@
       "imageTokens": 504,
       "savingsPct": 62,
       "models": {
+        "claude-opus-5": {
+          "exactCorrect": 3,
+          "exactTotal": 4,
+          "confab": 0,
+          "abstain": 1,
+          "refused": 1,
+          "refusalCat": "cyber",
+          "gistOk": true,
+          "guardOk": true,
+          "answers": [
+            {
+              "id": "hex",
+              "kind": "exact",
+              "expected": "a3f9c1e0b7d2",
+              "got": "",
+              "stop": "refusal",
+              "cat": "cyber",
+              "ok": false,
+              "abstained": false,
+              "confab": false,
+              "refused": true,
+              "ms": 1488
+            },
+            {
+              "id": "camel",
+              "kind": "exact",
+              "expected": "tokenLedgerShard",
+              "got": "tokenLedgerShard",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 3477
+            },
+            {
+              "id": "path",
+              "kind": "exact",
+              "expected": "src/core/anthropic-vision.ts",
+              "got": "`src/core/anthropic-vision.ts`",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 3939
+            },
+            {
+              "id": "port",
+              "kind": "exact",
+              "expected": "47821",
+              "got": "47821",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 3008
+            },
+            {
+              "id": "gist",
+              "kind": "gist",
+              "expected": "3",
+              "got": "3",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 2937
+            },
+            {
+              "id": "guard",
+              "kind": "guard",
+              "expected": "NOT STATED",
+              "got": "NOT STATED",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": true,
+              "confab": false,
+              "refused": false,
+              "ms": 2976
+            }
+          ]
+        },
         "claude-opus-4-8": {
           "exactCorrect": 3,
           "exactTotal": 4,
@@ -393,6 +573,96 @@
       "imageTokens": 728,
       "savingsPct": 45,
       "models": {
+        "claude-opus-5": {
+          "exactCorrect": 4,
+          "exactTotal": 4,
+          "confab": 0,
+          "abstain": 1,
+          "refused": 0,
+          "refusalCat": null,
+          "gistOk": true,
+          "guardOk": true,
+          "answers": [
+            {
+              "id": "hex",
+              "kind": "exact",
+              "expected": "a3f9c1e0b7d2",
+              "got": "`a3f9c1e0b7d2`",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 2899
+            },
+            {
+              "id": "camel",
+              "kind": "exact",
+              "expected": "tokenLedgerShard",
+              "got": "`tokenLedgerShard`",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 5323
+            },
+            {
+              "id": "path",
+              "kind": "exact",
+              "expected": "src/core/anthropic-vision.ts",
+              "got": "src/core/anthropic-vision.ts",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 4126
+            },
+            {
+              "id": "port",
+              "kind": "exact",
+              "expected": "47821",
+              "got": "47821",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 3787
+            },
+            {
+              "id": "gist",
+              "kind": "gist",
+              "expected": "3",
+              "got": "3",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": false,
+              "confab": false,
+              "refused": false,
+              "ms": 3050
+            },
+            {
+              "id": "guard",
+              "kind": "guard",
+              "expected": "NOT STATED",
+              "got": "NOT STATED",
+              "stop": "end_turn",
+              "cat": null,
+              "ok": true,
+              "abstained": true,
+              "confab": false,
+              "refused": false,
+              "ms": 3099
+            }
+          ]
+        },
         "claude-opus-4-8": {
           "exactCorrect": 4,
           "exactTotal": 4,

--- a/eval/opus-density/run.mjs
+++ b/eval/opus-density/run.mjs
@@ -52,7 +52,12 @@ const VARIANTS = [
   { name: '7x10', style: { cellWBonus: 2, cellHBonus: 2, aa: true }, cols: colsFor(2) },
   { name: '9x12', style: { cellWBonus: 4, cellHBonus: 4, aa: true }, cols: colsFor(4) },
 ];
-const MODELS = ['claude-opus-4-8', 'claude-fable-5'];
+// Override the model sweep without editing the harness, e.g. to profile a new
+// release against the Fable reference reader:
+//   PXPIPE_EVAL_MODELS=claude-opus-5,claude-fable-5 pnpm exec tsx eval/opus-density/run.mjs
+// Default unchanged so the committed Opus 4.8 receipts stay reproducible.
+const MODELS = (process.env.PXPIPE_EVAL_MODELS ?? 'claude-opus-4-8,claude-fable-5')
+  .split(',').map((s) => s.trim()).filter(Boolean);
 
 const TEXT_TOKENS = Math.ceil(SESSION.length / 3.5); // rough Claude-Code-dense baseline
 

--- a/src/core/anthropic-vision.ts
+++ b/src/core/anthropic-vision.ts
@@ -32,6 +32,7 @@ export interface AnthropicVisionProfile {
 const HIGH_RES_BASES = [
   'claude-fable-5',
   'claude-mythos-5',
+  'claude-opus-5',
   'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-sonnet-5',

--- a/src/dashboard/fragments.ts
+++ b/src/dashboard/fragments.ts
@@ -78,6 +78,7 @@ export function renderToggleFragment(enabled: boolean): string {
 /** Chip catalog — UNION with env scope + active set, so env-var models stay toggleable. Labels are cosmetic. */
 const MODEL_CATALOG: ReadonlyArray<{ id: string; label: string }> = [
   { id: 'claude-fable-5', label: 'Fable 5' },
+  { id: 'claude-opus-5', label: 'Opus 5' },
   { id: 'claude-opus-4-8', label: 'Opus 4.8' },
   { id: 'claude-opus-4-7', label: 'Opus 4.7' },
   { id: 'claude-sonnet-5', label: 'Sonnet 5' },

--- a/tests/anthropic-vision.test.ts
+++ b/tests/anthropic-vision.test.ts
@@ -24,12 +24,13 @@ describe('patchTokens — raw 28-px patch count', () => {
 
 describe('anthropicVisionProfile — tier by model', () => {
   it('puts the documented high-res models on the 2576/4784 tier', () => {
-    for (const m of ['claude-fable-5', 'claude-mythos-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-sonnet-5']) {
+    for (const m of ['claude-fable-5', 'claude-mythos-5', 'claude-opus-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-sonnet-5']) {
       expect(anthropicVisionProfile(m).tier).toBe('high-res');
     }
     // aliases / variant tags tier with their base
     expect(anthropicVisionProfile('claude-fable-5-high').tier).toBe('high-res');
     expect(anthropicVisionProfile('claude-opus-4-8[1m]').tier).toBe('high-res');
+    expect(anthropicVisionProfile('claude-opus-5[1m]').tier).toBe('high-res');
     expect(anthropicVisionProfile('claude-fable-5')).toEqual({ tier: 'high-res', maxLongEdge: 2576, maxVisualTokens: 4784 });
   });
 


### PR DESCRIPTION
## What

- Add `claude-opus-5` to `HIGH_RES_BASES` in `src/core/anthropic-vision.ts` so it gets the high-res vision profile (2576 long edge / 4784 visual tokens), including variant tags (`claude-opus-5[1m]`)
- Test coverage for both the bare model id and the variant tag in `tests/anthropic-vision.test.ts`
- "Opus 5" chip in the dashboard model catalog (`src/dashboard/fragments.ts`)
- Make the opus-density harness model sweep configurable via `PXPIPE_EVAL_MODELS` (default unchanged: `claude-opus-4-8,claude-fable-5`, so the committed receipts stay reproducible)
- Commit Opus 5 receipts to `eval/opus-density/results.json` (purely additive; existing Fable 5 / Opus 4.8 entries untouched)

## Why

Opus 5 reads pxpipe-rendered pages well enough to be a supported opt-in reader, on the same evidence bar previously applied to `opus-4-8`.

## Receipts

Measured with the existing opus-density harness - same pages, geometry, and probes as the committed receipts; text baseline 1335 tok:

| density | tokens saved | exact recall | confab | refused         |
| ------- | ------------ | ------------ | ------ | --------------- |
| 5x8     | 79%          | 3/4          | 1      | 0               |
| 7x10    | 62%          | 3/4          | 0      | 1 (cyber probe) |
| 9x12    | 45%          | 4/4          | 0      | 0               |

Zero confabulations at 7x10/9x12 with the best exact-recall in the current table. The single 5x8 confab (n=4) is why this PR does **not** add Opus 5 to `DEFAULT_MODEL_BASES` - same opt-in bar as `opus-4-8`.

Reproduce:

```bash
PXPIPE_EVAL_MODELS=claude-opus-5,claude-fable-5 pnpm exec tsx eval/opus-density/run.mjs
```

## Notes

- No behavior change for anyone not explicitly targeting `claude-opus-5`
- Tests + typecheck pass locally (51/51)