### PR TITLE
Keep the OAuth identity as the first system block

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -154,17 +154,34 @@ const DEFAULTS: Required<TransformOptions> = {
  * block: the endpoint answers an unclassified request with an opaque
  * `429 rate_limit_error: "Error"` even when the account has quota left (#149).
  *
- * Which identity ships depends on the entrypoint, not the product:
- * `cc_entrypoint=cli` (terminal) sends the CLI line, while `sdk-cli` — used by
- * `claude -p` and the VS Code extension — sends the Agent SDK line.
+ * Which identity ships depends on the entrypoint, not the product. Claude Code
+ * 2.1.220 picks one of three:
+ *
+ *   if (vertex) return CLI;
+ *   if (nonInteractive) return appendSystemPrompt ? CLI_WITHIN_SDK : AGENT_SDK;
+ *   return CLI;
+ *
+ * so the terminal sends the CLI line, `claude -p` / the VS Code extension /
+ * Claude Desktop's `stream-json` mode send the Agent SDK line, and adding
+ * `--append-system-prompt` to any of those switches to the CLI-within-SDK line.
  */
 export const CLAUDE_CODE_OAUTH_IDENTITY =
   "You are Claude Code, Anthropic's official CLI for Claude.";
 
+export const CLAUDE_CODE_WITHIN_SDK_OAUTH_IDENTITY =
+  "You are Claude Code, Anthropic's official CLI for Claude, running within the Claude Agent SDK.";
+
 export const CLAUDE_AGENT_SDK_OAUTH_IDENTITY =
   "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
 
-const OAUTH_IDENTITIES = [CLAUDE_CODE_OAUTH_IDENTITY, CLAUDE_AGENT_SDK_OAUTH_IDENTITY];
+/** Longest first: CLAUDE_CODE_OAUTH_IDENTITY is a prefix of the within-SDK line,
+ *  so a shorter-first `startsWith` scan would match it and emit a truncated
+ *  identity, leaving `, running within the Claude Agent SDK.` to be imaged. */
+const OAUTH_IDENTITIES = [
+  CLAUDE_CODE_OAUTH_IDENTITY,
+  CLAUDE_CODE_WITHIN_SDK_OAUTH_IDENTITY,
+  CLAUDE_AGENT_SDK_OAUTH_IDENTITY,
+].sort((a, b) => b.length - a.length);
 
 // --- per-block break-even check ---
 //

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -148,12 +148,23 @@ const DEFAULTS: Required<TransformOptions> = {
 };
 
 /**
- * Subscription OAuth requests are classified as Claude Code traffic only when
- * this exact identity remains the first, separate top-level system block.
- * Never render it into an image or concatenate other text into its block.
+ * Subscription OAuth requests are classified as first-party traffic only when
+ * one of these exact identities remains the first, separate top-level system
+ * block. Never render one into an image or concatenate other text into its
+ * block: the endpoint answers an unclassified request with an opaque
+ * `429 rate_limit_error: "Error"` even when the account has quota left (#149).
+ *
+ * Which identity ships depends on the entrypoint, not the product:
+ * `cc_entrypoint=cli` (terminal) sends the CLI line, while `sdk-cli` — used by
+ * `claude -p` and the VS Code extension — sends the Agent SDK line.
  */
 export const CLAUDE_CODE_OAUTH_IDENTITY =
   "You are Claude Code, Anthropic's official CLI for Claude.";
+
+export const CLAUDE_AGENT_SDK_OAUTH_IDENTITY =
+  "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
+
+const OAUTH_IDENTITIES = [CLAUDE_CODE_OAUTH_IDENTITY, CLAUDE_AGENT_SDK_OAUTH_IDENTITY];
 
 // --- per-block break-even check ---
 //
@@ -687,6 +698,24 @@ function extractSystemText(sys: SystemField | undefined): { text: string; kept: 
     }
   }
   return { text: textParts.join('\n\n'), kept };
+}
+
+/**
+ * Remove a standalone OAuth identity block from passed-through system blocks.
+ * The caller re-emits it first; see the identity note above OAUTH_IDENTITIES.
+ */
+function liftIdentityBlock(kept: SystemField): { identity?: string; kept: SystemField } {
+  if (!Array.isArray(kept)) return { kept };
+  let identity: string | undefined;
+  const rest = kept.filter((block) => {
+    if (identity !== undefined) return true;
+    if (!block || typeof block !== 'object' || block.type !== 'text') return true;
+    const match = OAUTH_IDENTITIES.find((id) => block.text.trim() === id);
+    if (match === undefined) return true;
+    identity = match;
+    return false;
+  });
+  return { identity, kept: rest };
 }
 
 function lastStaticSystemCacheControl(sys: SystemField | undefined): TextBlock['cache_control'] | undefined {
@@ -1592,7 +1621,14 @@ export async function transformRequest(
   //    - dynamicText: <env>/<context>/... blocks (per-turn, kept as text).
   //    - staticText: everything else (cacheable, goes into the image).
   const systemStaticCacheControl = lastStaticSystemCacheControl(req.system);
-  const { text: rawSysText, kept: sysRemainder } = extractSystemText(req.system);
+  const { text: rawSysText, kept: rawSysRemainder } = extractSystemText(req.system);
+  // The identity block does not always carry cache_control — the CLI entrypoint
+  // marks only the big instruction block — so extractSystemText holds it in
+  // `kept`, which is re-emitted AFTER the env text. That is too late: the
+  // endpoint classifies on the leading block and answers an opaque
+  // `429 rate_limit_error: "Error"` when it does not lead (#149). Lift it out
+  // here so the assembly below can put it back in front.
+  const { identity: keptIdentity, kept: sysRemainder } = liftIdentityBlock(rawSysRemainder);
   const { kept: billingLine, body: sysBody } = stripBillingLine(rawSysText);
   // `# Environment` (working dir, git status, model ID) churns per turn but has
   // no XML wrapper, so the static/dynamic split would bake it into the slab PNG
@@ -1604,10 +1640,11 @@ export async function transformRequest(
   const splitSystem = splitStaticDynamic(sysBodyNoEnv);
   let staticText = splitSystem.staticText;
   const { dynamicText, blockCount: dynBlocks, unknownTags, staticTagContents } = splitSystem;
-  const preserveClaudeCodeIdentity = staticText.startsWith(CLAUDE_CODE_OAUTH_IDENTITY);
-  if (preserveClaudeCodeIdentity) {
-    staticText = staticText.slice(CLAUDE_CODE_OAUTH_IDENTITY.length).replace(/^\s+/, '');
+  const inlineIdentity = OAUTH_IDENTITIES.find((id) => staticText.startsWith(id));
+  if (inlineIdentity) {
+    staticText = staticText.slice(inlineIdentity.length).replace(/^\s+/, '');
   }
+  const preservedIdentity = keptIdentity ?? inlineIdentity;
   info.staticChars = staticText.length;
   info.dynamicBlockCount = dynBlocks;
   if (unknownTags.length > 0) info.unknownStaticTags = unknownTags;
@@ -1865,8 +1902,8 @@ export async function transformRequest(
   // Images go into first user message — system field rejects images (400 system.N.type).
   {
     const sysTail: SystemField = [];
-    if (preserveClaudeCodeIdentity) {
-      sysTail.push({ type: 'text', text: CLAUDE_CODE_OAUTH_IDENTITY });
+    if (preservedIdentity) {
+      sysTail.push({ type: 'text', text: preservedIdentity });
     }
     // Session-stable, so it sits ahead of the churny blocks below.
 


### PR DESCRIPTION
Fixes #149
Fixes #150

## Problem

Every request through pxpipe fails with a 429 whose body says nothing:

```json
{"type":"error","error":{"type":"rate_limit_error","message":"Error"},"request_id":"..."}
```

The account has quota left, and the same prompt succeeds without the proxy. The endpoint classifies a subscription-OAuth request as first-party only when the exact identity line is the **first, separate top-level system block**; an unclassified request is rejected as if rate-limited.

## Cause

Compression rebuilds `system`, and the identity was landing too late. `extractSystemText` splits blocks on `cache_control`: once any text block carries a marker, every unmarked block is diverted to `kept` and re-emitted after the dynamic text. Claude Code marks only the big instruction block, so the unmarked identity block ended up behind `# Environment`.

Before:

```js
[ { text: "# Environment\n..." },
  { text: "You are Claude Code, Anthropic's official CLI for Claude." } ]   // 429
```

After:

```js
[ { text: "You are Claude Code, Anthropic's official CLI for Claude." },
  { text: "# Environment\n..." } ]                                          // 200
```

The identity is lifted out of `kept` before assembly, so it leads regardless of whether it arrived marked. The rest of the array keeps its existing order — `# Environment` stays last on purpose, since it churns every turn and would otherwise invalidate the cached prefix.

## VS Code

The reporter saw this only in VS Code, with the terminal working. Claude Code 2.1.220 picks one of three identity lines by entrypoint, and only the first was recognized:

| entrypoint | identity line |
|---|---|
| terminal, Vertex | `You are Claude Code, Anthropic's official CLI for Claude.` |
| `claude -p`, VS Code extension | `You are a Claude agent, built on Anthropic's Claude Agent SDK.` |
| any of those + `--append-system-prompt` | `You are Claude Code, Anthropic's official CLI for Claude, running within the Claude Agent SDK.` |

All three are matched now. The table is sorted longest-first because the third line has the first as a prefix, and the inline scan uses `startsWith` — shortest-first would emit a truncated identity and image the remainder.

## Test

Reproduced against the live endpoint through pxpipe with the payload captured from the failing session: identity trailing or truncated -> 429 on every attempt; exact identity leading -> 200. `pnpm typecheck` and `pnpm test` (899 tests) pass.
