### PR TITLE
Recognize gateway-routed models in telemetry and render scope

### DIFF
--- a/docs/MODEL_RENDER_PROFILES.md
+++ b/docs/MODEL_RENDER_PROFILES.md
@@ -4,6 +4,16 @@ The endpoint is a wire protocol, not a rendering profile. Claude, GPT, and Grok
 can all arrive on `/v1/responses`; pxpipe resolves geometry and vision billing
 from the model id.
 
+A gateway may prefix that wire path with one routing segment and may qualify the
+model id with vendor segments. Both are recognized: `/compat/chat/completions`
+and `/grok/v1/responses` are read as the OpenAI shapes they are (one leading
+path segment is stripped), and the profile lookup tries the full id then its
+bare final segment, so `moonshotai/kimi-k3` and
+`workers-ai/@cf/moonshotai/kimi-k3` both resolve the same as `kimi-k3` — vendor
+segments pick an upstream, not a
+geometry. Prefix recognition does not move routing — a provider-prefixed path
+still forwards to the passthrough upstream.
+
 | model rule | default | cell | columns | max height | evidence |
 |---|:---:|---|---:|---:|---|
 | `claude-*` / `anthropic-*` | yes | Spleen 5×8 | 312 | 728 px | established Claude suites |
@@ -53,3 +63,43 @@ PXPIPE_GPT_PROFILES='{"gpt-5.6-sol":{"stripCols":120}}'
 
 The profitability gate uses the same resolved profile as the renderer, so a
 style or geometry override cannot leave cost prediction on stale dimensions.
+
+## Unmeasured families
+
+An id that names a family pxpipe HAS measured, but does not match any of that
+family's profiles — an unmeasured Gemini or Grok sibling — is refused by
+`isMisresolvedModelId`, and the request passes through as text. Such an id would
+otherwise fall through to `DEFAULT_GPT_PROFILE` and be gated with OpenAI's tile
+math, i.e. priced with the wrong provider's formula.
+
+An id that names no known family at all (anything reached through a gateway's
+OpenAI-compatible route — Kimi K3 on Cloudflare is the example this repo has
+run) is NOT refused. It resolves to
+`DEFAULT_GPT_PROFILE` and is gated with OpenAI's tile math as an approximation.
+`PXPIPE_MODELS` is the only gate: listing such a model is the operator asserting
+it is worth imaging. Two consequences worth stating plainly:
+
+- The savings figure is an approximation, not a measurement. If tile math
+  overstates the model's real image cost, the gate declines transforms that
+  would have paid off; if it understates, you take a small loss.
+- Nothing checks that the model can accept images at all. A text-only model
+  will reject an imaged request outright — a 400 on the first compressed call,
+  not a silent degradation.
+
+To replace the approximation with real numbers, declare the geometry and vision
+cost yourself:
+
+```bash
+PXPIPE_MODELS=claude-fable-5,kimi-k3
+PXPIPE_GPT_PROFILES='{"kimi-k3":{"vision":{"regime":"mpix","tokensPerMegapixel":1000},"stripCols":152,"maxHeightPx":1932}}'
+```
+
+The `tokensPerMegapixel` above is a **placeholder, not a measurement** — read
+the real image-token rule off your provider's billing docs, or measure it by
+sending one known-size image and reading the reported input tokens. A wrong
+number here does not corrupt output; it corrupts the profitability gate and the
+dashboard's savings figure, which is worse, because both will look confident.
+
+Declaring a cost says nothing about whether the model can *read* dense imaged
+text. Verify that separately before trusting a compressed session — see
+[eval/](../eval) for the harnesses used on the shipped profiles.

--- a/src/core/applicability.ts
+++ b/src/core/applicability.ts
@@ -78,6 +78,19 @@ export function setAllowedModelBases(list: readonly string[] | null): void {
   runtimeModelBases = list === null ? null : list.map((s) => s.trim()).filter(Boolean);
 }
 
+/** Gateways qualify ids with routing segments:
+ *
+ *    google/gemini-3.6-flash
+ *    workers-ai/@cf/moonshotai/kimi-k3
+ *
+ *  The vendor picks the upstream, not the reader, so scope matching also
+ *  compares the segment after the last slash. Otherwise PXPIPE_MODELS entries
+ *  never match behind a gateway. */
+function unqualifiedModelId(base: string): string | null {
+  const slash = base.lastIndexOf('/');
+  return slash >= 0 ? base.slice(slash + 1) : null;
+}
+
 /** Membership test against the single allowed scope. Matches exact base or `-suffix`
  *  alias; [variant] tags stripped first. */
 function isAllowed(model: string | null | undefined): boolean {
@@ -87,9 +100,11 @@ function isAllowed(model: string | null | undefined): boolean {
   // (e.g. an unmeasured Gemini sibling falling through to the OpenAI fallback).
   // Which ids those are is profile-table knowledge, not a rule maintained here.
   if (isMisresolvedModelId(base)) return false;
+  const unqualified = unqualifiedModelId(base);
   return allowedModelBases().some((b) => {
     const target = b.toLowerCase();
-    return base === target || base.startsWith(`${target}-`) || base === `google/${target}`;
+    const hit = (id: string): boolean => id === target || id.startsWith(`${target}-`);
+    return hit(base) || (unqualified !== null && hit(unqualified));
   });
 }
 

--- a/src/core/gpt-model-profiles.ts
+++ b/src/core/gpt-model-profiles.ts
@@ -318,6 +318,17 @@ const FAMILY_ID_GUARDS: ReadonlyArray<{ mentions: RegExp; matches: (m: string) =
   { mentions: /grok/, matches: isGrokModel },
 ];
 
+/** True when the operator declared this id in PXPIPE_GPT_PROFILES. The guards
+ *  above catch implicit fallback to another provider's formula; an explicit
+ *  declaration supplies geometry and vision cost, so it clears them. */
+function hasDeclaredProfile(m: string): boolean {
+  const env = envProfiles();
+  if (env.size === 0) return false;
+  const ids = candidateIds(m);
+  for (const k of env.keys()) if (ids.some((id) => id.startsWith(k))) return true;
+  return false;
+}
+
 /**
  * True when an id NAMES a known provider family but does not match that
  * family's profile test — for example `gemini-3.6-pro`, when 3.6 Flash is the
@@ -332,7 +343,14 @@ const FAMILY_ID_GUARDS: ReadonlyArray<{ mentions: RegExp; matches: (m: string) =
  */
 export function isMisresolvedModelId(model: string | null | undefined): boolean {
   const m = (model ?? '').toLowerCase();
-  return FAMILY_ID_GUARDS.some((g) => g.mentions.test(m) && !g.matches(m));
+  if (hasDeclaredProfile(m)) return false;
+  // Must cover every spelling resolveGptProfile() tries, or guard and resolver
+  // disagree: `openrouter/gemini-3.6-flash` resolves to the measured Gemini
+  // profile via its unqualified id, so it must not be refused here.
+  const ids = candidateIds(m);
+  return FAMILY_ID_GUARDS.some(
+    (g) => ids.some((id) => g.mentions.test(id)) && !ids.some((id) => g.matches(id)),
+  );
 }
 
 function resolveBuiltin(m: string): GptModelProfile {
@@ -492,22 +510,38 @@ function envProfiles(): Map<string, GptModelProfile> {
   return envMap;
 }
 
+/** Vendor segments select an upstream, not a geometry, so both spellings of an
+ *  id must resolve to one profile — otherwise `moonshotai/kimi-k3` skips its measured
+ *  entry and lands on DEFAULT_GPT_PROFILE's OpenAI tile math. Mirrors
+ *  unqualifiedModelId() in applicability.ts. */
+function candidateIds(m: string): string[] {
+  const slash = m.lastIndexOf('/');
+  return slash >= 0 ? [m, m.slice(slash + 1)] : [m];
+}
+
 export function resolveGptProfile(model: string | null | undefined): GptModelProfile {
   // Match applicability.ts: bracketed transport variants (for example [1m])
   // do not define a different visual reader profile.
   const m = (model ?? '').toLowerCase().replace(/\[[^\]]*\]/g, '');
-  if (isGeminiModel(m)) return resolveGeminiProfile();
+  const ids = candidateIds(m);
+  if (ids.some(isGeminiModel)) return resolveGeminiProfile();
   const env = envProfiles();
   if (env.size > 0) {
     let best: GptModelProfile | undefined;
     let bestLen = -1;
     for (const [k, p] of env) {
-      if (m.startsWith(k) && k.length > bestLen) {
-        best = p;
-        bestLen = k.length;
+      // Longest matching key wins. Equal-length keys fall to env insertion
+      // order, not candidate order — the outer loop is over keys.
+      for (const id of ids) {
+        if (id.startsWith(k) && k.length > bestLen) {
+          best = p;
+          bestLen = k.length;
+        }
       }
     }
     if (best) return best;
   }
-  return resolveBuiltin(m);
+  const qualified = ids.length > 1 ? resolveBuiltin(ids[0]!) : undefined;
+  if (qualified && qualified !== DEFAULT_GPT_PROFILE) return qualified;
+  return resolveBuiltin(ids[ids.length - 1]!);
 }

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -221,6 +221,11 @@ function withClientDisconnect(
   });
 }
 
+/** Cap on bodies buffered only to sniff a model name, on paths pxpipe does not
+ *  transform. Chat requests naming a model are far below this; uploads that blow
+ *  past it stream through unbuffered. */
+const MODEL_SNIFF_MAX_BYTES = 1 << 20;
+
 /** Read the actual top-level `model` field. The body is already buffered for
  * transformation, so parsing it is both safer and simpler than a prefix regex
  * (which could mistake `metadata.model` for the routing model). */
@@ -804,14 +809,27 @@ function isProviderPrefixedPath(pathname: string): boolean {
   return PASSTHROUGH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
+/** One optional gateway/provider segment, then an optional `/v1`, before the
+ *  wire-shape suffix:
+ *
+ *    /v1/chat/completions
+ *    /openai/v1/chat/completions
+ *    /compat/chat/completions    AI Gateway's OpenAI-compatible route
+ *    /grok/chat/completions
+ *
+ *  Wire shape only: whether the body is OpenAI-shaped enough to parse a model
+ *  out of. Routing stays with isProviderPrefixedPath/isCanonicalOpenAIPath
+ *  above, so a prefixed path still goes to passthroughUpstream. */
+const PROVIDER_SEGMENT = String.raw`(?:\/[a-z0-9][a-z0-9._-]*)?(?:\/v1)?`;
+const OPENAI_CHAT_PATH = new RegExp(`^${PROVIDER_SEGMENT}\\/chat\\/completions$`);
+const OPENAI_RESPONSES_PATH = new RegExp(`^${PROVIDER_SEGMENT}\\/responses$`);
+
 function isOpenAIChatPath(pathname: string): boolean {
-  return pathname === '/v1/chat/completions' || pathname === '/openai/v1/chat/completions';
+  return OPENAI_CHAT_PATH.test(pathname);
 }
 
 function isOpenAIResponsesPath(pathname: string): boolean {
-  return pathname === '/v1/responses'
-    || pathname === '/openai/v1/responses'
-    || pathname === '/openai/responses';
+  return OPENAI_RESPONSES_PATH.test(pathname);
 }
 
 function isCanonicalOpenAIPath(pathname: string, headers: Headers, hasOpenAIKey: boolean): boolean {
@@ -1297,6 +1315,31 @@ export function createProxy(config: ProxyConfig = {}) {
           status: 502,
           headers: { 'content-type': 'application/json' },
         });
+      }
+    } else if (req.method === 'POST') {
+      // The model lives in the body, not the path, so read it here too or the
+      // dashboard row has a blank Model and token columns. Label only: the body
+      // is forwarded byte-for-byte, no transform, no baseline probe, no
+      // accounting change. Never overwrite a model already recovered from the
+      // path — Google routes name it there and carry no body `model`.
+      //
+      // This route also carries uploads and audio, so buffer only what can
+      // plausibly be a JSON request naming a model: declared JSON, declared
+      // length under the cap. Anything else streams and shows a blank Model, as
+      // before. A missing content-length is not evidence of a big body —
+      // chunked clients omit it — so only an explicit over-cap declaration
+      // disqualifies.
+      const declaredType = req.headers.get('content-type') ?? '';
+      const declaredLength = Number(req.headers.get('content-length') ?? NaN);
+      const worthBuffering =
+        declaredType.toLowerCase().includes('json') &&
+        !(Number.isFinite(declaredLength) && declaredLength > MODEL_SNIFF_MAX_BYTES);
+      if (worthBuffering) {
+        const bodyIn = new Uint8Array(await req.arrayBuffer());
+        requestModel ??= readModelField(bodyIn) ?? undefined;
+        bodyOut = bodyIn;
+      } else {
+        bodyOut = req.body; // pass through unchanged, model stays unknown
       }
     } else {
       bodyOut = req.body; // pass through unchanged

--- a/tests/gateway-wire-shape.test.ts
+++ b/tests/gateway-wire-shape.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Gateway-prefixed OpenAI wire shapes must be recognized as OpenAI-shaped.
+ *
+ * Regression: `/compat/chat/completions` (Cloudflare AI Gateway's
+ * OpenAI-compatible route — how non-Anthropic models reach pxpipe) and
+ * `/grok/chat/completions` matched neither isOpenAIChatPath nor
+ * isOpenAIResponsesPath, so the proxy skipped the parse block entirely: the
+ * emitted event carried no `model` and defaulted to `anthropic` accounting.
+ * The dashboard rendered those rows as endpoint "completions" with Model,
+ * Sent as, As text, Sent and Saved all blank. Observed in the wild across 70
+ * `/compat/chat/completions` and 306 `/grok/chat/completions` events.
+ *
+ * These are wire-shape tests only — they must not move upstream routing.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { createProxy, type ProxyEvent } from '../src/core/proxy.js';
+
+let ambientPxpipeModels: string | undefined;
+beforeAll(() => {
+  ambientPxpipeModels = process.env.PXPIPE_MODELS;
+  // Deliberately narrow: none of the ids below are in scope, so every request
+  // here is a passthrough. Telemetry must still be complete.
+  process.env.PXPIPE_MODELS = 'claude-fable-5';
+});
+afterAll(() => {
+  if (ambientPxpipeModels === undefined) delete process.env.PXPIPE_MODELS;
+  else process.env.PXPIPE_MODELS = ambientPxpipeModels;
+});
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const UPSTREAM = 'https://upstream.example.test';
+
+/** Captures the outbound URL and answers with a minimal OpenAI-shaped body. */
+function stubUpstream(cap: { url?: string }) {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    cap.url = String(input);
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl_1',
+        choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 11, completion_tokens: 2, total_tokens: 13 },
+      }),
+      { headers: { 'content-type': 'application/json' } },
+    );
+  }) as typeof fetch;
+}
+
+async function post(path: string, body: unknown): Promise<ProxyEvent> {
+  let captured: ProxyEvent | undefined;
+  const proxy = createProxy({
+    upstream: UPSTREAM,
+    onRequest: (e) => {
+      captured = e;
+    },
+  });
+  await proxy(
+    new Request(`http://localhost${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer fake-key' },
+      body: JSON.stringify(body),
+    }),
+  );
+  await new Promise((r) => setTimeout(r, 0));
+  if (!captured) throw new Error(`no event emitted for ${path}`);
+  return captured;
+}
+
+const CHAT_BODY = { model: 'kimi-k3', messages: [{ role: 'user', content: 'hi' }] };
+
+describe('gateway-prefixed chat/completions is OpenAI-shaped', () => {
+  it.each([
+    '/v1/chat/completions',
+    '/openai/v1/chat/completions',
+    '/compat/chat/completions',
+    '/grok/chat/completions',
+  ])('records model and openai accounting on %s', async (path) => {
+    const cap: { url?: string } = {};
+    stubUpstream(cap);
+    const ev = await post(path, CHAT_BODY);
+    expect(ev.model).toBe('kimi-k3');
+    expect(ev.accountingProvider).toBe('openai');
+  });
+
+  it.each(['/v1/responses', '/openai/responses', '/grok/v1/responses', '/compat/responses'])(
+    'records model and openai accounting on %s',
+    async (path) => {
+      const cap: { url?: string } = {};
+      stubUpstream(cap);
+      const ev = await post(path, { model: 'kimi-k3', input: 'hi' });
+      expect(ev.model).toBe('kimi-k3');
+      expect(ev.accountingProvider).toBe('openai');
+    },
+  );
+
+  it('leaves an out-of-scope model uncompressed', async () => {
+    const cap: { url?: string } = {};
+    stubUpstream(cap);
+    const ev = await post('/compat/chat/completions', CHAT_BODY);
+    expect(ev.info?.compressed).toBe(false);
+    expect(ev.info?.reason).toBe('unsupported_model');
+  });
+
+  it('does not move upstream routing for a provider-prefixed path', async () => {
+    const cap: { url?: string } = {};
+    stubUpstream(cap);
+    await post('/compat/chat/completions', CHAT_BODY);
+    // Same base + same path as before the wire-shape widening.
+    expect(cap.url).toBe(`${UPSTREAM}/compat/chat/completions`);
+  });
+
+  // Recording the model and transforming the body are separate decisions. The
+  // model lives in the body, so it is read for any POST regardless of path —
+  // otherwise an unrecognized path produces a dashboard row with every column
+  // blank. Treating the path as a transformable wire shape is still strict.
+  it('records the model but does not transform an unrecognized path', async () => {
+    const cap: { url?: string } = {};
+    stubUpstream(cap);
+    const ev = await post('/compat/chat/completions/extra', CHAT_BODY);
+    expect(ev.model).toBe('kimi-k3');
+    expect(ev.info?.compressed).toBeFalsy();
+  });
+
+  it('does not treat a two-segment prefix as a provider prefix', async () => {
+    const cap: { url?: string } = {};
+    stubUpstream(cap);
+    const ev = await post('/a/b/chat/completions', CHAT_BODY);
+    expect(ev.model).toBe('kimi-k3');
+    expect(ev.info?.compressed).toBeFalsy();
+    // Routing is untouched: no provider prefix was recognized here.
+    expect(cap.url).toBe(`${UPSTREAM}/a/b/chat/completions`);
+  });
+});
+
+/**
+ * The model sniff on unrecognized POST paths buffers the body. That route also
+ * carries uploads, so the buffering is gated: JSON only, and not past a
+ * declared size cap. When the gate declines, the row's Model is blank — the
+ * pre-existing behavior — and the body must still reach upstream untouched.
+ */
+describe('model sniff on unrecognized paths is gated', () => {
+  async function postRaw(
+    path: string,
+    headers: Record<string, string>,
+    body: string,
+  ): Promise<{ ev: ProxyEvent; sentBody: string | undefined }> {
+    let captured: ProxyEvent | undefined;
+    let sentBody: string | undefined;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentBody = init?.body === undefined || init?.body === null
+        ? undefined
+        : typeof init.body === 'string'
+          ? init.body
+          : new TextDecoder().decode(await new Response(init.body as BodyInit).arrayBuffer());
+      return new Response('{}', { headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+    const proxy = createProxy({
+      upstream: UPSTREAM,
+      onRequest: (e) => {
+        captured = e;
+      },
+    });
+    await proxy(new Request(`http://localhost${path}`, { method: 'POST', headers, body }));
+    await new Promise((r) => setTimeout(r, 0));
+    if (!captured) throw new Error(`no event emitted for ${path}`);
+    return { ev: captured, sentBody };
+  }
+
+  const BODY = JSON.stringify(CHAT_BODY);
+
+  it('sniffs a JSON body with no declared length (chunked clients omit it)', async () => {
+    const { ev, sentBody } = await postRaw(
+      '/some/unknown/path',
+      { 'content-type': 'application/json' },
+      BODY,
+    );
+    expect(ev.model).toBe('kimi-k3');
+    expect(sentBody).toBe(BODY);
+  });
+
+  it('skips a non-JSON body and forwards it unchanged', async () => {
+    const { ev, sentBody } = await postRaw(
+      '/some/unknown/path',
+      { 'content-type': 'application/octet-stream' },
+      BODY,
+    );
+    expect(ev.model).toBeUndefined();
+    expect(sentBody).toBe(BODY);
+  });
+
+  it('skips a JSON body declaring a length past the cap', async () => {
+    const { ev, sentBody } = await postRaw(
+      '/some/unknown/path',
+      { 'content-type': 'application/json', 'content-length': String((1 << 20) + 1) },
+      BODY,
+    );
+    expect(ev.model).toBeUndefined();
+    expect(sentBody).toBe(BODY);
+  });
+});

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -34,7 +34,11 @@ describe('public library API', () => {
     expect(isPxpipeSupportedModel('claude-fable-5-high')).toBe(true);
     expect(isPxpipeSupportedModel('google/gemini-3.6-flash')).toBe(true);
     expect(isPxpipeSupportedModel('gemini-3.6-flash-preview')).toBe(false);
-    expect(isPxpipeSupportedModel('untrusted/google/gemini-3.6-flash')).toBe(false);
+    // Any prefix depth is stripped to the last segment, because real gateway
+    // ids nest more than one level (`workers-ai/@cf/moonshotai/kimi-k3`). The
+    // vendor segments pick an upstream, not a geometry, so they do not gate
+    // scope — an unrecognized prefix in front of a known id still matches.
+    expect(isPxpipeSupportedModel('untrusted/google/gemini-3.6-flash')).toBe(true);
     // Opus 5 IS in the default scope (applicability.ts :: DEFAULT_MODEL_BASES), so it
     // ships compressed with no opt-in. Its dense-hex score is still unmeasured
     // (README "—") — the same axis that excluded Opus 4.8 at 0/15.

--- a/tests/qualified-model-ids.test.ts
+++ b/tests/qualified-model-ids.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Gateway-qualified model ids (`moonshotai/kimi-k3`, `openrouter/…`) name the same
+ * reader as the bare id — the vendor segment picks an upstream, not a geometry.
+ *
+ * Scope matching, profile resolution, and the misresolution guard must agree on
+ * that, or a gateway id either (a) silently never matches its PXPIPE_MODELS
+ * entry, or worse (b) matches scope but resolves to DEFAULT_GPT_PROFILE and is
+ * gated with OpenAI's tile math — the wrong provider's pricing formula.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  isPxpipeSupportedGptModel,
+  setAllowedModelBases,
+} from '../src/core/applicability.js';
+import {
+  DEFAULT_GPT_PROFILE,
+  isMisresolvedModelId,
+  resolveGptProfile,
+} from '../src/core/gpt-model-profiles.js';
+import { GEMINI_3_6_FLASH_PROFILE } from '../src/core/gemini-model-profiles.js';
+
+afterEach(() => {
+  setAllowedModelBases(null);
+  delete process.env.PXPIPE_GPT_PROFILES;
+});
+
+describe('scope matching for gateway-qualified ids', () => {
+  it('admits both spellings for one PXPIPE_MODELS entry', () => {
+    setAllowedModelBases(['gpt-5.6-sol']);
+    expect(isPxpipeSupportedGptModel('gpt-5.6-sol')).toBe(true);
+    expect(isPxpipeSupportedGptModel('vendor/gpt-5.6-sol')).toBe(true);
+  });
+
+  it('strips a multi-segment gateway prefix to the last segment', () => {
+    setAllowedModelBases(['kimi-k3']);
+    // workers-ai/@cf/moonshotai/kimi-k3 — the real Cloudflare Workers AI id.
+    expect(isPxpipeSupportedGptModel('workers-ai/@cf/moonshotai/kimi-k3')).toBe(true);
+  });
+
+  it('still requires the last segment to match exactly', () => {
+    setAllowedModelBases(['gpt-5.6-sol']);
+    expect(isPxpipeSupportedGptModel('vendor/gpt-5.6-terra')).toBe(false);
+    expect(isPxpipeSupportedGptModel('vendor/gpt')).toBe(false);
+    expect(isPxpipeSupportedGptModel('a/b/gpt-5.6-terra')).toBe(false);
+  });
+
+  it('does not let a vendor segment smuggle in an unscoped model', () => {
+    setAllowedModelBases(['gpt-5.6-sol']);
+    expect(isPxpipeSupportedGptModel('gpt-5.6-sol/gpt-5.5')).toBe(false);
+  });
+
+  it('keeps the pre-existing google/ behaviour', () => {
+    setAllowedModelBases(['gemini-3.6-flash']);
+    expect(isPxpipeSupportedGptModel('google/gemini-3.6-flash')).toBe(true);
+    expect(isPxpipeSupportedGptModel('google/gemini-3.6-pro')).toBe(false);
+  });
+});
+
+describe('unknown OpenAI-compatible ids fall back to DEFAULT_GPT_PROFILE', () => {
+  // Kimi K3 through Cloudflare's OpenAI-compatible route is the worked example
+  // (see messages-chat-bridge.ts). pxpipe has measured no geometry for it, but
+  // an unmeasured OpenAI-compatible id is not refused: it is gated with
+  // DEFAULT_GPT_PROFILE's tile math, which is an approximation, not a
+  // measurement. Scope is the only gate, and no env var is required.
+  it('admits every spelling on scope alone, with no env var set', () => {
+    delete process.env.PXPIPE_GPT_PROFILES;
+    setAllowedModelBases(['kimi-k3']);
+    expect(isMisresolvedModelId('kimi-k3')).toBe(false);
+    expect(isPxpipeSupportedGptModel('kimi-k3')).toBe(true);
+    expect(isPxpipeSupportedGptModel('moonshotai/kimi-k3')).toBe(true);
+    expect(isPxpipeSupportedGptModel('workers-ai/@cf/moonshotai/kimi-k3')).toBe(true);
+  });
+
+  it('gives an undeclared id the default tile vision cost', () => {
+    delete process.env.PXPIPE_GPT_PROFILES;
+    expect(resolveGptProfile('kimi-k3').vision).toEqual(DEFAULT_GPT_PROFILE.vision);
+  });
+
+  it('lets an explicit declaration override the fallback', () => {
+    process.env.PXPIPE_GPT_PROFILES = JSON.stringify({
+      'kimi-k3': { vision: { regime: 'mpix', tokensPerMegapixel: 1000 } },
+    });
+    setAllowedModelBases(['kimi-k3', 'example-model-1']);
+    expect(resolveGptProfile('kimi-k3').vision).toEqual({
+      regime: 'mpix',
+      tokensPerMegapixel: 1000,
+    });
+    // A sibling with no declaration of its own is still admitted — it falls
+    // back to the default profile rather than being refused.
+    expect(isPxpipeSupportedGptModel('example-model-1')).toBe(true);
+    expect(resolveGptProfile('example-model-1').vision).toEqual(DEFAULT_GPT_PROFILE.vision);
+  });
+});
+
+describe('profile resolution for gateway-qualified ids', () => {
+  it('resolves a qualified id to the same measured profile as the bare id', () => {
+    expect(resolveGptProfile('openrouter/gemini-3.6-flash')).toBe(GEMINI_3_6_FLASH_PROFILE);
+    expect(resolveGptProfile('vendor/gpt-5.6-sol')).toBe(resolveGptProfile('gpt-5.6-sol'));
+  });
+
+  it('lets a PXPIPE_GPT_PROFILES key written bare match a qualified id', () => {
+    process.env.PXPIPE_GPT_PROFILES = JSON.stringify({
+      'kimi-k3': { vision: { regime: 'mpix', tokensPerMegapixel: 1000 }, stripCols: 100 },
+    });
+    const bare = resolveGptProfile('kimi-k3');
+    expect(bare.stripCols).toBe(100);
+    expect(resolveGptProfile('moonshotai/kimi-k3').stripCols).toBe(100);
+  });
+
+  it('leaves a genuinely unknown id on the OpenAI default', () => {
+    // Resolution falls back to the OpenAI default, and isMisresolvedModelId
+    // does not refuse it: an id naming no measured family is in scope if the
+    // operator listed it, priced with tile math as an approximation.
+    expect(resolveGptProfile('moonshotai/kimi-k3')).toBe(DEFAULT_GPT_PROFILE);
+  });
+});
+
+describe('misresolution guard agrees with the resolver', () => {
+  it('does not refuse a qualified id that resolves to its measured profile', () => {
+    expect(isMisresolvedModelId('openrouter/gemini-3.6-flash')).toBe(false);
+    expect(resolveGptProfile('openrouter/gemini-3.6-flash')).not.toBe(DEFAULT_GPT_PROFILE);
+  });
+
+  it('still refuses an unmeasured sibling under any spelling', () => {
+    expect(isMisresolvedModelId('gemini-3.6-pro')).toBe(true);
+    expect(isMisresolvedModelId('openrouter/gemini-3.6-pro')).toBe(true);
+  });
+});


### PR DESCRIPTION
70 compat and 306 grok events rendered with Model, Sent as, As text, Sent and Saved blank. `/compat/chat/completions` matched no known wire shape, so the parse block was skipped and the event defaulted to anthropic accounting.

```text
Before:
POST /compat/chat/completions  shape: none    model: ""       acct: anthropic

After:
POST /compat/chat/completions  shape: openai  model: kimi-k3  acct: openai
```

Non-obvious mechanism:

- One leading provider segment is accepted on OpenAI chat/responses paths. Routing is unchanged — a prefixed path still forwards to passthrough.
- Profiles resolve by full id, then bare final segment. Vendor picks an upstream, not a geometry.

  ```text
  moonshotai/kimi-k3, workers-ai/@cf/moonshotai/kimi-k3  ->  kimi-k3
  ```

- On POST paths pxpipe does not transform, the top-level `model` field is read for labeling only. Gated to JSON under a size cap, since that route also carries uploads. Gate declines -> model blank as before, body streams unchanged.
- Ids naming no measured family resolve to `DEFAULT_GPT_PROFILE` instead of being refused.

Trust boundary moved. Matching was hardcoded to `google/`; it now strips everything before the last `/`.

```text
untrusted/google/gemini-3.6-flash  ->  in scope (was rejected)
gpt-5.6-sol/gpt-5.5                ->  still rejected
```

Intended: `PXPIPE_MODELS` stays the gate on which models get imaged, and the prefix is not part of that decision. If `model` is attacker-controlled, this widens billing misattribution surface.

For unmeasured families, savings is OpenAI tile math, not a measurement, and nothing checks the model accepts images — a text-only model 400s on the first imaged request. No vision gate by design: the scope list is hand-written, so a capability check re-asks a question the operator already answered, and the failure is a loud 400 rather than silent corruption.

