### PR TITLE
Pin instructions where the model actually reads them

### DIFF
--- a/src/core/pin.ts
+++ b/src/core/pin.ts
@@ -61,10 +61,32 @@ function matchPinCmd(line: string): { verb: string; rest: string } | null {
 /** Leading `<system-reminder>` run — the harness's CLAUDE.md envelope. */
 const LEADING_REMINDER_RE = /^\s*<system-reminder>[\s\S]*?<\/system-reminder>/;
 
-/** Any reminder, anywhere in a block. The harness appends its own notices (e.g.
- *  "task tools haven't been used recently") to a turn the user typed, so a turn
- *  is command-only by what the *user* wrote, not by what the harness added. */
-const ANY_REMINDER_RE = /<system-reminder>[\s\S]*?<\/system-reminder>/g;
+const REMINDER_OPEN = '<system-reminder>';
+const REMINDER_CLOSE = '</system-reminder>';
+
+/**
+ * Drop every reminder, anywhere in a block. The harness appends its own notices
+ * (e.g. "task tools haven't been used recently") to a turn the user typed, so a
+ * turn is command-only by what the *user* wrote, not by what the harness added.
+ *
+ * Scanned rather than matched with `/<system-reminder>[\s\S]*?<\/…>/g`: under a
+ * lazy body every unterminated open rescans to the end of the string, so a
+ * message carrying many of them costs O(n²). An unterminated open ends the
+ * scan; the rest of the block is text the user can see, so it stays.
+ */
+function stripReminders(text: string): string {
+  let out = '';
+  let at = 0;
+  for (;;) {
+    const open = text.indexOf(REMINDER_OPEN, at);
+    if (open < 0) break;
+    const close = text.indexOf(REMINDER_CLOSE, open + REMINDER_OPEN.length);
+    if (close < 0) break;
+    out += text.slice(at, open);
+    at = close + REMINDER_CLOSE.length;
+  }
+  return out + text.slice(at);
+}
 
 /** Opening marker of a synthesized pin confirmation. We generate these, so the
  *  match is on bytes we control, not a heuristic that could eat a real reply. */
@@ -288,7 +310,7 @@ function isCommandOnlyTurn(m: Message): boolean {
     // line. Stripping reminders before the test would classify that turn as
     // command-only and drop the project's instructions from every later request.
     if (LEADING_REMINDER_RE.test(raw)) return false;
-    const text = raw.replace(ANY_REMINDER_RE, '');
+    const text = stripReminders(raw);
     for (const line of text.split('\n')) {
       if (!line.trim()) continue;
       if (!matchPinCmd(line)) return false;

--- a/src/core/pin.ts
+++ b/src/core/pin.ts
@@ -1,0 +1,579 @@
+/**
+ * User-pinned instructions.
+ *
+ * The problem: CLAUDE.md arrives in message 0, and by the time a long tool loop
+ * has run, position 0 reads as background rather than instruction. The harness
+ * itself works around this for its own rules by re-emitting `<system-reminder>`
+ * at the TAIL, where the model reads it last, immediately before generating.
+ * A pin buys that slot for the user's rules.
+ *
+ * Syntax is one line, one pin, wherever the user can type:
+ *
+ *     @pxpipe pin be concise, no walls of text
+ *     @pxpipe unpin
+ *
+ * The line is identical in a rules file (durable) and in a chat turn (session-only),
+ * so a session pin that works is made permanent by pasting it into the file. What
+ * differs is only WHERE it was found, which is enough to classify it:
+ *
+ *   - inside the leading `<system-reminder>` run of message 0  → 'file'
+ *   - in a user's typed text                                   → 'session'
+ *   - in any later `<system-reminder>` (inlined `@`-mention)   → 'session'
+ *
+ * State is re-derived from the transcript on every request — no store, no session
+ * id (the Messages API has none), and rewinding the conversation rewinds the pins.
+ * This works even though we strip the commands from the outbound copy: pxpipe only
+ * rewrites the request going upstream, so the client's own transcript keeps
+ * re-sending them verbatim every turn.
+ */
+
+import type { ContentBlock, Message, TextBlock } from './types.js';
+
+/** One pin line. Longer than this is a document, not an instruction. */
+const PIN_MAX_CHARS = 300;
+
+/** Total pinned text emitted at the tail. A pin that dilutes itself is not a pin. */
+const PIN_TOTAL_MAX_CHARS = 2000;
+
+/**
+ * `@pxpipe pin <text>` / `@pxpipe unpin`, anchored to a whole line so removal is a
+ * whole-line delete — deterministic, with no leftover blank-line ambiguity. That
+ * determinism is what lets us MOVE pins (strip from source, emit at tail) instead
+ * of copying: the rewrite stays a pure function of the message, so the protected
+ * prefix remains byte-stable turn to turn, exactly like demoteProtectedHeadText.
+ */
+const PIN_CMD_RE = /^[ \t]*@pxpipe[ \t]+(pin|unpin)\b[ \t]*(.*?)[ \t]*$/;
+
+/** Leading `<system-reminder>` run — the harness's CLAUDE.md envelope. */
+const LEADING_REMINDER_RE = /^\s*<system-reminder>[\s\S]*?<\/system-reminder>/;
+
+/** Any reminder, anywhere in a block. The harness appends its own notices (e.g.
+ *  "task tools haven't been used recently") to a turn the user typed, so a turn
+ *  is command-only by what the *user* wrote, not by what the harness added. */
+const ANY_REMINDER_RE = /<system-reminder>[\s\S]*?<\/system-reminder>/g;
+
+/** Opening marker of a synthesized pin confirmation. We generate these, so the
+ *  match is on bytes we control, not a heuristic that could eat a real reply. */
+/** Prefix on every synthesized reply, and the whole test for recognizing one on
+ *  the way back in. Shares the `@pxpipe` namespace with the commands so there is
+ *  one token to learn and one to match, and unlike `·` it survives any encoding
+ *  or copy/paste the transcript is put through. */
+export const PIN_REPLY_MARK = '@pxpipe ';
+
+/**
+ * Which tier a pin lives in. `'file'`, not `'claude.md'`: the same tier holds
+ * whatever the harness inlined, which is CLAUDE.md under Claude Code and
+ * AGENTS.md under Codex. The tier is named for the origin because the origin is
+ * what answers the two questions a user has: why `unpin` refuses, and what to
+ * edit instead.
+ */
+export type PinSource = 'file' | 'session';
+
+/** Which command the live turn ended with — it decides what the reply lists. */
+export type PinVerb = 'pin' | 'unpin';
+
+export interface Pin {
+  text: string;
+  source: PinSource;
+  /**
+   * Absolute path of the file this line came from, when the harness named it in
+   * the envelope. Carried per pin, not per tier, because one leading run can
+   * inline several files and a header that says `CLAUDE.md` over a line that
+   * came from `AGENTS.md` sends the user to edit the wrong file.
+   */
+  path?: string;
+}
+
+/**
+ * Fold every pin command in the transcript, oldest to newest.
+ *
+ *   @pxpipe unpin 2        remove the pin listed as 2
+ *   @pxpipe unpin use tabs remove by text (exact, else prefix)
+ *   @pxpipe unpin all      clear every session pin
+ *   @pxpipe unpin          NOT destructive — prints the list
+ *
+ * Bare `unpin` used to clear everything and then print what survived, which read
+ * as a menu and destroyed the thing the user was still deciding about. Removal now
+ * requires naming a target; the bare form is a query.
+ *
+ * Every form clears SESSION pins only. Clearing CLAUDE.md pins too would mean an
+ * `unpin` typed forty turns ago silently disables the project's rules for the
+ * rest of the session with nothing on screen to explain why; to drop a durable
+ * pin you delete its line from the file, where the change is visible.
+ */
+export function foldPins(messages: Message[]): Pin[] {
+  const pins: Pin[] = [];
+  messages.forEach((m, idx) => {
+    if (m.role !== 'user') return;
+    for (const { line, source, path } of pinLines(m, idx)) {
+      const cmd = PIN_CMD_RE.exec(line);
+      if (!cmd) continue;
+      if (cmd[1] === 'unpin') {
+        applyUnpin(pins, cmd[2]!.trim());
+        continue;
+      }
+      const text = cmd[2]!.trim().slice(0, PIN_MAX_CHARS);
+      if (source === 'file') {
+        // A file is a document, not a list of instructions. Its blank lines and
+        // its repeated lines ARE the format: a fence closes with the same ```
+        // that opened it, a table rule repeats, and an example that shows
+        // `Before: <code sample>` shows the same `<code sample>` again under
+        // `After:`. Deduping or dropping those leaves the user's own rules
+        // rendered as something they did not write — an empty `After:`, a fence
+        // that never closes. Only message 0's leading reminder reaches here
+        // (see pinLines), so the document is ingested exactly once and cannot
+        // accumulate across turns without the dedup guard.
+        const prev = pins[pins.length - 1];
+        // Blank runs collapse to one, and a leading blank is dropped: they cost
+        // budget that later lines need, and neither changes how the text reads.
+        if (!text && (!prev || !prev.text)) continue;
+        pins.push({ text, source, path });
+        continue;
+      }
+      if (!text) continue;
+      if (pins.some((p) => p.text === text)) continue;
+      pins.push({ text, source });
+    }
+  });
+  return pins;
+}
+
+/**
+ * Resolve one `unpin` argument against the pins in effect at that point.
+ *
+ * Numbers address the SESSION list only — the same list pinReplyText numbers.
+ * This is not cosmetic: an `@pxpipe unpin 2` stays in the transcript and is
+ * re-folded on every later request, so if numbering also covered CLAUDE.md pins,
+ * adding one line to that file would renumber the list underneath a command
+ * already given, and it would silently start deleting a different pin.
+ * Numbering only the removable entries makes the indices immune to file edits.
+ */
+function applyUnpin(pins: Pin[], arg: string): void {
+  if (!arg) return; // bare `unpin` is a query; pinReplyText answers it
+  if (arg === 'all') {
+    for (let i = pins.length - 1; i >= 0; i--) {
+      if (pins[i]!.source === 'session') pins.splice(i, 1);
+    }
+    return;
+  }
+  const session = pins.filter((p) => p.source === 'session');
+  let target: Pin | undefined;
+  if (/^\d+$/.test(arg)) {
+    target = session[Number(arg) - 1];
+  } else {
+    // Text form: the user already knows the words, so accept a prefix rather
+    // than demand the pin be retyped exactly.
+    const lower = arg.toLowerCase();
+    target = session.find((p) => p.text === arg)
+      ?? session.find((p) => p.text.toLowerCase().startsWith(lower));
+  }
+  if (target) pins.splice(pins.indexOf(target), 1);
+}
+
+/**
+ * Every line of a user message that may carry a command, tagged with where it
+ * came from.
+ *
+ * Message 0's LEADING reminder run is the harness's file envelope, whatever it
+ * chose to inline there: global CLAUDE.md, project CLAUDE.md, AGENTS.md. A file
+ * backs those pins, so they are durable and `unpin` cannot reach them.
+ *
+ * A reminder block anywhere else is inlined `@`-mention content (the harness reads
+ * the file and pastes it in) or a per-turn notice. No file tier backs those, so
+ * they pin as `session` and `unpin` can drop them. That is deliberate: an inlined
+ * document containing `@pxpipe pin ...` can pin itself, and the removable tier
+ * plus the pin report is what makes that visible and reversible.
+ */
+function* pinLines(
+  m: Message,
+  idx: number,
+): Generator<{ line: string; source: PinSource; path?: string }> {
+  const blocks: ContentBlock[] = typeof m.content === 'string'
+    ? [{ type: 'text', text: m.content }]
+    : Array.isArray(m.content) ? m.content : [];
+  let leadingRun = idx === 0;
+  for (const blk of blocks) {
+    if (!blk || typeof blk !== 'object' || (blk as { type?: string }).type !== 'text') {
+      continue;
+    }
+    const text = (blk as TextBlock).text;
+    if (typeof text !== 'string') continue;
+    if (LEADING_REMINDER_RE.test(text)) {
+      // A file backs the leading run, so it owns the durable tier. Everything
+      // later is inlined mention content or a per-turn notice: pin it, but keep
+      // it in the tier `unpin` can reach.
+      const source: PinSource = leadingRun ? 'file' : 'session';
+      // Per block, not per message: one leading run can inline several files,
+      // and each pin has to remember which one to send the user back to.
+      for (const block of reminderBlocks(text)) {
+        const path = source === 'file' ? filePathOf(block) : undefined;
+        for (const line of block.split('\n')) yield { line, source, path };
+      }
+      continue;
+    }
+    leadingRun = false;
+    for (const line of text.split('\n')) yield { line, source: 'session' };
+  }
+}
+
+/** The leading `<system-reminder>` run of a block, one entry per reminder. */
+function reminderBlocks(text: string): string[] {
+  const out: string[] = [];
+  let rest = text;
+  for (;;) {
+    const m = LEADING_REMINDER_RE.exec(rest);
+    if (!m) break;
+    out.push(m[0]);
+    rest = rest.slice(m[0].length);
+  }
+  return out;
+}
+
+/**
+ * The file a reminder block was read from, when it says so.
+ *
+ * Every harness that inlines a rules file labels it, because the model has to
+ * know which file it is reading: Claude Code writes `Contents of <path> (...)`,
+ * and Codex the same for AGENTS.md. Matching the label rather than a filename
+ * list is what makes this work for a file we have never heard of; an unlabelled
+ * block just falls back to the generic header.
+ */
+function filePathOf(block: string): string | undefined {
+  return /^Contents of (.+?)(?: \(|:\s*$)/m.exec(block)?.[1]?.trim();
+}
+
+/** True when this message's only typed content is pin commands. */
+function isCommandOnlyTurn(m: Message): boolean {
+  if (m.role !== 'user') return false;
+  const blocks: ContentBlock[] = typeof m.content === 'string'
+    ? [{ type: 'text', text: m.content }]
+    : Array.isArray(m.content) ? m.content : [];
+  let sawCommand = false;
+  for (const blk of blocks) {
+    if (!blk || typeof blk !== 'object') return false;
+    if ((blk as { type?: string }).type !== 'text') return false; // tool_result/image: real work
+    const raw = (blk as TextBlock).text;
+    if (typeof raw !== 'string') return false;
+    const text = raw.replace(ANY_REMINDER_RE, '');
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      if (!PIN_CMD_RE.test(line)) return false;
+      sawCommand = true;
+    }
+  }
+  return sawCommand;
+}
+
+/** True when a message is a pin confirmation this proxy synthesized. */
+function isPinReply(m: Message | undefined): boolean {
+  if (!m || m.role !== 'assistant') return false;
+  const blocks = Array.isArray(m.content) ? m.content : [];
+  if (typeof m.content === 'string') return m.content.startsWith(PIN_REPLY_MARK);
+  if (blocks.length !== 1) return false;
+  const blk = blocks[0]!;
+  return (blk as { type?: string }).type === 'text'
+    && typeof (blk as TextBlock).text === 'string'
+    && (blk as TextBlock).text.startsWith(PIN_REPLY_MARK);
+}
+
+/**
+ * Remove pin commands and their synthesized confirmations from the OUTBOUND copy.
+ * The client keeps its own transcript, so nothing is lost: the next request still
+ * arrives with every command intact and foldPins re-derives the same state.
+ *
+ * A command-only turn is dropped together with the confirmation that answered it —
+ * never one alone, or the user/assistant roles stop alternating. A mixed turn keeps
+ * its prose and loses only the command lines, so the model is not distracted by
+ * configuration in the middle of a request it has to act on.
+ */
+export function stripPinCommands(messages: Message[]): Message[] {
+  const out: Message[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]!;
+    if (isCommandOnlyTurn(m) && isPinReply(messages[i + 1])) {
+      i++; // drop the pair
+      continue;
+    }
+    if (m.role !== 'user') {
+      out.push(m);
+      continue;
+    }
+    const stripped = stripFromMessage(m);
+    out.push(stripped ?? m);
+  }
+  return out;
+}
+
+/** Strip command lines from a user message, or undefined if nothing changed.
+ *  Returns the original when stripping would leave the message with no content —
+ *  an empty `content` is rejected by the API, and dropping a lone message would
+ *  break role alternation. */
+function stripFromMessage(m: Message): Message | undefined {
+  if (typeof m.content === 'string') {
+    const text = stripLines(m.content);
+    if (text === m.content) return undefined;
+    return text.trim() ? { ...m, content: text } : undefined;
+  }
+  if (!Array.isArray(m.content)) return undefined;
+  let changed = false;
+  const blocks: ContentBlock[] = [];
+  for (const blk of m.content) {
+    if (blk && typeof blk === 'object' && (blk as { type?: string }).type === 'text') {
+      const tb = blk as TextBlock;
+      if (typeof tb.text === 'string') {
+        const text = stripLines(tb.text);
+        if (text !== tb.text) {
+          changed = true;
+          // Preserve cache_control: dropping the block would move the breakpoint.
+          if (!text.trim() && tb.cache_control === undefined) continue;
+          blocks.push({ ...tb, text });
+          continue;
+        }
+      }
+    }
+    blocks.push(blk);
+  }
+  if (!changed || blocks.length === 0) return undefined;
+  return { ...m, content: blocks };
+}
+
+function stripLines(text: string): string {
+  return text
+    .split('\n')
+    .filter((line) => !PIN_CMD_RE.test(line))
+    .join('\n');
+}
+
+/**
+ * The block appended at the tail. Sits after every existing `cache_control`
+ * breakpoint, so its bytes are re-read each turn by construction and it can never
+ * cost a cache miss — which is also why formatting drift in the user's source
+ * lines is free here, and why we normalize purely for tidy telemetry.
+ */
+export function pinBlockText(pins: Pin[]): string {
+  if (pins.length === 0) return '';
+  let budget = PIN_TOTAL_MAX_CHARS;
+  const lines: string[] = [];
+  for (const p of pins) {
+    if (budget - p.text.length < 0) break;
+    budget -= p.text.length;
+    // Session pins are a list the user dictated one line at a time, so a bullet
+    // is what they meant. A file excerpt is markdown the user already formatted;
+    // bulleting it turns their `##` headings, table rows and fenced blocks into
+    // list items, i.e. we would be reformatting the very text we claim is "the
+    // user's own words".
+    lines.push(p.source === 'file' ? p.text : `- ${p.text}`);
+  }
+  if (lines.length === 0) return '';
+  return [
+    '<system-reminder>',
+    '[pxpipe pin] The user pinned these instructions and pxpipe relocated them here,',
+    'last in the request, because rules stated far above get read as background. They',
+    "are the user's own words and they govern this reply; on conflict they win.",
+    ...lines,
+    '</system-reminder>',
+  ].join('\n');
+}
+
+/** Append the pin block to the final user message. Returns chars added. */
+export function appendPinBlock(messages: Message[], pins: Pin[]): number {
+  const text = pinBlockText(pins);
+  if (!text) return 0;
+  const last = messages[messages.length - 1];
+  // An assistant prefill must remain the final message, and nothing may follow it.
+  if (!last || last.role !== 'user') return 0;
+  if (typeof last.content === 'string') {
+    last.content = [{ type: 'text', text: last.content }];
+  }
+  if (!Array.isArray(last.content)) return 0;
+  last.content.push({ type: 'text', text });
+  return text.length;
+}
+
+/**
+ * The confirmation shown when a bare pin command is answered locally.
+ *
+ * Always the COMPLETE list, never a delta: the question a user has after typing a
+ * pin is "what is in effect now", and a delta makes them replay the session in
+ * their head to find out. The source header is the part that matters: it says
+ * which lines survive a restart and which `unpin` will clear.
+ */
+/**
+ * File pins grouped under the file they came from, in first-seen order.
+ *
+ * Grouped rather than tagged per line: against a real rules file the tag repeats
+ * down the whole list and buries the text it means to annotate. A block the
+ * harness did not label still gets a header, because the alternative is a run of
+ * lines with no answer to "where do I edit this".
+ */
+function fileHeaders(pins: Pin[]): Array<{ path: string; pins: Pin[] }> {
+  const out: Array<{ path: string; pins: Pin[] }> = [];
+  for (const p of pins) {
+    if (p.source !== 'file') continue;
+    const path = p.path ?? 'system instructions';
+    const last = out[out.length - 1];
+    if (last && last.path === path) last.pins.push(p);
+    else out.push({ path, pins: [p] });
+  }
+  return out;
+}
+
+export function pinReplyText(pins: Pin[], verb: PinVerb = 'pin'): string {
+  if (verb === 'unpin') {
+    // `unpin` is a removal prompt, so it lists removal targets. Showing the file
+    // lines here offers the user things this command cannot act on, and with a
+    // file of any size the few numbered entries are buried under dozens of
+    // unactionable ones. `pin` still lists everything in effect.
+    const session = pins.filter((p) => p.source === 'session');
+    if (session.length === 0) {
+      const where = fileHeaders(pins);
+      const fromFile = pins.length > 0
+        ? `\n  ${pins.length} pinned ${pins.length === 1 ? 'line' : 'lines'} come from ${where.length === 1 ? where[0]!.path : `${where.length} files`}   (edit the file to change these)`
+        : '';
+      return `${PIN_REPLY_MARK}nothing to unpin${fromFile}`;
+    }
+    const lines = [`session   (@pxpipe unpin <n>, or unpin all)`, ''];
+    session.forEach((p, i) => lines.push(`${i + 1}. ${p.text}`));
+    return `${PIN_REPLY_MARK}${session.length} removable\n${lines.join('\n')}`;
+  }
+  if (pins.length === 0) {
+    return `${PIN_REPLY_MARK}nothing pinned\n  @pxpipe pin <instruction>`;
+  }
+  // Grouped under a source header rather than tagging each line: against a real
+  // CLAUDE.md the tag repeats down the whole list and buries the text it means to
+  // annotate. Only session pins are numbered, because only they can be removed by
+  // one, so the numbering doubles as the marker for what `unpin N` will act on.
+  const out: string[] = [];
+  const session = pins.filter((p) => p.source === 'session');
+  for (const group of fileHeaders(pins)) {
+    out.push('', `${group.path}   (edit the file to change these)`, '');
+    // Column 0, never indented: the pinned text is the user's markdown, and a
+    // four-space indent turns the whole block into one code span, which is how
+    // a rules file full of headings, tables and fences stops rendering at all.
+    for (const p of group.pins) out.push(p.text);
+  }
+  if (session.length > 0) {
+    out.push('', `session   (@pxpipe unpin <n>, or unpin all)`, '');
+    session.forEach((p, i) => out.push(`${i + 1}. ${p.text}`));
+  }
+  return `${PIN_REPLY_MARK}${pins.length} pinned\n${out.slice(1).join('\n')}`;
+}
+
+/**
+ * True when the live turn is nothing but pin commands, so the proxy can answer it
+ * without spending an upstream call. Deliberately narrow: a turn carrying any real
+ * prose, or a tool_result (a tool loop that must not be hijacked mid-flight), is
+ * forwarded normally with the command lines merely stripped.
+ */
+export function isPinOnlyRequest(messages: Message[] | undefined): boolean {
+  const last = (messages ?? [])[messages!.length - 1];
+  return !!last && isCommandOnlyTurn(last);
+}
+
+/**
+ * The verb the live turn ended with. Last one wins: a turn is answered once, so
+ * `pin x` followed by `unpin` is a removal prompt, not a listing.
+ */
+function liveVerb(m: Message | undefined): PinVerb {
+  let verb: PinVerb = 'pin';
+  if (!m) return verb;
+  const blocks: ContentBlock[] = typeof m.content === 'string'
+    ? [{ type: 'text', text: m.content }]
+    : Array.isArray(m.content) ? m.content : [];
+  for (const blk of blocks) {
+    const text = (blk as TextBlock)?.text;
+    if (typeof text !== 'string') continue;
+    for (const line of text.split('\n')) {
+      const cmd = PIN_CMD_RE.exec(line);
+      if (cmd) verb = cmd[1] as PinVerb;
+    }
+  }
+  return verb;
+}
+
+/**
+ * Answer a bare pin turn locally, or undefined to forward normally.
+ *
+ * Fails open on anything unexpected — a malformed body is the upstream's problem
+ * to report, not ours to swallow, and a parse quirk must never cost the user a
+ * turn that had real work in it.
+ */
+export function pinCommandResponse(
+  bodyIn: Uint8Array,
+): { body: string; contentType: string } | undefined {
+  let req: { messages?: Message[]; model?: string; stream?: boolean };
+  try {
+    req = JSON.parse(new TextDecoder().decode(bodyIn));
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(req.messages) || !isPinOnlyRequest(req.messages)) return undefined;
+  return synthesizeReply(
+    pinReplyText(foldPins(req.messages), liveVerb(req.messages[req.messages.length - 1])),
+    typeof req.model === 'string' ? req.model : 'pxpipe',
+    req.stream === true,
+  );
+}
+
+/** A local `/v1/messages` response carrying `text`, matching the client's
+ *  streaming preference. Zero usage: nothing was billed, and reporting otherwise
+ *  would corrupt the dashboard's token accounting. */
+export function synthesizeReply(
+  text: string,
+  model: string,
+  stream: boolean,
+): { body: string; contentType: string } {
+  const id = `msg_pxpipe_pin_${Date.now().toString(36)}`;
+  const usage = { input_tokens: 0, output_tokens: 0 };
+  if (!stream) {
+    return {
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id,
+        type: 'message',
+        role: 'assistant',
+        model,
+        content: [{ type: 'text', text }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage,
+      }),
+    };
+  }
+  const ev = (event: string, data: unknown) =>
+    `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  return {
+    contentType: 'text/event-stream',
+    body:
+      ev('message_start', {
+        type: 'message_start',
+        message: {
+          id,
+          type: 'message',
+          role: 'assistant',
+          model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage,
+        },
+      }) +
+      ev('content_block_start', {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text', text: '' },
+      }) +
+      ev('content_block_delta', {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text },
+      }) +
+      ev('content_block_stop', { type: 'content_block_stop', index: 0 }) +
+      ev('message_delta', {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+        usage: { output_tokens: 0 },
+      }) +
+      ev('message_stop', { type: 'message_stop' }),
+  };
+}

--- a/src/core/pin.ts
+++ b/src/core/pin.ts
@@ -42,7 +42,21 @@ const PIN_TOTAL_MAX_CHARS = 2000;
  * of copying: the rewrite stays a pure function of the message, so the protected
  * prefix remains byte-stable turn to turn, exactly like demoteProtectedHeadText.
  */
-const PIN_CMD_RE = /^[ \t]*@pxpipe[ \t]+(pin|unpin)\b[ \t]*(.*?)[ \t]*$/;
+const PIN_CMD_RE = /^@pxpipe[ \t]+(pin|unpin)\b(.*)$/;
+
+/**
+ * Parse one line as a pin command. Returns null when it isn't one.
+ *
+ * The surrounding whitespace is trimmed in JS rather than in the pattern. The
+ * obvious `^[ \t]*...[ \t]*(.*?)[ \t]*$` is quadratic: on a line of many tabs
+ * the leading, lazy, and trailing groups can all claim the same run, so the
+ * engine retries every split before failing. Prompt text reaches this on every
+ * line of every message, so it stays linear.
+ */
+function matchPinCmd(line: string): { verb: string; rest: string } | null {
+  const m = PIN_CMD_RE.exec(line.trim());
+  return m ? { verb: m[1]!, rest: m[2]!.trim() } : null;
+}
 
 /** Leading `<system-reminder>` run — the harness's CLAUDE.md envelope. */
 const LEADING_REMINDER_RE = /^\s*<system-reminder>[\s\S]*?<\/system-reminder>/;
@@ -106,13 +120,19 @@ export function foldPins(messages: Message[]): Pin[] {
   messages.forEach((m, idx) => {
     if (m.role !== 'user') return;
     for (const { line, source, path } of pinLines(m, idx)) {
-      const cmd = PIN_CMD_RE.exec(line);
+      const cmd = matchPinCmd(line);
       if (!cmd) continue;
-      if (cmd[1] === 'unpin') {
-        applyUnpin(pins, cmd[2]!.trim());
+      if (cmd.verb === 'unpin') {
+        applyUnpin(pins, cmd.rest);
         continue;
       }
-      const text = cmd[2]!.trim().slice(0, PIN_MAX_CHARS);
+      const raw = cmd.rest;
+      // Mark the cut. The source line is stripped from the outbound copy, so a
+      // severed rule reads to the model as a whole one — "do X unless Y" becomes
+      // "do X" — while the user's own transcript still shows the full text.
+      const text = raw.length > PIN_MAX_CHARS
+        ? `${raw.slice(0, PIN_MAX_CHARS)}… [pxpipe: pin truncated]`
+        : raw;
       if (source === 'file') {
         // A file is a document, not a list of instructions. Its blank lines and
         // its repeated lines ARE the format: a fence closes with the same ```
@@ -205,9 +225,19 @@ function* pinLines(
       const source: PinSource = leadingRun ? 'file' : 'session';
       // Per block, not per message: one leading run can inline several files,
       // and each pin has to remember which one to send the user back to.
+      let consumed = 0;
       for (const block of reminderBlocks(text)) {
+        consumed += block.length;
         const path = source === 'file' ? filePathOf(block) : undefined;
         for (const line of block.split('\n')) yield { line, source, path };
+      }
+      // The harness packs the envelope and the user's own typed prompt into the
+      // SAME block. Stopping at the run would strip a pin typed in the first
+      // turn (stripLines is unconditional) without ever folding it.
+      const rest = text.slice(consumed);
+      if (rest.trim()) {
+        leadingRun = false;
+        for (const line of rest.split('\n')) yield { line, source: 'session' };
       }
       continue;
     }
@@ -254,10 +284,14 @@ function isCommandOnlyTurn(m: Message): boolean {
     if ((blk as { type?: string }).type !== 'text') return false; // tool_result/image: real work
     const raw = (blk as TextBlock).text;
     if (typeof raw !== 'string') return false;
+    // The CLAUDE.md envelope rides in the same block as the user's first typed
+    // line. Stripping reminders before the test would classify that turn as
+    // command-only and drop the project's instructions from every later request.
+    if (LEADING_REMINDER_RE.test(raw)) return false;
     const text = raw.replace(ANY_REMINDER_RE, '');
     for (const line of text.split('\n')) {
       if (!line.trim()) continue;
-      if (!PIN_CMD_RE.test(line)) return false;
+      if (!matchPinCmd(line)) return false;
       sawCommand = true;
     }
   }
@@ -299,6 +333,16 @@ export function stripPinCommands(messages: Message[]): Message[] {
       continue;
     }
     const stripped = stripFromMessage(m);
+    if (stripped === null) {
+      // Commands and nothing else, with no confirmation to pair with. Keeping
+      // the original would send `@pxpipe pin ...` to the model as if it were a
+      // request; dropping it alone would break role alternation, so it goes
+      // with the reply that answered it. As the final turn there is no reply
+      // yet and proxy.ts answers locally, so leave it for that path.
+      if (messages[i + 1]?.role === 'assistant') { i++; continue; }
+      out.push(m);
+      continue;
+    }
     out.push(stripped ?? m);
   }
   return out;
@@ -308,11 +352,11 @@ export function stripPinCommands(messages: Message[]): Message[] {
  *  Returns the original when stripping would leave the message with no content —
  *  an empty `content` is rejected by the API, and dropping a lone message would
  *  break role alternation. */
-function stripFromMessage(m: Message): Message | undefined {
+function stripFromMessage(m: Message): Message | null | undefined {
   if (typeof m.content === 'string') {
     const text = stripLines(m.content);
     if (text === m.content) return undefined;
-    return text.trim() ? { ...m, content: text } : undefined;
+    return text.trim() ? { ...m, content: text } : null;
   }
   if (!Array.isArray(m.content)) return undefined;
   let changed = false;
@@ -324,8 +368,18 @@ function stripFromMessage(m: Message): Message | undefined {
         const text = stripLines(tb.text);
         if (text !== tb.text) {
           changed = true;
-          // Preserve cache_control: dropping the block would move the breakpoint.
-          if (!text.trim() && tb.cache_control === undefined) continue;
+          if (!text.trim()) {
+            // `{text: ''}` is rejected by the API, so the block cannot stay. Its
+            // cache_control can't just go with it — dropping a breakpoint moves
+            // the cache boundary — so hand it to the block in front.
+            const prev = blocks[blocks.length - 1] as TextBlock | undefined;
+            if (tb.cache_control !== undefined && prev) {
+              blocks[blocks.length - 1] = { ...prev, cache_control: tb.cache_control };
+            } else if (tb.cache_control !== undefined) {
+              blocks.push(blk); // nothing in front to hold it: leave as sent
+            }
+            continue;
+          }
           blocks.push({ ...tb, text });
           continue;
         }
@@ -333,14 +387,15 @@ function stripFromMessage(m: Message): Message | undefined {
     }
     blocks.push(blk);
   }
-  if (!changed || blocks.length === 0) return undefined;
+  if (!changed) return undefined;
+  if (blocks.length === 0) return null;
   return { ...m, content: blocks };
 }
 
 function stripLines(text: string): string {
   return text
     .split('\n')
-    .filter((line) => !PIN_CMD_RE.test(line))
+    .filter((line) => !matchPinCmd(line))
     .join('\n');
 }
 
@@ -355,7 +410,9 @@ export function pinBlockText(pins: Pin[]): string {
   let budget = PIN_TOTAL_MAX_CHARS;
   const lines: string[] = [];
   for (const p of pins) {
-    if (budget - p.text.length < 0) break;
+    // Skip, don't stop: one long file excerpt early in a big CLAUDE.md would
+    // otherwise swallow every session pin the user typed this turn.
+    if (budget - p.text.length < 0) continue;
     budget -= p.text.length;
     // Session pins are a list the user dictated one line at a time, so a bullet
     // is what they meant. A file excerpt is markdown the user already formatted;
@@ -373,6 +430,20 @@ export function pinBlockText(pins: Pin[]): string {
     ...lines,
     '</system-reminder>',
   ].join('\n');
+}
+
+/**
+ * True when appendPinBlock has somewhere to land.
+ *
+ * Pins are MOVED, not copied, so the strip and the append are one operation: an
+ * assistant prefill as the final message (nothing may follow it) or a final user
+ * turn with content we cannot push onto means the block has no home, and
+ * stripping anyway would delete the user's rules from the request entirely.
+ */
+export function canAppendPinBlock(messages: Message[]): boolean {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'user') return false;
+  return typeof last.content === 'string' || Array.isArray(last.content);
 }
 
 /** Append the pin block to the final user message. Returns chars added. */
@@ -484,8 +555,8 @@ function liveVerb(m: Message | undefined): PinVerb {
     const text = (blk as TextBlock)?.text;
     if (typeof text !== 'string') continue;
     for (const line of text.split('\n')) {
-      const cmd = PIN_CMD_RE.exec(line);
-      if (cmd) verb = cmd[1] as PinVerb;
+      const cmd = matchPinCmd(line);
+      if (cmd) verb = cmd.verb as PinVerb;
     }
   }
   return verb;

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -20,6 +20,7 @@ import {
   chatCompletionsUrl,
   openAIChatToAnthropicResponse,
 } from './messages-chat-bridge.js';
+import { pinCommandResponse } from './pin.js';
 import { parseGoogleModelFromPath, transformGoogleGenerateContent } from './google.js';
 import { isGeminiModel } from './gemini-model-profiles.js';
 import { resolveGptProfile } from './gpt-model-profiles.js';
@@ -1149,6 +1150,22 @@ export function createProxy(config: ProxyConfig = {}) {
         // Fail-closed: unreadable model → no compression, not a risky guess.
         const model = googleModel ?? readModelField(bodyIn);
         requestModel = model ?? undefined;
+        // A turn whose only content is `@pxpipe pin` / `@pxpipe unpin` is
+        // configuration, not a question. Answer it here: forwarding it would bill
+        // a full prefix to have the model paraphrase a list the proxy already
+        // holds, and the reply would be a guess about state it cannot see.
+        if (isMessages) {
+          const pinReply = pinCommandResponse(bodyIn);
+          if (pinReply) {
+            return new Response(pinReply.body, {
+              status: 200,
+              headers: {
+                'content-type': pinReply.contentType,
+                'cache-control': 'no-cache',
+              },
+            });
+          }
+        }
         // /v1/messages is only a wire schema: Claude Code can target a non-
         // Anthropic model (for example GPT-5.6 Sol). Do not apply Claude's
         // renderer or Anthropic count_tokens merely because the route is

--- a/src/core/tracker.ts
+++ b/src/core/tracker.ts
@@ -36,6 +36,13 @@ export interface TrackEvent {
   baseline_imaged_tokens?: number;
   /** Provider-specific estimate of pxpipe-added native text. */
   native_injected_tokens?: number;
+  /** Chars re-emitted as the pin footer on the last user message.
+   *  These are MOVED, not copied: the source lines are stripped from the
+   *  cacheable prefix and re-sent as plain text at the tail, so they are paid
+   *  at full input price every turn instead of cache-read price once. Not part
+   *  of orig_chars or compressed_chars, so any savings figure that ignores it
+   *  overstates the win by this much per turn. */
+  pin_chars?: number;
   /** TEXT chars in the outgoing body (all text blocks, incl. non-compressed tool_results).
    *  With image_pixels, a regression over cold-miss events solves chars_per_token (α) and pixels_per_token (β). */
   outgoing_text_chars?: number;
@@ -217,6 +224,9 @@ export function toTrackEvent(ev: ProxyEvent): TrackEvent {
     }
     if (info.outgoingTextChars !== undefined && info.outgoingTextChars > 0) {
       out.outgoing_text_chars = info.outgoingTextChars;
+    }
+    if (info.pinChars !== undefined && info.pinChars > 0) {
+      out.pin_chars = info.pinChars;
     }
     if (info.responsesComposition) {
       out.responses_composition = info.responsesComposition;

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -36,6 +36,7 @@ import {
   renderCellWidth,
   type RenderStyle,
 } from './render.js';
+import { appendPinBlock, foldPins, stripPinCommands, type Pin } from './pin.js';
 import { factSheetText } from './factsheet.js';
 import { stripSchemaDescriptions, schemaHasStructure } from './schema-strip.js';
 import { bytesToBase64 } from './png.js';
@@ -563,6 +564,10 @@ export interface TransformInfo {
   /** Total TEXT chars in the outgoing body (system + messages, excluding image base64).
    *  Denominator for empirical chars-per-token regression on cold-miss events. */
   outgoingTextChars?: number;
+  /** User-pinned instructions relocated to the request tail, and the chars that
+   *  cost. Both absent when nothing is pinned. Uncached by construction (the
+   *  block lands after every breakpoint), so these chars are paid every turn. */
+  pinChars?: number;
   /** OpenAI Responses only: local o200k decomposition of the ORIGINAL request
    *  before pxpipe rewrites it. No provider count_tokens call. Categories are
    *  mutually exclusive text-token estimates; imageParts counts native images. */
@@ -1491,6 +1496,19 @@ function approxBlockBytes(blk: ImageBlock): number {
 
 
 /**
+ * Emit the user's pins at the tail, immediately before serialization.
+ *
+ * Last, so nothing the transform does afterwards can bury them again, and after
+ * every cache_control breakpoint, so the appended bytes are always in the
+ * re-read suffix and can never invalidate a cached prefix.
+ */
+function applyPins(req: MessagesRequest, info: TransformInfo, pins: Pin[]): void {
+  if (pins.length === 0 || !Array.isArray(req.messages)) return;
+  const chars = appendPinBlock(req.messages, pins);
+  if (chars > 0) info.pinChars = chars;
+}
+
+/**
  * Run history-image compression on `req.messages` and finalize the body.
  * Called from both the main path AND early-exit paths (below_min_chars,
  * not_profitable) — history collapse must run even when the slab skips.
@@ -1501,6 +1519,7 @@ async function runHistoryCollapseAndFinalize(
   o: Required<TransformOptions>,
   opts: TransformOptions,
   droppedCodepoints: Map<number, number>,
+  pins: Pin[],
 ): Promise<{ body: Uint8Array; info: TransformInfo; collapsed: boolean }> {
   let collapsedFlag = false;
   if (Array.isArray(req.messages) && req.messages.length > 0) {
@@ -1568,6 +1587,7 @@ async function runHistoryCollapseAndFinalize(
       info.historyReason = histInfo.reason;
     }
   }
+  applyPins(req, info, pins);
   info.outgoingTextChars = countOutgoingTextChars(req);
   const outBody = new TextEncoder().encode(JSON.stringify(req));
   return { body: outBody, info, collapsed: collapsedFlag };
@@ -1631,6 +1651,25 @@ export async function transformRequest(
   } catch (e) {
     info.reason = `parse_error: ${(e as Error).message}`;
     return { body, info };
+  }
+
+  // 0. User-pinned instructions. Fold the transcript's pin commands, then remove
+  //    them from the outbound copy — the client's own transcript is untouched, so
+  //    the next request still carries every command and re-derives the same state.
+  //    The surviving pins are re-emitted at the very tail (applyPins, below), after
+  //    every cache breakpoint, where the model reads them last.
+  //    `pinsRewrote` is what the early-exit paths below test: when either the
+  //    strip or the tail append changed `req`, the original bytes no longer
+  //    describe the request and must not be the ones forwarded.
+  let pins: Pin[] = [];
+  let pinsRewrote = false;
+  if (Array.isArray(req.messages)) {
+    pins = foldPins(req.messages);
+    const stripped = stripPinCommands(req.messages);
+    pinsRewrote = pins.length > 0
+      || stripped.length !== req.messages.length
+      || stripped.some((m, i) => m !== req.messages![i]);
+    req.messages = stripped;
   }
 
   // 1. Pull system text out. Split into:
@@ -1788,12 +1827,15 @@ export async function transformRequest(
     // If history collapses, we flip `info.compressed = true` and let the
     // library wrapper return reason='applied'; otherwise this still
     // populates `outgoingTextChars` for the regression denominator.
-    const finalized = await runHistoryCollapseAndFinalize(req, info, o, opts, droppedCodepoints);
+    const finalized = await runHistoryCollapseAndFinalize(req, info, o, opts, droppedCodepoints, pins);
     if (finalized.collapsed) {
       info.compressed = true;
       return { body: finalized.body, info };
     }
-    return { body, info };
+    // `body` is the original bytes. If the pin pass edited `req`, those bytes
+    // describe a request we are no longer sending, so forwarding them would put
+    // the raw `@pxpipe pin` line back and drop the tail block.
+    return { body: pinsRewrote ? finalized.body : body, info };
   }
 
   // Break-even check guards even the slab (rare edge: tiny tool docs + tiny slab < 10k chars).
@@ -1857,12 +1899,15 @@ export async function transformRequest(
     info.reason = `not_profitable (slab=${combined.length} chars)`;
     bumpPassthrough(info, 'not_profitable');
     // Slab not profitable but history may still be collapsable — try before returning.
-    const finalized = await runHistoryCollapseAndFinalize(req, info, o, opts, droppedCodepoints);
+    const finalized = await runHistoryCollapseAndFinalize(req, info, o, opts, droppedCodepoints, pins);
     if (finalized.collapsed) {
       info.compressed = true;
       return { body: finalized.body, info };
     }
-    return { body, info };
+    // `body` is the original bytes. If the pin pass edited `req`, those bytes
+    // describe a request we are no longer sending, so forwarding them would put
+    // the raw `@pxpipe pin` line back and drop the tail block.
+    return { body: pinsRewrote ? finalized.body : body, info };
   }
 
   // Instruction header co-renders into the same PNG (+1.04pp L1 OCR vs baseline;
@@ -2242,6 +2287,7 @@ export async function transformRequest(
     }
     info.droppedCodepointsTop = out;
   }
+  applyPins(req, info, pins);
   info.outgoingTextChars = countOutgoingTextChars(req);
   const outBody = new TextEncoder().encode(JSON.stringify(req));
   return { body: outBody, info };

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -36,7 +36,7 @@ import {
   renderCellWidth,
   type RenderStyle,
 } from './render.js';
-import { appendPinBlock, foldPins, stripPinCommands, type Pin } from './pin.js';
+import { appendPinBlock, canAppendPinBlock, foldPins, stripPinCommands, type Pin } from './pin.js';
 import { factSheetText } from './factsheet.js';
 import { stripSchemaDescriptions, schemaHasStructure } from './schema-strip.js';
 import { bytesToBase64 } from './png.js';
@@ -568,6 +568,8 @@ export interface TransformInfo {
    *  cost. Both absent when nothing is pinned. Uncached by construction (the
    *  block lands after every breakpoint), so these chars are paid every turn. */
   pinChars?: number;
+  /** Pin folding threw and was skipped. The body still goes out unpinned. */
+  pinError?: string;
   /** OpenAI Responses only: local o200k decomposition of the ORIGINAL request
    *  before pxpipe rewrites it. No provider count_tokens call. Categories are
    *  mutually exclusive text-token estimates; imageParts counts native images. */
@@ -1661,15 +1663,25 @@ export async function transformRequest(
   //    `pinsRewrote` is what the early-exit paths below test: when either the
   //    strip or the tail append changed `req`, the original bytes no longer
   //    describe the request and must not be the ones forwarded.
+  //    Strip and append are one move, so both are skipped unless the tail can
+  //    take the block; otherwise the strip would delete the rules outright.
   let pins: Pin[] = [];
   let pinsRewrote = false;
-  if (Array.isArray(req.messages)) {
-    pins = foldPins(req.messages);
-    const stripped = stripPinCommands(req.messages);
-    pinsRewrote = pins.length > 0
-      || stripped.length !== req.messages.length
-      || stripped.some((m, i) => m !== req.messages![i]);
-    req.messages = stripped;
+  if (Array.isArray(req.messages) && canAppendPinBlock(req.messages)) {
+    try {
+      pins = foldPins(req.messages);
+      const stripped = stripPinCommands(req.messages);
+      pinsRewrote = pins.length > 0
+        || stripped.length !== req.messages.length
+        || stripped.some((m, i) => m !== req.messages![i]);
+      req.messages = stripped;
+    } catch (e) {
+      // A malformed message must not fail the request: pins are an optimization,
+      // the untouched body is still valid.
+      pins = [];
+      pinsRewrote = false;
+      info.pinError = String((e as Error)?.message ?? e);
+    }
   }
 
   // 1. Pull system text out. Split into:

--- a/src/dashboard/fragments.ts
+++ b/src/dashboard/fragments.ts
@@ -787,6 +787,12 @@ export function renderStatsTableFragment(p: FullStatsPayload): string {
     tr('original chars', numFmt(s.origCharsTotal)) +
     tr('image bytes', numFmt(s.imageBytesTotal)) +
     tr('bytes / char', charRatio) +
+    (s.pinEvents
+      ? tr(
+          'pin footer (uncached)',
+          `${numFmt(s.pinCharsTotal ?? 0)} chars / ${numFmt(s.pinEvents)} req`,
+        )
+      : '') +
     tr('latency p50 / p95', `${numFmt(s.durationP50)} / ${numFmt(s.durationP95)} ms`) +
     tr('first-byte p50 / p95', `${numFmt(s.firstByteP50)} / ${numFmt(s.firstByteP95)} ms`) +
     `</tbody></table>`

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -135,6 +135,8 @@ export interface FullStatsSummary {
   eventsWithBaseline: number;
   origCharsTotal: number;
   imageBytesTotal: number;
+  pinCharsTotal?: number;
+  pinEvents?: number;
   durationP50: number;
   durationP95: number;
   firstByteP50: number;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -28,6 +28,12 @@ export interface Summary {
    *  from the text path by rendering to PNG. */
   origCharsTotal: number;
   imageBytesTotal: number;
+  /** Sum of pin_chars: text pxpipe moved out of the cacheable prefix and
+   *  re-emitted as the tail footer. Paid at full input price every turn, so it
+   *  is a recurring charge against the one-time imaging win above. */
+  pinCharsTotal: number;
+  /** Requests that carried a pin footer. Zero means pins cost nothing. */
+  pinEvents: number;
   /** Aggregated Anthropic token usage. */
   inputTokensTotal: number;
   outputTokensTotal: number;
@@ -59,6 +65,8 @@ export function newSummary(): Summary {
     passthrough: 0,
     origCharsTotal: 0,
     imageBytesTotal: 0,
+    pinCharsTotal: 0,
+    pinEvents: 0,
     inputTokensTotal: 0,
     outputTokensTotal: 0,
     cacheCreateTokensTotal: 0,
@@ -87,6 +95,13 @@ export function fold(s: Summary, ev: TrackEvent): Summary {
   } else if (ev.compressed === false) {
     s.passthrough++;
     if (ev.reason) s.skipReasons.set(ev.reason, (s.skipReasons.get(ev.reason) ?? 0) + 1);
+  }
+
+  // Outside the compressed branch on purpose: the pin footer is appended on
+  // both the compressed and passthrough paths, so it is charged either way.
+  if (typeof ev.pin_chars === 'number' && ev.pin_chars > 0) {
+    s.pinCharsTotal += ev.pin_chars;
+    s.pinEvents++;
   }
 
   if (typeof ev.duration_ms === 'number') s.durationMs.push(ev.duration_ms);
@@ -181,6 +196,15 @@ export function renderTextReport(s: Summary): string {
   const ratio =
     s.origCharsTotal > 0 ? (s.imageBytesTotal / s.origCharsTotal).toFixed(3) : '—';
   lines.push(`  bytes/char ratio:   ${ratio}`);
+  if (s.pinEvents > 0) {
+    const perTurn = Math.round(s.pinCharsTotal / s.pinEvents);
+    lines.push(
+      `  pin footer:         ${fmtN(s.pinCharsTotal)} chars over ${fmtN(s.pinEvents)} req (~${fmtN(perTurn)}/req)`,
+    );
+    lines.push(
+      '    moved out of the cached prefix, so charged as fresh input every turn',
+    );
+  }
   lines.push('');
 
   lines.push('Anthropic token usage:');
@@ -299,6 +323,8 @@ export function summaryToJson(s: Summary): Record<string, unknown> {
     passthrough: s.passthrough,
     origCharsTotal: s.origCharsTotal,
     imageBytesTotal: s.imageBytesTotal,
+    pinCharsTotal: s.pinCharsTotal,
+    pinEvents: s.pinEvents,
     inputTokensTotal: s.inputTokensTotal,
     outputTokensTotal: s.outputTokensTotal,
     cacheCreateTokensTotal: s.cacheCreateTokensTotal,


### PR DESCRIPTION
## Problem

Opus 5 stops following the instructions you gave it. It overthinks, wanders
into files nobody asked about, and answers a question adjacent to the one you
typed. The rules are in CLAUDE.md, which the model read thousands of tokens
ago and now treats as background. Repeating the rule in the current turn fixes
it every time, which says the problem is distance, not comprehension.

## Mechanism

pxpipe reads `@pxpipe pin <text>` out of the user message, strips the command
line from the copy sent upstream, and re-emits the active pins as a
`<system-reminder>` block appended to the last user message. Every request now
ends with the rules, immediately before the model starts generating.

Pins are re-derived from the transcript on each request, so the block is a
pure function of the conversation. No server-side state and a resumed session
reconstructs the same block.

## Cost: the pin block is not cacheable

It sits after the cached prefix, on purpose. Moving it earlier would put the
rules back in background position and invalidate the prompt cache on every
edit. So the block is re-sent uncached each turn and billed as fresh input.

The dashboard already accounts for it: those characters are counted as
`pinChars`, not booked as savings, so the savings number stays honest.

Keep pins short. A few lines is the intended size; a pasted style guide is paid
for on every request.

## Usage

Two tiers, same syntax:

- an `@pxpipe pin` line in CLAUDE.md / AGENTS.md is durable
- a line typed in chat lives for the session

Command-only turns are answered by the proxy and never reach the model:
`@pxpipe pin` reports, `@pxpipe unpin <n>` and `unpin all` remove.

    You: @pxpipe pin no walls of text
    pxpipe · 1 pinned          (local reply, no tokens)

    ...40 turns later, that line is still the last thing before your question.

A turn counts as command-only by what the user typed. Harness-injected
`<system-reminder>` blocks are stripped first, otherwise Claude Code's own
notices make a bare `@pxpipe unpin` look like real work and bill it as a model
turn.
