### PR TITLE
build(ci): pin trusted supply-chain inputs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    groups:
-      workflow-actions:
-        patterns:
-          - "*"
     open-pull-requests-limit: 5
     commit-message:
       prefix: build

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,14 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: build
+
+  # Keep package.json and pnpm-lock.yaml under the same automated review loop.
+  # Dependabot's default three-day cooldown applies to version updates;
+  # security updates are intentionally not delayed.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: build

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # Workflow actions are pinned to immutable commits. Dependabot proposes the
+  # reviewed SHA changes while retaining the human-readable major tags in the
+  # workflow comments.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      workflow-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,15 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Do not leave the read token in git config while dependency scripts
+          # and the repository test/build commands execute.
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,20 +2,23 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
-
-permissions:
-  contents: write # create the GitHub Release for the pushed tag
-  id-token: write # npm provenance / trusted publishing
+    tags: ["v*"]
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release # must match the npm Trusted Publisher config
+    permissions:
+      contents: read
+      id-token: write # npm provenance / trusted publishing
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Publishing uses OIDC, and the release job receives its own token.
+          # No later command needs a credential persisted in git config.
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: pnpm
@@ -35,11 +38,19 @@ jobs:
           fi
       # prepublishOnly runs typecheck + tests + build as the gate
       # Auth via npm Trusted Publisher (OIDC) - no token needed.
-      # Requires npm >= 11.5; upgrade explicitly to avoid relying on the bundled version.
+      # Requires npm >= 11.5. Pin the reviewed publishing client so a release
+      # cannot execute a newly-published npm@latest version without a code review.
       - if: steps.check.outputs.skip == 'false'
         run: |
-          npm install -g npm@latest
+          npm install --global npm@12.0.2
           npm publish --access public --provenance
+
+  release:
+    needs: publish
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # create the GitHub Release for the pushed tag
+    steps:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,17 @@ jobs:
           node-version: 24.15.0
           cache: pnpm
           registry-url: https://registry.npmjs.org
-      - run: pnpm install --frozen-lockfile
+      - name: Verify tag matches package version
+        run: |
+          EXPECTED_TAG="v$(node -p "require('./package.json').version")"
+          if [ "$GITHUB_REF_NAME" != "$EXPECTED_TAG" ]; then
+            echo "release tag $GITHUB_REF_NAME does not match package version $EXPECTED_TAG" >&2
+            exit 1
+          fi
+      # The publish job can mint an npm OIDC token. Do not execute transitive
+      # dependency lifecycle scripts in that privileged job; the repository's
+      # own prepublishOnly gate still runs during npm publish below.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       # Skip if this version is already on the registry (idempotent re-runs)
       - name: Check version not already published
         id: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,15 @@ on:
   push:
     tags: ["v*"]
 
+# Never let two runs for the same tag race through registry checks/publishing.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     environment: release # must match the npm Trusted Publisher config
     permissions:
       contents: read
@@ -17,6 +23,8 @@ jobs:
           # Publishing uses OIDC, and the release job receives its own token.
           # No later command needs a credential persisted in git config.
           persist-credentials: false
+          # Required to prove the tagged commit belongs to the default branch.
+          fetch-depth: 0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
@@ -26,10 +34,17 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - name: Verify tag matches package version
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           EXPECTED_TAG="v$(node -p "require('./package.json').version")"
           if [ "$GITHUB_REF_NAME" != "$EXPECTED_TAG" ]; then
             echo "release tag $GITHUB_REF_NAME does not match package version $EXPECTED_TAG" >&2
+            exit 1
+          fi
+          TAGGED_COMMIT=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$TAGGED_COMMIT" "origin/$DEFAULT_BRANCH"; then
+            echo "tagged commit $TAGGED_COMMIT is not reachable from $DEFAULT_BRANCH" >&2
             exit 1
           fi
       # The publish job can mint an npm OIDC token. Do not execute transitive
@@ -60,6 +75,7 @@ jobs:
   release:
     needs: publish
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions:
       contents: write # create the GitHub Release for the pushed tag
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24
+          # npm@12.0.2 requires Node 24.15.0 or newer. Keep this exact so a
+          # runner tool-cache change cannot silently alter the release runtime.
+          node-version: 24.15.0
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
@@ -42,7 +44,7 @@ jobs:
       # cannot execute a newly-published npm@latest version without a code review.
       - if: steps.check.outputs.skip == 'false'
         run: |
-          npm install --global npm@12.0.2
+          npm install --global --ignore-scripts npm@12.0.2
           npm publish --access public --provenance
 
   release:
@@ -54,6 +56,9 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job intentionally has no checkout. Tell gh which repository to
+          # target instead of relying on a git remote that is not present.
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
             gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes


### PR DESCRIPTION
Addresses the workflow supply-chain recommendations in #87.

## What changed

- pin checkout, pnpm setup, and Node setup actions to reviewed immutable commits
- pin the runner family, release Node runtime, and npm publishing client
- disable checkout credential persistence and dependency lifecycle scripts in the OIDC-enabled publish job
- split npm publishing and GitHub Release creation into least-privilege jobs
- make the checkout-free release job target the repository explicitly
- require the tag to match package.json and the tagged commit to be reachable from the default branch
- serialize releases per tag and bound CI, publish, and release job runtimes
- add separate Dependabot review loops for GitHub Actions and npm/pnpm dependencies

## Validation

- action SHAs verified against upstream tag refs
- workflow YAML and shell expressions pass actionlint
- Dependabot YAML parses successfully
- clean install with dependency lifecycle scripts disabled passed typecheck, 920 tests, and build
- pnpm audit reports no known vulnerabilities
- hosted CI passed

A real npm publication was intentionally not performed because that would create an external release.