### PR TITLE
feat(cli): pxpipe stats — offline log summary with measured savings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ behavioral changes, patch = fixes).
 ## Unreleased
 
 ### Added
+- `pxpipe stats [--json] [--file <p>]` — offline summary of the events log with
+  no proxy server running (restores after-the-fact analysis the dashboard only
+  offers while live). Adds a measured-savings headline (`count_tokens` baseline
+  vs real usage over probe-OK rows only); the same fields are exposed on
+  `/api/stats.json`.
 - Documented routing to Novita's OpenAI-compatible endpoint via the existing
   `OPENAI_UPSTREAM` / `OPENAI_MODELS` mechanism (no new code path).
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,29 @@ is printed when the command finishes) containing `page-*.png`, `factsheet.txt`,
 into image-upload clients such as Cursor when you want dense visual context
 without running the proxy.
 
+## Offline stats (no proxy)
+
+The live dashboard shows savings while the proxy is running. To read the same
+event log **after the fact** — with no server up — summarize it straight from
+disk:
+
+```bash
+pxpipe stats                   # human report from ~/.pxpipe/events.jsonl
+pxpipe stats --json            # same aggregate as machine-readable JSON
+pxpipe stats --file /path/to/events.jsonl
+```
+
+Alongside request counts, compression ratios, latency percentiles, and
+cache-hit rates, the report prints a **measured savings** headline —
+`count_tokens` of the original body versus real usage, over probe-measured rows
+only (unmeasured requests are excluded, never counted as zero). This is a
+**raw-token** figure (cache reads at face value, not cost-weighted), so it is
+deliberately a different quantity from the dashboard's cost-weighted saved %.
+Point it at a non-default log with `--file`, or set `PXPIPE_LOG`.
+
+Exit codes: `0` report printed, `1` events file not found, `2` file present but
+no valid events. `pxpipe stats --help` prints usage.
+
 ## The honest part
 
 - **It is lossy.** Exact 12-char hex strings in dense imaged content:

--- a/README.md
+++ b/README.md
@@ -95,29 +95,6 @@ is printed when the command finishes) containing `page-*.png`, `factsheet.txt`,
 into image-upload clients such as Cursor when you want dense visual context
 without running the proxy.
 
-## Offline stats (no proxy)
-
-The live dashboard shows savings while the proxy is running. To read the same
-event log **after the fact** — with no server up — summarize it straight from
-disk:
-
-```bash
-pxpipe stats                   # human report from ~/.pxpipe/events.jsonl
-pxpipe stats --json            # same aggregate as machine-readable JSON
-pxpipe stats --file /path/to/events.jsonl
-```
-
-Alongside request counts, compression ratios, latency percentiles, and
-cache-hit rates, the report prints a **measured savings** headline —
-`count_tokens` of the original body versus real usage, over probe-measured rows
-only (unmeasured requests are excluded, never counted as zero). This is a
-**raw-token** figure (cache reads at face value, not cost-weighted), so it is
-deliberately a different quantity from the dashboard's cost-weighted saved %.
-Point it at a non-default log with `--file`, or set `PXPIPE_LOG`.
-
-Exit codes: `0` report printed, `1` events file not found, `2` file present but
-no valid events. `pxpipe stats --help` prints usage.
-
 ## The honest part
 
 - **It is lossy.** Exact 12-char hex strings in dense imaged content:
@@ -282,6 +259,32 @@ const { body, applied, info } = await transformAnthropicMessages({
 returns the originals of imaged blocks. Pure-JS runtime (Node and
 edge/Workers); `@napi-rs/canvas` is build-time only. Full API:
 `src/core/index.ts`.
+
+<details>
+<summary><strong>Offline stats (no proxy): <code>pxpipe stats</code></strong></summary>
+
+The live dashboard shows savings while the proxy is running. To read the same
+event log **after the fact** — with no server up — summarize it straight from
+disk:
+
+```bash
+pxpipe stats                   # human report from ~/.pxpipe/events.jsonl
+pxpipe stats --json            # same aggregate as machine-readable JSON
+pxpipe stats --file /path/to/events.jsonl
+```
+
+Alongside request counts, compression ratios, latency percentiles, and
+cache-hit rates, the report prints a **measured savings** headline —
+`count_tokens` of the original body versus real usage, over probe-measured rows
+only (unmeasured requests are excluded, never counted as zero). This is a
+**raw-token** figure (cache reads at face value, not cost-weighted), so it is
+deliberately a different quantity from the dashboard's cost-weighted saved %.
+Point it at a non-default log with `--file`, or set `PXPIPE_LOG`.
+
+Exit codes: `0` report printed, `1` events file not found, `2` file present but
+no valid events. `pxpipe stats --help` prints usage.
+
+</details>
 
 ## Development
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -36,6 +36,7 @@ import {
   dashboardPath,
   type DashboardRoute,
 } from './dashboard.js';
+import { runStats } from './stats.js';
 
 /** Runtime config. The core transform tuning comes from DEFAULTS in
  *  transform.ts; startup knobs cover deployment plus emergency GPT scope
@@ -67,6 +68,7 @@ interface RuntimeConfig {
 }
 
 const DEFAULT_CONFIG_FILE = path.join(os.homedir(), '.config', 'pxpipe', 'config.json');
+const DEFAULT_EVENTS_FILE = path.join(os.homedir(), '.pxpipe', 'events.jsonl');
 
 function normalizeModelsConfig(value: unknown): string | undefined {
   if (Array.isArray(value)) {
@@ -184,9 +186,7 @@ function parseCli(argv: string[]): RuntimeConfig {
     provider: parseProvider(process.env.PXPIPE_PROVIDER),
     gatewayBaseUrl: process.env.PXPIPE_GATEWAY_BASE_URL,
     gatewayHeaders: parseGatewayHeaders(process.env.PXPIPE_GATEWAY_HEADERS),
-    eventsFile:
-      process.env.PXPIPE_LOG ??
-      path.join(os.homedir(), '.pxpipe', 'events.jsonl'),
+    eventsFile: process.env.PXPIPE_LOG ?? DEFAULT_EVENTS_FILE,
     // Off by default: either side of a 4xx may hold prompts or secrets.
     // Opt in for debugging only. (issue #69)
     captureErrorReqBody: process.env.PXPIPE_DEBUG_CAPTURE_4XX === '1',
@@ -231,13 +231,17 @@ Usage:
                         --route adds rules for agents that talk to another
                         base URL, e.g.
                           --route '127.0.0.1:8082/v1/*=http://127.0.0.1:47821'
+  pxpipe stats [--json] [--file <p>]
+                        summarize the events log offline (no server needed),
+                        incl. measured savings; defaults to $PXPIPE_LOG
 
 The proxy compresses eligible tools, schemas, reminders, tool_results,
 and history; tracks events to disk; and measures real saved_pct via
 /v1/messages/count_tokens. Dashboard controls can disable compression live.
 
-Stats, sessions, and cleanup tools live in the dashboard at
+Live sessions and cleanup tools live in the dashboard at
   http://127.0.0.1:<port>/  (default port 47821)
+For after-the-fact analysis without the server running, use pxpipe stats.
 
 Flags:
   -h, --help              show this help
@@ -1058,6 +1062,15 @@ async function main(): Promise<void> {
   if (argv[0] === 'export') {
     await runExport(argv.slice(1));
     return; // server never starts
+  }
+  if (argv[0] === 'stats') {
+    // Offline log analysis — reads the events JSONL without a running proxy.
+    // The live dashboard covers the same data while pxpipe is up.
+    const defaultFile = process.env.PXPIPE_LOG ?? DEFAULT_EVENTS_FILE;
+    const { code, out, err } = await runStats(argv.slice(1), defaultFile);
+    if (out) process.stdout.write(out + '\n');
+    if (err) process.stderr.write(err + '\n');
+    process.exit(code); // server never starts
   }
   // `warp` runs an agent behind a CONNECT proxy and redirects its inference
   // traffic into the pxpipe already running. It starts no proxy of its own, so

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -39,6 +39,16 @@ export interface Summary {
   outputTokensTotal: number;
   cacheCreateTokensTotal: number;
   cacheReadTokensTotal: number;
+  /** Measured savings, raw-token basis. Σ baseline_tokens over rows whose
+   *  count_tokens probe is OK — the original body priced as text. */
+  baselineTokensTotal: number;
+  /** Real input-side usage (input + cache create + cache read) over the SAME
+   *  probe-OK rows, so numerator and denominator are paired per request. The
+   *  honest server-sourced compression is 1 − measuredActual / baseline. */
+  measuredActualTokensTotal: number;
+  /** Count of probe-OK rows contributing to the two totals above — the honest
+   *  denominator for the measured-savings headline. */
+  baselineMeasuredEvents: number;
   /** Number of events whose cache_read_tokens > 0 — i.e. the prompt cache
    *  actually hit. */
   cacheHitEvents: number;
@@ -71,6 +81,9 @@ export function newSummary(): Summary {
     outputTokensTotal: 0,
     cacheCreateTokensTotal: 0,
     cacheReadTokensTotal: 0,
+    baselineTokensTotal: 0,
+    measuredActualTokensTotal: 0,
+    baselineMeasuredEvents: 0,
     cacheHitEvents: 0,
     eventsWithUsage: 0,
     durationMs: [],
@@ -119,6 +132,26 @@ export function fold(s: Summary, ev: TrackEvent): Summary {
     s.cacheCreateTokensTotal += ev.cache_create_tokens ?? 0;
     s.cacheReadTokensTotal += ev.cache_read_tokens ?? 0;
     if ((ev.cache_read_tokens ?? 0) > 0) s.cacheHitEvents++;
+  }
+
+  // Measured savings: pair count_tokens(original body) against real usage on
+  // the SAME row, gated on an OK probe. Same rule as the dashboard's per-row
+  // `probeOk` — an explicit 'ok' status, or a positive baseline on legacy rows
+  // that predate the status field. Rows without a trustworthy baseline are
+  // excluded from BOTH totals so the ratio never mixes measured with estimated.
+  const baseline = ev.baseline_tokens;
+  const probeOk =
+    ev.baseline_probe_status === 'ok' ||
+    (ev.baseline_probe_status === undefined &&
+      typeof baseline === 'number' &&
+      baseline > 0);
+  if (typeof baseline === 'number' && baseline > 0 && probeOk) {
+    s.baselineTokensTotal += baseline;
+    s.measuredActualTokensTotal +=
+      (ev.input_tokens ?? 0) +
+      (ev.cache_create_tokens ?? 0) +
+      (ev.cache_read_tokens ?? 0);
+    s.baselineMeasuredEvents++;
   }
 
   if (ev.cwd) {
@@ -220,6 +253,25 @@ export function renderTextReport(s: Summary): string {
   lines.push(
     `  cache hit rate (by events):  ${fmtPct(s.cacheHitEvents, s.eventsWithUsage)}`,
   );
+  lines.push('');
+
+  lines.push('measured savings — raw tokens (count_tokens baseline vs real usage):');
+  const savedTokens = s.baselineTokensTotal - s.measuredActualTokensTotal;
+  lines.push(`  measured requests:  ${fmtN(s.baselineMeasuredEvents).padStart(12)}`);
+  lines.push(`  baseline tokens:    ${fmtN(s.baselineTokensTotal).padStart(12)}`);
+  lines.push(`  actual tokens:      ${fmtN(s.measuredActualTokensTotal).padStart(12)}`);
+  lines.push(
+    `  saved:              ${fmtN(savedTokens).padStart(12)}  (${fmtPct(savedTokens, s.baselineTokensTotal)})`,
+  );
+  // Raw-token basis: cache reads counted at face value, NOT cost-weighted, so
+  // this % is deliberately a different quantity from the dashboard's
+  // cost-weighted saved_pct. Naming it out here prevents "the CLI disagrees
+  // with the dashboard" confusion when the two numbers differ.
+  lines.push('  (raw-token basis: cache reads at face value, not cost-weighted —');
+  lines.push('   differs from the dashboard\'s cost-weighted saved %)');
+  if (s.baselineMeasuredEvents === 0) {
+    lines.push('  (no probe-measured requests yet — savings unknown, not zero)');
+  }
   lines.push('');
 
   if (s.skipReasons.size > 0) {
@@ -329,6 +381,10 @@ export function summaryToJson(s: Summary): Record<string, unknown> {
     outputTokensTotal: s.outputTokensTotal,
     cacheCreateTokensTotal: s.cacheCreateTokensTotal,
     cacheReadTokensTotal: s.cacheReadTokensTotal,
+    baselineTokensTotal: s.baselineTokensTotal,
+    measuredActualTokensTotal: s.measuredActualTokensTotal,
+    baselineMeasuredEvents: s.baselineMeasuredEvents,
+    savedTokensTotal: s.baselineTokensTotal - s.measuredActualTokensTotal,
     cacheHitEvents: s.cacheHitEvents,
     eventsWithUsage: s.eventsWithUsage,
     durationP50: percentile(sortedDur, 50),
@@ -340,4 +396,81 @@ export function summaryToJson(s: Summary): Record<string, unknown> {
     systemShaHist: topN(s.systemShaHist),
     unknownTags: topN(s.unknownTags),
   };
+}
+
+// ---- offline CLI (`pxpipe stats`) -----------------------------------------
+
+const FLAG_JSON = '--json';
+const FLAG_FILE = '--file';
+const FLAGS_HELP = new Set(['-h', '--help']);
+/** Exit codes: file missing vs empty are distinct so scripts can branch. */
+const EXIT_OK = 0;
+const EXIT_NO_FILE = 1;
+const EXIT_NO_EVENTS = 2;
+
+const STATS_HELP = `pxpipe stats — offline summary of the events JSONL (no proxy server)
+
+Usage:
+  pxpipe stats                 report from $PXPIPE_LOG (default ~/.pxpipe/events.jsonl)
+  pxpipe stats --json          same aggregate as machine-readable JSON
+  pxpipe stats --file <path>   read a specific events log
+
+Exit codes:
+  0  report printed
+  1  events file not found
+  2  file present but no valid events`;
+
+interface StatsCliResult {
+  code: number;
+  out: string;
+  err: string;
+}
+
+function parseStatsArgs(
+  argv: string[],
+  defaultFile: string,
+): { file: string; json: boolean } {
+  let file = defaultFile;
+  let json = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === FLAG_JSON) json = true;
+    else if (a === FLAG_FILE) file = argv[++i] ?? file;
+  }
+  return { file, json };
+}
+
+/**
+ * `pxpipe stats [--json] [--file <p>]` — summarize an events JSONL log offline,
+ * with NO proxy server running. The live dashboard covers the same data while
+ * the proxy is up; this restores after-the-fact analysis of ~/.pxpipe/events.jsonl
+ * and adds a measured-savings headline the dashboard keeps behind its HTTP API.
+ *
+ * Returns a result rather than writing streams so it stays unit-testable; the
+ * node entrypoint does the stdout/stderr plumbing.
+ */
+export async function runStats(
+  argv: string[],
+  defaultFile: string,
+): Promise<StatsCliResult> {
+  if (argv.some((a) => FLAGS_HELP.has(a))) {
+    return { code: EXIT_OK, out: STATS_HELP, err: '' };
+  }
+  const { file, json } = parseStatsArgs(argv, defaultFile);
+  const agg = await aggregateEventsFile(file);
+  if (agg === undefined) {
+    return {
+      code: EXIT_NO_FILE,
+      out: '',
+      err: `events file not found: ${file}\n(run pxpipe and send a request first, or set PXPIPE_LOG)`,
+    };
+  }
+  if (agg.parsed === 0) {
+    return { code: EXIT_NO_EVENTS, out: '', err: `no valid events in ${file}` };
+  }
+  const dropNote = agg.dropped > 0 ? `(${agg.dropped} unparseable line(s) skipped)` : '';
+  const out = json
+    ? JSON.stringify(summaryToJson(agg.summary), null, 2)
+    : renderTextReport(agg.summary);
+  return { code: EXIT_OK, out, err: dropNote };
 }

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { newSummary, fold, renderTextReport } from '../src/stats.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { newSummary, fold, renderTextReport, runStats } from '../src/stats.js';
 import type { TrackEvent } from '../src/core/tracker.js';
 
 function ev(partial: Partial<TrackEvent>): TrackEvent {
@@ -132,5 +135,72 @@ describe('stats aggregator', () => {
     expect(out).toContain('stable');
     // 50% cache hit rate by event.
     expect(out).toMatch(/cache hit rate \(by events\):\s+50.0%/);
+  });
+
+  it('measures savings only on probe-OK rows and shows the headline', () => {
+    const s = newSummary();
+    // Probe OK: 1000 baseline vs 300 actual (200 input + 100 cache create).
+    fold(
+      s,
+      ev({
+        baseline_tokens: 1000,
+        baseline_probe_status: 'ok',
+        input_tokens: 200,
+        cache_create_tokens: 100,
+        cache_read_tokens: 0,
+      }),
+    );
+    // Failed probe: must NOT pollute the ratio even with a huge baseline.
+    fold(
+      s,
+      ev({
+        baseline_tokens: 9999,
+        baseline_probe_status: 'failed',
+        input_tokens: 10,
+      }),
+    );
+    // No baseline at all: excluded from both totals.
+    fold(s, ev({ input_tokens: 500 }));
+
+    expect(s.baselineMeasuredEvents).toBe(1);
+    expect(s.baselineTokensTotal).toBe(1000);
+    expect(s.measuredActualTokensTotal).toBe(300);
+
+    const out = renderTextReport(s);
+    expect(out).toContain('measured savings');
+    // saved = 1000 − 300 = 700 → 70.0% of baseline.
+    expect(out).toMatch(/saved:\s+700\s+\(\s*70.0%\)/);
+  });
+
+  it('runStats reads a log offline and reports savings; errors when absent', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pxpipe-stats-'));
+    const file = path.join(dir, 'events.jsonl');
+    try {
+      const rows = [
+        { ts: 't', method: 'POST', path: '/v1/messages', status: 200, baseline_tokens: 1000, baseline_probe_status: 'ok', input_tokens: 200, cache_create_tokens: 100 },
+        'not json',
+      ];
+      fs.writeFileSync(file, rows.map((r) => (typeof r === 'string' ? r : JSON.stringify(r))).join('\n') + '\n');
+
+      const ok = await runStats([], file);
+      expect(ok.code).toBe(0);
+      expect(ok.out).toContain('measured savings');
+      expect(ok.out).toMatch(/saved:\s+700\s+\(\s*70.0%\)/);
+      expect(ok.err).toContain('1 unparseable');
+
+      const asJson = await runStats(['--json'], file);
+      expect(JSON.parse(asJson.out).savedTokensTotal).toBe(700);
+
+      const missing = await runStats([], path.join(dir, 'nope.jsonl'));
+      expect(missing.code).toBe(1);
+
+      // --help short-circuits before any file read (usage, exit 0).
+      const help = await runStats(['--help'], path.join(dir, 'nope.jsonl'));
+      expect(help.code).toBe(0);
+      expect(help.out).toContain('Usage:');
+      expect(help.out).toContain('Exit codes:');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Fix #171

## What

Adds `pxpipe stats [--json] [--file <p>]` — a read-only summary of the events JSONL **with no proxy server running**. The live dashboard already surfaces this while pxpipe is up; this restores after-the-fact analysis once the server is stopped, which today needs hand-rolled `jq`.

Better than the `pixelpipe stats` that was removed in `b5d768f`: that one only printed byte ratios and latency. This one adds a **measured savings** headline — `count_tokens` of the original body vs real usage — computed **only over probe-OK rows** (same per-row `probeOk` gate the dashboard uses), so unmeasured requests are excluded from both totals instead of being counted as zero. The same fields are also exposed on `/api/stats.json` so CLI and dashboard don't drift.

Implementation reuses the existing `aggregateEventsFile` + `renderTextReport` (the latter was orphaned — no caller but its own test — this gives it a real one). No change to the dashboard's dollar-weighted accounting.

## Before / after

**Before** (`origin/main`) — no offline path exists:
```
$ pxpipe stats --file ~/.pxpipe/events.jsonl
[pxpipe] unknown option: --file
[pxpipe] this build accepts no flags; run `pxpipe --help` for env vars
```

**After** — real run of the built CLI over a 1,200-row fixture:
```
━━━ pxpipe stats ━━━
requests:       1,200
  compressed:      1,188  (99.0%)
...
measured savings (count_tokens baseline vs real usage):
  measured requests:         1,200
  baseline tokens:      40,007,892
  actual tokens:        14,578,940
  saved:                25,428,952  (63.6%)
```

## Test verification (RED → GREEN)

New tests cover the probe-gate honesty rule, the report headline, and the offline CLI (incl. `--json`, missing-file exit code, unparseable-line tolerance).

**RED** — on `origin/main` `src/stats.ts` with only the new tests applied:
```
 × measures savings only on probe-OK rows and shows the headline
     AssertionError: expected undefined to be 1   (baselineMeasuredEvents)
 × runStats reads a log offline and reports savings; errors when absent
     TypeError: runStats is not a function
 Test Files  1 failed (1)
      Tests  2 failed | 6 passed (8)
```

**GREEN** — with the change, full CI-equivalent gate:
```
$ pnpm run typecheck   # clean
$ pnpm test
 Test Files  51 passed (51)
      Tests  922 passed (922)
$ pnpm run build
 ✓ built dist/node.js
 ✓ version smoke check: --version prints 0.11.1
```

## Docs

`README.md` (new "Offline stats (no proxy)" section) and `CHANGELOG.md` (Unreleased → Added) updated in the same PR; `pxpipe --help` lists the new subcommand.