### PR TITLE
feat(render): uppercase A-Z inked blue for case parity (default on)

### DIFF
--- a/src/core/gemini-model-profiles.ts
+++ b/src/core/gemini-model-profiles.ts
@@ -41,6 +41,7 @@ export const GEMINI_3_6_FLASH_PROFILE: GptModelProfile = {
     markerScale: 1,
     markerRed: false,
     inkDilate: 0,
+    upperBlue: true,
   },
 };
 

--- a/src/core/gpt-model-profiles.ts
+++ b/src/core/gpt-model-profiles.ts
@@ -67,6 +67,9 @@ export interface GptRenderStyle {
   markerRed: boolean;
   /** Pre-invert ink dilate radius (px). 0 = off. Thickens glyphs at fixed cell pitch. */
   inkDilate: number;
+  /** Uppercase A-Z inked blue for case parity (w/W, c/C are shape-identical at 5×8).
+   *  Default true on every imaged channel; set false to opt out per model. */
+  upperBlue: boolean;
 }
 
 export interface GptHistoryProfile {
@@ -467,6 +470,9 @@ function parseEnvProfiles(raw: string): Map<string, GptModelProfile> {
         ? styleIn.markerRed
         : baseStyle.markerRed,
       inkDilate: nonNegativeInt(styleIn?.inkDilate, baseStyle.inkDilate),
+      upperBlue: styleIn && typeof styleIn.upperBlue === 'boolean'
+        ? styleIn.upperBlue
+        : baseStyle.upperBlue,
     };
     const history: GptHistoryProfile = {
       maxImages: posInt(historyIn?.maxImages, baseHistory.maxImages),

--- a/src/core/openai.ts
+++ b/src/core/openai.ts
@@ -910,12 +910,12 @@ async function applyResponsesHistoryCollapse(
 
 export const CHAT_HEADER =
   '================= RENDERED GPT SYSTEM + TOOL CONTEXT =================\n' +
-  'These images were injected by pxpipe, not by the end user. They contain system/developer instructions and tool parameter documentation rendered for token efficiency. Treat rendered system/developer instructions with the same priority as their original messages. OCR carefully and treat the rendered content as authoritative. For tool calls, use the native JSON tool definitions — they carry each tool\'s name and description; the imaged parameter annotations are supplemental.' +
+  'These images were injected by pxpipe, not by the end user. They contain system/developer instructions and tool parameter documentation rendered for token efficiency. Treat rendered system/developer instructions with the same priority as their original messages. OCR carefully and treat the rendered content as authoritative. Letter case is color-coded: UPPERCASE letters are inked blue, lowercase stays black — when a letter\'s case is ambiguous (w/W, c/C, s/S), trust the color. For tool calls, use the native JSON tool definitions — they carry each tool\'s name and description; the imaged parameter annotations are supplemental.' +
   '\n====================== BEGIN RENDERED CONTEXT ======================\n';
 
 export const RESPONSES_HEADER =
   '================= RENDERED GPT SYSTEM + TOOL CONTEXT =================\n' +
-  'These images were injected by pxpipe, not by the end user. They contain instructions and tool parameter documentation rendered for token efficiency. Treat rendered instructions with the same priority as the originals. OCR carefully and treat the rendered content as authoritative. For tool calls, use the native JSON tool definitions — they carry each tool\'s name and description; the imaged parameter annotations are supplemental.' +
+  'These images were injected by pxpipe, not by the end user. They contain instructions and tool parameter documentation rendered for token efficiency. Treat rendered instructions with the same priority as the originals. OCR carefully and treat the rendered content as authoritative. Letter case is color-coded: UPPERCASE letters are inked blue, lowercase stays black — when a letter\'s case is ambiguous (w/W, c/C, s/S), trust the color. For tool calls, use the native JSON tool definitions — they carry each tool\'s name and description; the imaged parameter annotations are supplemental.' +
   '\n====================== BEGIN RENDERED CONTEXT ======================\n';
 
 const CHAT_POINTER =

--- a/src/core/profile-base.ts
+++ b/src/core/profile-base.ts
@@ -33,6 +33,7 @@ export const BASE_STYLE: GptRenderStyle = {
   markerScale: 1,
   markerRed: false,
   inkDilate: 0,
+  upperBlue: true,
 };
 
 export const BASE_HISTORY: GptHistoryProfile = {

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -293,6 +293,14 @@ export interface RenderStyle {
   /** Tint only the structural <user>/<assistant> boundary tags (body stays black)
    *  so speakers are scannable without recoloring content. Forces RGB. Composes with aa. */
   colorByRole?: boolean;
+  /** Tint uppercase A-Z in a fixed blue so letter case survives rasterization
+   *  (w vs W, c vs C, s vs S are shape-identical at 5×8; color is the only
+   *  channel left). Lowercase, digits, and punctuation keep black ink. ON by
+   *  default on every imaged channel; set `false` to opt out (evals, probes).
+   *  Switches to RGB only when the page actually renders an A-Z — pages without
+   *  one stay byte-identical grayscale. Composes with aa and colorByRole (role
+   *  tags keep their hue); under colorCycle the cycle color wins. */
+  upperBlue?: boolean;
   /** Morphological ink dilate radius in pixels (pre-invert). Thickens glyphs without
    *  changing cell pitch — pure-image OCR aid at fixed 5×8 density. 0/unset = off. */
   inkDilate?: number;
@@ -390,6 +398,12 @@ export const ROLE_PALETTE: [number, number, number][] = [
 ];
 const ROLE_SLOT_USER = 1;
 const ROLE_SLOT_ASSISTANT = 2;
+
+/** upperBlue ink: fixed blue for uppercase A-Z (case parity — color separates
+ *  W/w, C/c, S/s where 5×8 shapes cannot; a real w→W misread shipped before this).
+ *  Deliberately NOT the assistant-role blue [20,40,160]: history pages render
+ *  both signals, and the two blues must stay tellable apart. */
+export const UPPER_INK: [number, number, number] = [0, 70, 190];
 
 /**
  * Slot markers for the parallel "slot string" — the structure-through mechanism
@@ -898,13 +912,28 @@ export async function renderChunkToPng(
   // markerMask: 1 where ↵ glyph was inked; used to recolor those pixels red.
   const markerMask: Uint8Array | null =
     style.markerRed ? new Uint8Array(width * height) : null;
-  // colorMask: stores colorSlot per inked pixel (0 = background) for colorCycle / colorByRole RGB output.
+  // colorMask: stores colorSlot per inked pixel (0 = background) for colorCycle / colorByRole /
+  // upperBlue RGB output.
   const useColorCycle = style.colorCycle === true;
   const useColorByRole = style.colorByRole === true;
+  // upperBlue is ON unless opted out. It forces RGB only when this page actually inks an
+  // A-Z — pages without one keep byte-identical grayscale output. colorCycle already gives
+  // every glyph its own hue, so the cycle wins there; invert:false (eval-only polarity)
+  // skips it because the RGB composition below assumes ink-on-paper.
+  const useUpperBlue =
+    style.upperBlue !== false && style.invert !== false && !useColorCycle &&
+    fitLines.some((l) => /[A-Z]/.test(l));
   const colorMask: Uint8Array | null =
-    (useColorCycle || useColorByRole) ? new Uint8Array(width * height) : null;
+    (useColorCycle || useColorByRole || useUpperBlue) ? new Uint8Array(width * height) : null;
   // Ink palette is fixed for the whole page; the composition pass indexes it per pixel.
-  const inkPalette = useColorByRole ? ROLE_PALETTE : GLYPH_PALETTE;
+  // colorByRole reserves slots 1-2 for the role tags; uppercase ink rides behind them
+  // (slot 3) so both signals coexist on colored history pages.
+  const inkPalette: readonly [number, number, number][] = useColorByRole
+    ? [...ROLE_PALETTE, UPPER_INK]
+    : useUpperBlue
+      ? [UPPER_INK]
+      : GLYPH_PALETTE;
+  const upperSlot = useColorByRole ? ROLE_PALETTE.length + 1 : 1;
 
   /** Stamp colorSlot over the inked pixels of one glyph's cell span. Identical
    *  for every blit path — only the horizontal span differs (scaled markers
@@ -940,9 +969,17 @@ export async function renderChunkToPng(
       const codepoint = ch.codePointAt(0)!;
       const baseX = PAD_X + col * cellW;
       const isMarker = codepoint === NL_SENTINEL_CP;
-      const colorSlot = useColorByRole
-        ? (slotRow ? slotForMarkCp(slotRow[charIdx]?.codePointAt(0)) : 0) // 0 = body (black); only tags carry a role hue
-        : (glyphIndex % GLYPH_PALETTE.length) + 1; // 0 reserved for background in colorMask
+      // Case parity: uppercase A-Z carries the fixed blue ink; everything else stays slot 0 (black).
+      const upperInkSlot = useUpperBlue && codepoint >= 0x41 && codepoint <= 0x5a ? upperSlot : 0;
+      let colorSlot: number;
+      if (useColorByRole) {
+        const roleSlot = slotRow ? slotForMarkCp(slotRow[charIdx]?.codePointAt(0)) : 0;
+        colorSlot = roleSlot > 0 ? roleSlot : upperInkSlot; // tags keep their role hue
+      } else if (useUpperBlue) {
+        colorSlot = upperInkSlot;
+      } else {
+        colorSlot = (glyphIndex % GLYPH_PALETTE.length) + 1; // colorCycle; 0 reserved for background
+      }
       let advance: number;
       if (isMarker && markerScale > 1) {
         advance = blitGlyphScaled(fb, markerMask, width, height, baseX, baseY, codepoint, markerScale, style.font);
@@ -994,10 +1031,19 @@ export async function renderChunkToPng(
 
   let png: Uint8Array;
   if (colorMask) {
-    // colorCycle / colorByRole: AA-blend ink onto paper in palette color.
+    // colorCycle / colorByRole / upperBlue: AA-blend ink onto paper in palette color.
     const rgb = new Uint8Array(width * height * 3);
     for (let i = 0; i < fb.length; i++) {
       const g = fb[i]!; // post-invert (+ optional paper): 0 = ink, paper = background
+      // markerRed keeps priority over class/role ink now that upperBlue makes the
+      // colorMask path the common case — without this, enabling upperBlue would
+      // silently turn red ↵ markers black on markerRed pages.
+      if (markerMask && markerMask[i] === 1 && g < 128) {
+        rgb[i * 3] = 220;
+        rgb[i * 3 + 1] = 0;
+        rgb[i * 3 + 2] = 0;
+        continue;
+      }
       const slot = colorMask[i]!;
       if (slot > 0) {
         // coverage relative to paper so AA fringes stay correct on mid-light bg

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1883,6 +1883,8 @@ export async function transformRequest(
     ' For exact identifiers, paths, hashes, version strings, and numbers, use the adjacent' +
     ' exact-value factsheet; if a value was only visible in an image and is not in that factsheet,' +
     ' do not guess it — say it is not safe to quote from the image and re-read the source text.' +
+    ' Letter case is color-coded: UPPERCASE letters are inked blue, lowercase stays black —' +
+    ' when a letter\u2019s case is ambiguous (w/W, c/C, s/S), trust the color.' +
     reflowNoteImg +
     '\n====================== BEGIN RENDERED CONTEXT ======================\n';
   const combinedWithHeader = imageInstructionHeader + combined;

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -2374,3 +2374,138 @@ describe('colorByRole (structure-through slot string)', () => {
     expect(plain.png[25]).toBe(0); // 0 = grayscale
   });
 });
+
+describe('upperBlue (case parity: uppercase A-Z inked blue)', () => {
+  // Decode our own PNG output (filter=None, single IDAT, zlib) back to pixels.
+  // colorType 2 → RGB triples; colorType 0 → grayscale bytes.
+  const decodePng = async (
+    png: Uint8Array,
+  ): Promise<{ w: number; h: number; colorType: number; px: Uint8Array }> => {
+    const dv = new DataView(png.buffer, png.byteOffset, png.byteLength);
+    const w = dv.getUint32(16);
+    const h = dv.getUint32(20);
+    const colorType = png[25]!;
+    // Collect IDAT payloads.
+    const idat: Uint8Array[] = [];
+    let off = 8;
+    while (off < png.length) {
+      const len = dv.getUint32(off);
+      const type = String.fromCharCode(png[off + 4]!, png[off + 5]!, png[off + 6]!, png[off + 7]!);
+      if (type === 'IDAT') idat.push(png.subarray(off + 8, off + 8 + len));
+      off += 12 + len;
+    }
+    const ds = new DecompressionStream('deflate');
+    const writer = ds.writable.getWriter();
+    for (const part of idat) void writer.write(part.slice());
+    void writer.close();
+    const raw = new Uint8Array(await new Response(ds.readable).arrayBuffer());
+    const bpp = colorType === 2 ? 3 : 1;
+    const stride = w * bpp + 1;
+    const px = new Uint8Array(w * h * bpp);
+    for (let y = 0; y < h; y++) {
+      expect(raw[y * stride]).toBe(0); // filter None — matches our encoder
+      px.set(raw.subarray(y * stride + 1, y * stride + 1 + w * bpp), y * w * bpp);
+    }
+    return { w, h, colorType, px };
+  };
+
+  /** Distinct ink colors (r,g,b) present in a horizontal cell range [x0, x1). */
+  const inkColorsIn = (
+    img: { w: number; h: number; px: Uint8Array },
+    x0: number,
+    x1: number,
+  ): Set<string> => {
+    const out = new Set<string>();
+    for (let y = 0; y < img.h; y++) {
+      for (let x = x0; x < x1; x++) {
+        const i = (y * img.w + x) * 3;
+        const r = img.px[i]!, g = img.px[i + 1]!, b = img.px[i + 2]!;
+        if (r < 250 || g < 250 || b < 250) out.add(`${r},${g},${b}`); // any ink
+      }
+    }
+    return out;
+  };
+
+  const PAD = 4; // PAD_X
+  const cellX = (col: number, cellW: number) => PAD + col * cellW;
+
+  it('uppercase letters are inked blue; lowercase stays black (w/W, c/C separable by color alone)', async () => {
+    const cellW = renderCellWidth({});
+    for (const pair of ['wW', 'cC', 'sS'] as const) {
+      const img = await renderChunkToPng(pair, 10, {});
+      expect(img.png[25]).toBe(2); // truecolor: the page contains an uppercase
+      const decoded = await decodePng(img.png);
+      const lowerInk = inkColorsIn(decoded, cellX(0, cellW), cellX(1, cellW));
+      const upperInk = inkColorsIn(decoded, cellX(1, cellW), cellX(2, cellW));
+      // Lowercase cell: pure black ink only (r=g=b).
+      expect(lowerInk.size).toBeGreaterThan(0);
+      for (const c of lowerInk) {
+        const [r, g, b] = c.split(',').map(Number);
+        expect(r).toBe(g);
+        expect(g).toBe(b);
+      }
+      // Uppercase cell: fixed blue ink [0,70,190] (bit atlas → full coverage, exact palette).
+      expect(upperInk.has('0,70,190')).toBe(true);
+      // The two cells share no ink color — case is decidable by color alone.
+      for (const c of upperInk) expect(lowerInk.has(c)).toBe(false);
+    }
+  });
+
+  it('existing confusable-set semantics keep their ink: l/i/o black (lowercase), I/O blue, digits black', async () => {
+    const cellW = renderCellWidth({});
+    const img = await renderChunkToPng('lioIO01', 20, {});
+    const decoded = await decodePng(img.png);
+    for (let col = 0; col < 3; col++) { // l i o
+      for (const c of inkColorsIn(decoded, cellX(col, cellW), cellX(col + 1, cellW))) {
+        const [r, g, b] = c.split(',').map(Number);
+        expect([r, g, b]).toEqual([r, r, r]); // grayscale ink only
+      }
+    }
+    for (let col = 3; col < 5; col++) { // I O
+      expect(inkColorsIn(decoded, cellX(col, cellW), cellX(col + 1, cellW)).has('0,70,190')).toBe(true);
+    }
+    for (let col = 5; col < 7; col++) { // 0 1
+      for (const c of inkColorsIn(decoded, cellX(col, cellW), cellX(col + 1, cellW))) {
+        const [r, g, b] = c.split(',').map(Number);
+        expect([r, g, b]).toEqual([r, r, r]);
+      }
+    }
+  });
+
+  it('pages without any uppercase stay grayscale and byte-identical to pre-upperBlue output', async () => {
+    const noUpper = await renderChunkToPng('all lowercase 0123 !?', 40, {});
+    expect(noUpper.png[25]).toBe(0); // grayscale — no RGB penalty when the signal is unused
+    const optedOut = await renderChunkToPng('all lowercase 0123 !?', 40, { upperBlue: false });
+    expect(noUpper.png).toEqual(optedOut.png); // no-upper page is bit-for-bit the opted-out page
+  });
+
+  it('upperBlue: false opts out (uppercase page stays grayscale)', async () => {
+    const img = await renderChunkToPng('Wide CASE', 40, { upperBlue: false });
+    expect(img.png[25]).toBe(0);
+  });
+
+  it('composes with colorByRole: role tags keep their hue, uppercase body glyphs go blue', async () => {
+    const body = 'W';
+    const text = `<user>\n${body}\n</user>`;
+    const slot = roleSlotSegment('user', body, SLOT_MARK_USER);
+    const img = await renderChunkToPng(text, 40, { colorByRole: true }, undefined, slot);
+    const decoded = await decodePng(img.png);
+    const all = inkColorsIn(decoded, 0, decoded.w);
+    expect(all.has('150,20,20')).toBe(true); // ROLE_PALETTE user tag red survives
+    expect(all.has('0,70,190')).toBe(true); // body W carries the uppercase blue
+  });
+
+  it('AA path blends toward the uppercase blue (blue channel dominates red on W ink)', async () => {
+    const cellW = renderCellWidth({ aa: true });
+    const img = await renderChunkToPng('wW', 10, { aa: true });
+    const decoded = await decodePng(img.png);
+    const upperInk = inkColorsIn(decoded, cellX(1, cellW), cellX(2, cellW));
+    expect(upperInk.size).toBeGreaterThan(0);
+    let sawBlueDominant = false;
+    for (const c of upperInk) {
+      const [r, , b] = c.split(',').map(Number);
+      if (b! > r! + 40) sawBlueDominant = true;
+    }
+    expect(sawBlueDominant).toBe(true);
+  });
+});

--- a/tests/upper-blue.test.ts
+++ b/tests/upper-blue.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+import {
+  renderChunkToPng,
+  roleSlotSegment,
+  SLOT_MARK_USER,
+  UPPER_INK,
+  ROLE_PALETTE,
+  CELL_H,
+  CELL_W,
+} from '../src/core/render.js';
+
+/**
+ * upperBlue (case parity): uppercase A-Z carries a fixed blue ink so letter
+ * case survives rasterization. At 5×8, w/W, c/C, s/S, x/X, z/Z differ only by
+ * scale — after the vision encoder resamples, color is the only channel left.
+ * A real w→W misread shipped before this; owner approved the defensive
+ * implementation without a red repro (200/200 single-image probes stayed
+ * clean; the misread happened in long-context).
+ */
+
+interface DecodedPng {
+  width: number;
+  height: number;
+  channels: 1 | 3;
+  /** Row-major; grayscale 1 byte/px, RGB 3 bytes/px. */
+  pixels: Uint8Array;
+}
+
+async function inflateZlib(data: Uint8Array): Promise<Uint8Array> {
+  const ds = new DecompressionStream('deflate');
+  const stream = new Blob([data as BlobPart]).stream().pipeThrough(ds);
+  const buf = await new Response(stream).arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+/** Minimal decoder for this repo's own encoder: 8-bit gray/RGB, filter None, single IDAT. */
+async function decodePng(png: Uint8Array): Promise<DecodedPng> {
+  const dv = new DataView(png.buffer, png.byteOffset, png.byteLength);
+  const width = dv.getUint32(16);
+  const height = dv.getUint32(20);
+  const colorType = png[25]!;
+  const channels = colorType === 2 ? 3 : 1;
+  // Walk chunks, concat IDAT payloads.
+  const idat: Uint8Array[] = [];
+  let off = 8;
+  while (off < png.length) {
+    const len = dv.getUint32(off);
+    const type = String.fromCharCode(png[off + 4]!, png[off + 5]!, png[off + 6]!, png[off + 7]!);
+    if (type === 'IDAT') idat.push(png.subarray(off + 8, off + 8 + len));
+    off += 12 + len;
+  }
+  const raw = await inflateZlib(
+    idat.length === 1 ? idat[0]! : new Uint8Array(idat.flatMap((c) => [...c])),
+  );
+  const stride = width * channels + 1;
+  const pixels = new Uint8Array(width * height * channels);
+  for (let y = 0; y < height; y++) {
+    expect(raw[y * stride]).toBe(0); // filter None — matches png.ts encoder
+    pixels.set(raw.subarray(y * stride + 1, (y + 1) * stride), y * width * channels);
+  }
+  return { width, height, channels, pixels };
+}
+
+const PAD = 4; // PAD_X = PAD_Y = 4 in render.ts
+
+/** Classify every inked pixel of a single-line render by source column (= char index
+ *  when all chars are width-1). Returns per-char ink summaries. */
+function inkByChar(img: DecodedPng, text: string): { blue: number; black: number }[] {
+  const out = Array.from(text, () => ({ blue: 0, black: 0 }));
+  for (let y = 0; y < img.height; y++) {
+    for (let x = 0; x < img.width; x++) {
+      const col = Math.floor((x - PAD) / CELL_W);
+      if (col < 0 || col >= text.length) continue;
+      let r: number, g: number, b: number;
+      if (img.channels === 3) {
+        const i = (y * img.width + x) * 3;
+        r = img.pixels[i]!; g = img.pixels[i + 1]!; b = img.pixels[i + 2]!;
+      } else {
+        r = g = b = img.pixels[y * img.width + x]!;
+      }
+      if (r > 200 && g > 200 && b > 200) continue; // background
+      if (b > r + 40) out[col]!.blue++;
+      else if (r === g && g === b) out[col]!.black++;
+    }
+  }
+  return out;
+}
+
+describe('upperBlue (uppercase case-parity ink)', () => {
+  it('uppercase inks blue, lowercase and digits stay black', async () => {
+    const text = 'abc XYZ 019';
+    const img = await renderChunkToPng(text, 40);
+    expect(img.png[25]).toBe(2); // page has A-Z → RGB
+    const ink = await decodePng(img.png).then((d) => inkByChar(d, text));
+    for (const [i, ch] of Array.from(text).entries()) {
+      if (/[A-Z]/.test(ch)) {
+        expect(ink[i]!.blue, `'${ch}' should be blue`).toBeGreaterThan(0);
+        expect(ink[i]!.black, `'${ch}' should carry no black ink`).toBe(0);
+      } else if (ch !== ' ') {
+        expect(ink[i]!.black, `'${ch}' should be black`).toBeGreaterThan(0);
+        expect(ink[i]!.blue, `'${ch}' should carry no blue ink`).toBe(0);
+      }
+    }
+  });
+
+  it('shape-identical case pairs (w/W, c/C, s/S, x/X, z/Z) are color-distinguishable', async () => {
+    const text = 'wW cC sS xX zZ';
+    const ink = await decodePng((await renderChunkToPng(text, 40)).png).then((d) =>
+      inkByChar(d, text),
+    );
+    for (const [lo, hi] of [[0, 1], [3, 4], [6, 7], [9, 10], [12, 13]] as const) {
+      expect(ink[lo]!.blue, `'${text[lo]}' lower must not be blue`).toBe(0);
+      expect(ink[lo]!.black).toBeGreaterThan(0);
+      expect(ink[hi]!.blue, `'${text[hi]}' upper must be blue`).toBeGreaterThan(0);
+      expect(ink[hi]!.black).toBe(0);
+    }
+  });
+
+  it('pages without any A-Z stay grayscale and byte-identical to upperBlue:false', async () => {
+    const text = 'lowercase only 123 — 中文 too';
+    const on = await renderChunkToPng(text, 60);
+    const off = await renderChunkToPng(text, 60, { upperBlue: false });
+    expect(on.png[25]).toBe(0); // still grayscale — cache/byte story intact
+    expect(on.png).toEqual(off.png);
+  });
+
+  it('upperBlue:false restores the exact legacy bytes for uppercase pages', async () => {
+    const text = 'Mixed CASE content';
+    const off = await renderChunkToPng(text, 40, { upperBlue: false });
+    expect(off.png[25]).toBe(0); // opt-out = legacy grayscale output
+  });
+
+  it('pixel diff vs upperBlue:false is confined to uppercase cells (no layout drift)', async () => {
+    const text = 'The Quick brown FOX 42 jumps';
+    const on = await decodePng((await renderChunkToPng(text, 40)).png);
+    const off = await decodePng((await renderChunkToPng(text, 40, { upperBlue: false })).png);
+    expect(on.width).toBe(off.width);
+    expect(on.height).toBe(off.height);
+    const chars = Array.from(text);
+    for (let y = 0; y < on.height; y++) {
+      for (let x = 0; x < on.width; x++) {
+        const g = off.pixels[y * off.width + x]!;
+        const i = (y * on.width + x) * 3;
+        const same =
+          on.pixels[i] === g && on.pixels[i + 1] === g && on.pixels[i + 2] === g;
+        if (same) continue;
+        const col = Math.floor((x - PAD) / CELL_W);
+        const ch = chars[col] ?? '';
+        expect(/[A-Z]/.test(ch), `diff pixel at (${x},${y}) outside uppercase cell '${ch}'`).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it('composes with colorByRole: role tags keep their hue, body uppercase goes blue', async () => {
+    const body = 'Say HELLO world';
+    const text = `<user>\n${body}\n</user>`;
+    const slot = roleSlotSegment('user', body, SLOT_MARK_USER);
+    const img = await renderChunkToPng(text, 40, { colorByRole: true }, undefined, slot);
+    expect(img.png[25]).toBe(2);
+    const d = await decodePng(img.png);
+    // Row 0 = "<user>" tag → ROLE_PALETTE[0] red. Row 1 = body.
+    const [tagR] = ROLE_PALETTE[0]!;
+    let sawTagHue = 0;
+    let sawBodyBlue = 0;
+    let sawBodyBlack = 0;
+    for (let y = 0; y < d.height; y++) {
+      const row = Math.floor((y - PAD) / CELL_H);
+      for (let x = 0; x < d.width; x++) {
+        const i = (y * d.width + x) * 3;
+        const [r, g, b] = [d.pixels[i]!, d.pixels[i + 1]!, d.pixels[i + 2]!];
+        if (r > 200 && g > 200 && b > 200) continue;
+        if (row === 0 && r > b + 40 && Math.abs(r - tagR) < 90) sawTagHue++;
+        if (row === 1 && b > r + 40) sawBodyBlue++;
+        if (row === 1 && r === g && g === b) sawBodyBlack++;
+      }
+    }
+    expect(sawTagHue).toBeGreaterThan(0); // <user> stayed red
+    expect(sawBodyBlue).toBeGreaterThan(0); // HELLO went blue
+    expect(sawBodyBlack).toBeGreaterThan(0); // lowercase body stayed black
+  });
+
+  it('markerRed ↵ pixels stay red when upperBlue forces the RGB path', async () => {
+    const text = 'Alpha↵Beta';
+    const d = await decodePng(
+      (await renderChunkToPng(text, 40, { markerRed: true })).png,
+    );
+    let sawRed = 0;
+    for (let i = 0; i < d.pixels.length; i += 3) {
+      if (d.pixels[i]! > 180 && d.pixels[i + 1]! < 60 && d.pixels[i + 2]! < 60) sawRed++;
+    }
+    expect(sawRed).toBeGreaterThan(0);
+  });
+
+  it('UPPER_INK is distinct from the assistant role blue', () => {
+    expect(UPPER_INK).not.toEqual(ROLE_PALETTE[1]);
+  });
+});


### PR DESCRIPTION
## What

Uppercase A–Z now carries a fixed blue ink (`UPPER_INK = [0,70,190]`) on every imaged channel — case parity for shape-identical pairs. Lowercase, digits, and punctuation keep black ink; the `l/i/I/o/O` reading rules and the red `↵` marker are unchanged.

At 5×8, `w/W`, `c/C`, `s/S`, `x/X`, `z/Z` differ only by scale, and after the vision encoder resamples, scale is gone — color is the only channel left. A real `w→W` misread shipped in long-context; 200/200 single-image probes never reproduced it, and the owner approved implementing the defense without a red repro.

## How

- `render.ts`: new `RenderStyle.upperBlue` (default **on**; `false` opts out). Rides the existing colorMask/palette machinery — no slot-string, wrap, or shrink changes.
  - Pages with **no** A-Z stay byte-identical grayscale (colorMask not allocated), so the cache/byte-freeze story is intact for pages the feature doesn't touch.
  - Composes with `colorByRole` (role tags keep their hue; uppercase body glyphs go blue — deliberately NOT the assistant-role blue so both signals stay tellable apart) and with `markerRed` (red `↵` keeps priority on the RGB path). `colorCycle` wins where explicitly set.
- Banners (`transform.ts` slab header, `openai.ts` CHAT/RESPONSES headers): document the new semantics — "UPPERCASE letters are inked blue, lowercase stays black — when a letter's case is ambiguous (w/W, c/C, s/S), trust the color."
- Profiles: `GptRenderStyle.upperBlue` wired through `BASE_STYLE`, the Gemini profile, and `PXPIPE_MODELS` env-override parsing, so it can be disabled per model.

## No-regression evidence

- `pnpm run typecheck` clean; `pnpm test` **934/934** green (52 files), including 14 new targeted tests (`tests/upper-blue.test.ts` + `tests/render.test.ts`): uppercase-blue/lowercase-black per-cell ink assertions, w/W-style pair distinguishability, l/i/o/I/O/digit ink semantics preserved, byte-identity for no-uppercase pages and for `upperBlue:false`, pixel diff confined to uppercase cells (no layout drift), `colorByRole` + `markerRed` composition.
- Out-of-band golden check: rendered a 22-page corpus (render.ts source, mixed-case, lowercase-only, CJK-mix) on base `d41f056` vs this branch, decoded both PNG sets, and pixel-diffed 22.8M pixels: **86,553 differing px, 0 non-blue** — every changed pixel is blue-dominant uppercase ink; dimensions, wrap, page count all byte-stable. Lowercase-only pages: **0 differing pixels**. `upperBlue:false` reproduces base **bit-for-bit** on all 22 pages.
- Size (recorded, not gated): grayscale→RGB flip costs bytes on pages that contain uppercase, e.g. dense code page 13.5 KB → 24.1 KB (+78%), CJK-mix page 4.5 KB → 52.7 KB (worst case: RGB + colored ink defeats the gray palette). Billed vision tokens are unchanged — patch-grid billing is dimension-only, and dimensions are untouched.

Scope guard: no changes to fold/wrap anchors, slot/lockstep mechanism, or `shrinkColsToContent`/degradation paths.
