### PR TITLE
Add Novita AI as a provider option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ behavioral changes, patch = fixes).
 
 ## Unreleased
 
+### Added
+- Documented routing to Novita's OpenAI-compatible endpoint via the existing
+  `OPENAI_UPSTREAM` / `OPENAI_MODELS` mechanism (no new code path).
+
 ### Changed
 - Opt-in `gpt-5.6-sol` now uses native 14px JetBrains Mono at 84 columns. Its paid
   pilot preserved gist and guard checks, read 7/8 exact values, and produced no

--- a/docs/CLAUDE_CODE_PROVIDER_ROUTING.md
+++ b/docs/CLAUDE_CODE_PROVIDER_ROUTING.md
@@ -9,6 +9,13 @@ Claude models use Anthropic by default. Two optional routes can run together:
 - `OPENAI_MODELS` routes exact model IDs to OpenAI Responses.
 - `CLOUDFLARE_MODELS` routes exact model IDs to Cloudflare's OpenAI-compatible endpoint.
 
+Any OpenAI-compatible provider, including [Novita](https://novita.ai/), can be
+routed the same way `OPENAI_MODELS` already routes to OpenAI itself — set
+`OPENAI_UPSTREAM` to that provider's base URL and list its model IDs. This is
+untested end to end (see the caveat above); it follows the same
+`OPENAI_UPSTREAM` + `OPENAI_MODELS` mechanism already documented below, not a
+new code path.
+
 If a model appears in both lists, precedence is:
 
 ```text
@@ -38,6 +45,25 @@ The Cloudflare variables derive this OpenAI-compatible endpoint:
 ```text
 https://api.cloudflare.com/client/v4/accounts/<account-id>/ai/v1
 ```
+
+### Novita (OpenAI-compatible)
+
+Novita exposes an OpenAI-compatible endpoint, so it goes through the same
+`OPENAI_UPSTREAM` / `OPENAI_MODELS` route as OpenAI itself — no separate flag:
+
+```bash
+OPENAI_UPSTREAM=https://api.novita.ai/openai \
+OPENAI_API_KEY=your-novita-key \
+OPENAI_MODELS=deepseek/deepseek-v3.2 \
+npx pxpipe-proxy
+```
+
+Swap `OPENAI_MODELS` for any [Novita model ID](https://novita.ai/models). This
+was verified against Novita's `/openai/v1/responses` and
+`/openai/v1/chat/completions` endpoints (both reject with an auth error rather
+than 404, confirming the routes exist); the actual model reply was not
+exercised end to end, so treat the routing as reachable but unverified, same
+disclaimer as everything past Kimi K3 above.
 
 ## Connect Claude Code
 


### PR DESCRIPTION
## Summary

- Adds Novita AI as a provider option.

## Validation

Compared against the baseline on `d41f0566f10c`: compared_to_baseline. Pre-existing failures are left as-is.

## Reviewer Notes

- **This is a documentation-only change; no code path is added or modified.** Novita's inference API is OpenAI-compatible and routes through the `OPENAI_UPSTREAM` / `OPENAI_MODELS` mechanism this project already ships and already documents for OpenAI itself (and, via Cloudflare, for Kimi K3). We did not add a new provider abstraction.
- **The routing was verified reachable, not functionally exercised.** We do not hold a Novita API key. `curl` against `https://api.novita.ai/openai/v1/responses` and `.../v1/chat/completions` both return `403 INVALID_API_KEY` rather than `404`, which confirms the endpoints exist at the documented shape, but we did not send an authenticated request and confirm a real completion comes back through pxpipe end to end.
- **Model ID in the example (`deepseek/deepseek-v3.2`) was pulled from Novita's live `/v3/openai/models` listing** at the time of writing, not guessed; it may not be the model you'd choose to feature.
- **Token-compression eligibility (`PXPIPE_GPT_PROFILES` / render profile) is intentionally out of scope.** Making a Novita model participate in this project's image-compression feature requires a measured vision-token cost profile (as every other model in `src/core/gpt-model-profiles.ts` has), and we had no way to measure that without an API key. Listing a placeholder number would corrupt the profitability gate silently. This PR only adds the routing recipe; a model added this way runs uncompressed until someone measures and contributes a profile, same as any other newly-routed OpenAI-compatible model on day one.
- Full test suite (`pnpm test`, 51 files / 920 tests) passes identically before and after this change, which is expected for a docs-only diff.
