### PR TITLE
fix(openai-history): keepTail:0 in mixed Responses collapse protected every message

### DIFF
--- a/src/core/openai-history.ts
+++ b/src/core/openai-history.ts
@@ -784,8 +784,12 @@ async function planResponsesMixedCollapse(
     messageIndices.push(i);
     if (msg.role === 'user') latestUserIndex = i;
   }
+  // slice(-0) returns the WHOLE array, so guard keepTail===0 explicitly —
+  // otherwise "protect 0 tail messages" protects every message and blocks
+  // all collapse. latestUserIndex is added separately below.
+  const tail = Math.max(0, Math.floor(o.keepTail));
   const protectedMessages = new Set(
-    messageIndices.slice(-Math.max(0, Math.floor(o.keepTail))),
+    tail > 0 ? messageIndices.slice(-tail) : [],
   );
   if (latestUserIndex >= 0) protectedMessages.add(latestUserIndex);
 

--- a/tests/openai-history.test.ts
+++ b/tests/openai-history.test.ts
@@ -558,6 +558,25 @@ describe('planResponsesPairCollapse — native state classification', () => {
     expect(plan.baselineTokens).toBeLessThan(o200k(plan.text));
   });
 
+  it('mixed mode with keepTail 0 collapses old messages (no slice(-0) whole-array protect)', async () => {
+    // Regression: keepTail:0 must protect NO tail messages. slice(-0) returns
+    // the whole array, which would protect every message and block all collapse.
+    const items: Array<Record<string, unknown>> = [
+      { role: 'user', content: `old request ${'alpha '.repeat(500)}` },   // 0
+      { role: 'assistant', content: `old answer ${'beta '.repeat(500)}` }, // 1
+      { role: 'user', content: 'current live request' },                   // 2 (latest user)
+    ];
+    const plan = await planResponsesPairCollapse(items, yes, {
+      responsesMode: 'mixed', keepTail: 0, keepRecentPairs: 0,
+      minCollapseTokens: 1, maxImages: 100,
+    });
+    const selected = new Set(plan.selectedIndices);
+    // Only the latest user turn stays native; the old turns collapse.
+    expect(selected.has(0)).toBe(true);
+    expect(selected.has(1)).toBe(true);
+    expect(selected.has(2)).toBe(false);
+  });
+
   it('with a one-item Sol tail, protects the latest user and newest closed pair only', async () => {
     const items: Array<Record<string, unknown>> = [
       { role: 'user', content: `old request ${'alpha '.repeat(500)}` },


### PR DESCRIPTION
### Problem
In `planResponsesMixedCollapse` (`src/core/openai-history.ts`), the protected trailing messages are computed as:

```ts
messageIndices.slice(-Math.max(0, Math.floor(o.keepTail)))
```

When `keepTail` is `0`, that expression is `slice(-0)`. `Array.prototype.slice(-0)` treats `-0` as `0` and returns the **entire array** — so "protect zero trailing messages" instead protects **every** message. Every old turn then becomes a hard barrier, no history collapses, and the planner returns `reason: 'no_closed_prefix'` with nothing imaged (the exact inverse of the intent).

`keepTail: 0` is a legal, reachable config: it flows through `nonNegativeInt(historyIn?.keepTail, …)` (which accepts `0`) from a host's `gptHistory.keepTail` override. The shipped Sol profile uses `keepTail: 1`, so this is a latent correctness bug on an override path, not a default-path failure.

### Fix
Guard `keepTail === 0` explicitly so it protects nothing; the latest user turn is still protected separately via `latestUserIndex`.

```ts
const tail = Math.max(0, Math.floor(o.keepTail));
const protectedMessages = new Set(tail > 0 ? messageIndices.slice(-tail) : []);
```

Added a regression test (verified it fails on the old code, passes on the fix). Full suite green except 3 pre-existing Windows-only file-permission failures in `node-security.test.ts` (unrelated; fail on a clean tree here too). `typecheck` clean.

Generated with [Claude Code](https://claude.com/claude-code)
