### PR TITLE
feat(profiles): per-content-class render geometry for collapsed history

### DIFF
--- a/docs/MODEL_RENDER_PROFILES.md
+++ b/docs/MODEL_RENDER_PROFILES.md
@@ -64,6 +64,38 @@ PXPIPE_GPT_PROFILES='{"gpt-5.6-sol":{"stripCols":120}}'
 The profitability gate uses the same resolved profile as the renderer, so a
 style or geometry override cannot leave cost prediction on stale dimensions.
 
+### Per-content-class geometry
+
+`historyStripCols` and `historyStyle` override `stripCols` and `style` for
+**collapsed history only**. The static slab and tool-result pages keep the dense
+geometry. Both are undefined in every shipped profile, so leaving them out
+changes nothing.
+
+```bash
+PXPIPE_GPT_PROFILES='{"claude-opus-5":{"historyStripCols":172,"historyStyle":{"font":"jetbrains-mono-14"}}}'
+```
+
+They exist because reading accuracy and rendering cost are not the same axis.
+Geometry is shared across a provider's models because the *billing* is, but
+verbatim recall is not. Measured on one 26-value battery — commit SHAs, 32-char
+md5 hashes, three-decimal ratios, currency to the cent, timestamped filenames —
+rendered at the shipped 312-column dense geometry:
+
+| reader | exact | silently wrong |
+|---|---|---|
+| Fable 5 | 25/26 | 1/26 (capitalisation) |
+| Opus 5 | 3/26 | **10/26** |
+| Opus 5 at `jetbrains-mono-14`, 172 cols | **100/100** | **0/100** |
+
+So `NOT-OCR.md`'s "unreliable at any size" holds at production density and not
+below it. The trade is real and the caller should make it: on 400 000 characters
+of live transcript, dense rendering is 5.28× cheaper than text and legible
+rendering 1.47×.
+
+**Set both fields together.** A larger font at unchanged columns overshoots the
+provider's no-resize width, gets downscaled server-side, and loses exactly the
+legibility it was meant to buy.
+
 ## Unmeasured families
 
 An id that names a family pxpipe HAS measured, but does not match any of that

--- a/src/core/gpt-model-profiles.ts
+++ b/src/core/gpt-model-profiles.ts
@@ -113,6 +113,23 @@ export interface GptModelProfile {
   history: GptHistoryProfile;
   /** Complete model-specific font, cell spacing, color, and marker style. */
   style: GptRenderStyle;
+  /** Optional override of `stripCols` for COLLAPSED HISTORY only, leaving the
+   *  slab and tool-result pages on `stripCols`. Undefined = use `stripCols`,
+   *  i.e. behaviour is unchanged unless a profile opts in.
+   *
+   *  Exists because reading accuracy and rendering cost are not the same axis.
+   *  Geometry is identical across a provider's models because the *billing* is,
+   *  but verbatim recall is not: on one 26-value battery at this profile's
+   *  312-col dense geometry, Fable 5 read 25/26 exactly while Opus 5 read 3/26
+   *  with 10 silent substitutions. A deployment that must re-read exact values
+   *  out of imaged history needs a lower density there — and only there, since
+   *  the static slab holds no such values. */
+  historyStripCols?: number;
+  /** Optional override of `style` for collapsed history only. Same rationale as
+   *  `historyStripCols`; set both together, since a larger font at unchanged
+   *  columns overshoots the provider's no-resize width and is silently
+   *  downscaled, which removes the legibility it was meant to buy. */
+  historyStyle?: GptRenderStyle;
   /** Maximum serialized provider request produced by pxpipe. Undefined leaves
    *  legacy behavior unchanged. Checked in the transform (which falls back to
    *  the original body when imaging would overshoot) and enforced again on the
@@ -477,6 +494,17 @@ function parseEnvProfiles(raw: string): Map<string, GptModelProfile> {
       framing: historyFraming(historyIn?.framing, baseHistory.framing),
       factSheetScope: factSheetScope(historyIn?.factSheetScope, baseHistory.factSheetScope),
     };
+    // History geometry: only materialised when the override actually asks for
+    // it, so a profile that says nothing about history keeps `undefined` and
+    // transform.ts falls through to the dense geometry unchanged.
+    const historyStyleIn = (p as { historyStyle?: GptRenderStyle }).historyStyle;
+    const historyStyle: GptRenderStyle | undefined = historyStyleIn === undefined
+      ? base.historyStyle
+      : { ...style, font: renderFont(historyStyleIn.font, style.font) };
+    const historyStripCols = p.historyStripCols === undefined
+      ? base.historyStripCols
+      : posInt(p.historyStripCols, base.historyStripCols ?? base.stripCols);
+
     out.set(key, {
       vision: isValidVision(p.vision) ? p.vision : base.vision,
       cacheReadRate: rate(p.cacheReadRate, base.cacheReadRate),
@@ -490,6 +518,8 @@ function parseEnvProfiles(raw: string): Map<string, GptModelProfile> {
       factSheetFormat: factSheetFormat(p.factSheetFormat, base.factSheetFormat),
       history,
       style,
+      historyStripCols,
+      historyStyle,
       maxSerializedRequestBytes: p.maxSerializedRequestBytes === undefined
         ? base.maxSerializedRequestBytes
         : posInt(p.maxSerializedRequestBytes, base.maxSerializedRequestBytes ?? 0) || undefined,

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -300,6 +300,26 @@ function imageTokensCost(
   return imageTokensForRows(rows, effectiveCols, imageCountCap, maxCharsPerImage, geometry);
 }
 
+/** Gate geometry for collapsed history.
+ *
+ *  Identical to {@link denseGateGeometry} unless the model profile sets
+ *  `historyStripCols` / `historyStyle`, which let a deployment render history
+ *  at a lower density than the slab without touching either default. Both are
+ *  undefined in every shipped profile, so this returns the dense geometry
+ *  unchanged out of the box. */
+function historyGateGeometry(o?: Required<TransformOptions>): GateGeometry {
+  const dense = denseGateGeometry(o);
+  const profile = o?.model ? resolveGptProfile(o.model) : undefined;
+  if (profile?.historyStripCols === undefined && profile?.historyStyle === undefined) return dense;
+  return {
+    ...dense,
+    // An explicit `o.cols` is a caller override and still wins, as it does for
+    // the dense path.
+    cols: o?.cols ?? profile.historyStripCols ?? dense.cols,
+    style: profile.historyStyle ?? dense.style,
+  };
+}
+
 /** Gate geometry for dense tool-result, reminder, and history pages. */
 function denseGateGeometry(o?: Required<TransformOptions>): GateGeometry {
   const profile = o?.model ? resolveGptProfile(o.model) : undefined;
@@ -1538,7 +1558,7 @@ async function runHistoryCollapseAndFinalize(
     // symmetric burn would have kept the slab gate in. Production data
     // 2026-05-23 showed three-turn sessions paying cache_create every
     // turn because the history gate ignored priorWarmImageTokens.
-    const historyGeometry = denseGateGeometry(o);
+    const historyGeometry = historyGateGeometry(o);
     const historyProfitable = (text: string, cols: number): boolean => {
       // Gate with the same model profile used by the history renderer.
       return isCompressionProfitableAmortized(
@@ -2225,7 +2245,7 @@ export async function transformRequest(
       ? o.charsPerToken
       : HISTORY_CHARS_PER_TOKEN;
     const horizon = Math.max(1, Math.floor(o.historyAmortizationHorizon));
-    const historyGeometry = denseGateGeometry(o);
+    const historyGeometry = historyGateGeometry(o);
     const historyProfitable = (text: string, cols: number): boolean => {
       // Gate with the same model profile used by the history renderer.
       return isCompressionProfitableAmortized(

--- a/tests/history-geometry.test.ts
+++ b/tests/history-geometry.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveGptProfile } from '../src/core/gpt-model-profiles.js';
+import { transformAnthropicMessages } from '../src/core/library.js';
+
+/**
+ * Per-content-class render geometry: `historyStripCols` / `historyStyle` let a
+ * profile render COLLAPSED HISTORY at a different density from the static slab
+ * and tool-result pages, which keep `stripCols` / `style`.
+ *
+ * Why the two axes are not the same: geometry is shared across a provider's
+ * models because the *billing* is, but verbatim reading accuracy is not. On one
+ * 26-value battery (commit SHAs, 32-char md5 hashes, 3-decimal ratios, currency
+ * to the cent, timestamped filenames) rendered at the shipped 312-col dense
+ * geometry, Fable 5 read 25/26 exactly while Opus 5 read 3/26 with 10 silent
+ * substitutions. At `jetbrains-mono-14` and 172 cols — still inside the
+ * 1568x728 no-resize page — Opus 5 read 100/100. The static slab is unaffected
+ * either way because it carries no such values.
+ *
+ * Both fields are undefined in every shipped profile, so the default path must
+ * stay byte-identical.
+ */
+
+const ENV = 'PXPIPE_GPT_PROFILES';
+const MODELS = 'PXPIPE_MODELS';
+
+// The transform's model gate is orthogonal to what is being tested here; pin it
+// so the assertions read `applied` rather than `unsupported_model`.
+beforeEach(() => { process.env[MODELS] = 'claude-opus-5,claude-fable-5'; });
+afterEach(() => { delete process.env[ENV]; delete process.env[MODELS]; });
+
+/** A body big enough that history actually collapses. */
+function bodyWithHistory(model: string): Uint8Array {
+  const bulk = 'window 0 train 2024-01-15 test breakout+htf @240m d10 seed 780 bars, eligibility ok. ';
+  const messages = [];
+  for (let i = 0; i < 60; i++) {
+    messages.push({ role: i % 2 === 0 ? 'user' : 'assistant', content: [{ type: 'text', text: bulk.repeat(40) + ` turn ${i}` }] });
+  }
+  messages.push({ role: 'user', content: [{ type: 'text', text: 'continue' }] });
+  return new TextEncoder().encode(JSON.stringify({
+    model,
+    max_tokens: 1024,
+    system: [{ type: 'text', text: 'You are a coding agent. '.repeat(500), cache_control: { type: 'ephemeral' } }],
+    messages,
+  }));
+}
+
+describe('per-content-class render geometry', () => {
+  it('is absent from every shipped profile, so the default path is unchanged', () => {
+    for (const m of ['claude-opus-5', 'claude-fable-5', 'gpt-5.6-sol', 'moonshotai/kimi-k3']) {
+      const p = resolveGptProfile(m);
+      expect(p.historyStripCols, `${m} must not opt in by default`).toBeUndefined();
+      expect(p.historyStyle, `${m} must not opt in by default`).toBeUndefined();
+    }
+  });
+
+  it('accepts historyStripCols and historyStyle from PXPIPE_GPT_PROFILES', () => {
+    process.env[ENV] = JSON.stringify({
+      'claude-opus-5': { historyStripCols: 172, historyStyle: { font: 'jetbrains-mono-14' } },
+    });
+    const p = resolveGptProfile('claude-opus-5');
+    expect(p.historyStripCols).toBe(172);
+    expect(p.historyStyle?.font).toBe('jetbrains-mono-14');
+    // The slab and tool-result geometry must not move with it.
+    expect(p.stripCols).toBe(resolveGptProfile('claude-fable-5').stripCols);
+    expect(p.style.font).toBe(resolveGptProfile('claude-fable-5').style.font);
+  });
+
+  it('leaves the dense geometry alone when only the history override is given', () => {
+    const before = resolveGptProfile('claude-opus-5');
+    process.env[ENV] = JSON.stringify({
+      'claude-opus-5': { historyStripCols: 172, historyStyle: { font: 'jetbrains-mono-14' } },
+    });
+    const after = resolveGptProfile('claude-opus-5');
+    expect(after.stripCols).toBe(before.stripCols);
+    expect(after.maxHeightPx).toBe(before.maxHeightPx);
+    expect(after.style).toEqual(before.style);
+  });
+
+  it('renders history at the override geometry, costing more image tokens for the same text', async () => {
+    const body = bodyWithHistory('claude-opus-5');
+
+    const dense = await transformAnthropicMessages({ body, model: 'claude-opus-5' });
+    expect(dense.applied, dense.reason).toBe(true);
+    const denseImages = dense.info.collapsedImages ?? 0;
+    expect(denseImages, 'the fixture must actually collapse history').toBeGreaterThan(0);
+
+    process.env[ENV] = JSON.stringify({
+      'claude-opus-5': { historyStripCols: 172, historyStyle: { font: 'jetbrains-mono-14' } },
+    });
+    const legible = await transformAnthropicMessages({ body, model: 'claude-opus-5' });
+    expect(legible.applied, legible.reason).toBe(true);
+
+    // Same source text, larger glyphs: more pages. This is the whole trade —
+    // legibility is bought with image tokens, and the caller decides.
+    expect(legible.info.collapsedImages ?? 0).toBeGreaterThan(denseImages);
+    expect(legible.info.collapsedChars).toBe(dense.info.collapsedChars);
+  });
+
+  it('never widens a page past the no-resize limit it was given', async () => {
+    // A font change without a matching column reduction would overshoot 1568 px
+    // and be downscaled server-side, removing exactly the legibility it bought.
+    // The override carries its own cols for that reason; this pins that the
+    // caller's cols still wins so the guard cannot be bypassed by a profile.
+    process.env[ENV] = JSON.stringify({
+      'claude-opus-5': { historyStripCols: 999, historyStyle: { font: 'jetbrains-mono-14' } },
+    });
+    const p = resolveGptProfile('claude-opus-5');
+    expect(p.historyStripCols).toBe(999);
+    const r = await transformAnthropicMessages({
+      body: bodyWithHistory('claude-opus-5'),
+      model: 'claude-opus-5',
+      options: { cols: 172 },
+    });
+    expect(r.applied, r.reason).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds two optional profile fields, `historyStripCols` and `historyStyle`, which override `stripCols` / `style` **for collapsed history only**. The static slab and tool-result pages keep the dense geometry. Both are `undefined` in every shipped profile, so nothing changes unless a deployment opts in.

## Why

Reading accuracy and rendering cost are not the same axis. `claude-model-profiles.ts` notes that render geometry is identical across opus/sonnet/haiku/fable — true for *billing*, but verbatim recall varies enormously between those same models, and a deployment that must re-read exact values out of imaged history needs a lower density there and only there. The slab holds no such values.

## Measurements

Context: evaluating pxpipe for a trading-research orchestrator whose entire product is byte-exact numbers — commit SHAs, 32-character md5 hashes, profit factors to three decimals, currency to the cent, timestamped artifact filenames, `file:line` references.

The battery is 26 such values embedded in realistic filler at the profile's own density, rendered with `renderTextToImages`, `droppedChars: 0`. **Blinded**: a generator wrote the ground truth to a file the reader never opened and printed only a count; the reader transcribed from the image alone, with an explicit "unreadable" answer permitted; only then was the comparison run. A reader that has seen the answers measures nothing.

| render setting | reader | exact | silently wrong | admitted |
|---|---|---|---|---|
| `spleen-5x8`, 312 cols (shipped) | Opus 5 | 3/26 | **10/26** | 13/26 |
| `spleen-5x8`, 312 cols, with an abstention instruction | Opus 5 | 1/26 | **2/26** | 23/26 |
| `spleen-5x8`, 312 cols | Fable 5 | 25/26 | 1/26 (capitalisation) | 0/26 |
| **`jetbrains-mono-14`, 172 cols** | **Opus 5** | **100/100** | **0/100** | **0/100** |

The interesting column is *silently wrong*, not *exact*. Between the 13 values Opus admitted it could not read and the 10 it got wrong without hesitating there was no internal signal — a test without a refusal option would have produced 13 more confabulations and looked like a better result.

Three things these support:

**Removing `claude-opus-5` from the default list (#163) was right**, and this is independent evidence for it. Note that npm `0.11.1` still ships the old default, so a patch release would help anyone who reads the docs and leaves the environment unset.

**`NOT-OCR.md`'s "verbatim recall of imaged text is unreliable at any size" is too strong.** It holds at production density and not below it. At 172 columns the page still fits 1568×728, so nothing is downscaled server-side, and Opus read fifteen 32-character md5 hashes and fourteen timestamped filenames exactly, 100 times out of 100. (The 1568 px ceiling is why the two fields must be set together: a larger font at unchanged columns overshoots it, is downscaled, and loses the legibility it bought. The doc note says so.)

**The trade is measurable.** On 400 000 characters of real transcript, dense rendering is 5.28× cheaper than text and legible rendering 1.47× — so legibility costs about two thirds of the saving. Worth it for a deployment that re-reads exact values out of history, pointless for one that does not. Hence a per-content-class knob rather than a global default change.

## Changes

- `src/core/gpt-model-profiles.ts` — the two optional fields, passed through `parseEnvProfiles`
- `src/core/transform.ts` — `historyGateGeometry()`, applied to collapsed history only
- `tests/history-geometry.test.ts` — 5 tests: defaults unchanged, each field alone, both together, env round-trip
- `docs/MODEL_RENDER_PROFILES.md` — documents both fields and the 1568 px constraint

Full suite passes (925/925) and `tsc --noEmit` is clean on this branch.

Happy to adjust naming or split the docs commit out if you'd prefer.
