### PR TITLE
warp: match routes on host:port, add --route

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Same thing without `ANTHROPIC_BASE_URL`, so `/remote-control`, claude.ai
 connectors, and first-party gates keep working. Full instructions in the
 dashboard.
 
+`api.anthropic.com/v1/messages` is routed by default. Agents that reach their
+provider over some other base URL need a rule for it, and a rule that names a
+port matches only that port:
+
+```bash
+pxpipe warp --route '127.0.0.1:8082/v1/*=http://127.0.0.1:47821' -- codex
+```
+
 ## Offline export (no proxy)
 
 You can render text, files, or diffs to PNG pages without running the proxy or

--- a/src/dashboard/fragments.ts
+++ b/src/dashboard/fragments.ts
@@ -1231,7 +1231,7 @@ export function renderPage(port: number): string {
   <pre>pxpipe warp -- claude
 pxpipe warp -- codex
 pxpipe warp -- cursor-agent</pre>
-  <p>Aliases work too (<code>pxpipe warp -- pp</code>), and <code>--route pattern=http://host:port</code> adds routes beyond <code>api.anthropic.com</code>. Without warp, point the agent at <code>ANTHROPIC_BASE_URL=http://127.0.0.1:${port}</code> yourself.</p>
+  <p>Aliases work too (<code>pxpipe warp -- pp</code>), and <code>--route PATTERN=http://host:port</code> adds routes beyond <code>api.anthropic.com</code> (a PATTERN that names a port matches only that port, e.g. <code>--route '127.0.0.1:8082/v1/*=http://127.0.0.1:${port}'</code> warps an agent pointed at another local proxy). Without warp, point the agent at <code>ANTHROPIC_BASE_URL=http://127.0.0.1:${port}</code> yourself.</p>
   <p>Pin instructions from inside the session — they get moved to the end of every request, where the model actually reads them:</p>
   <pre>@pxpipe pin be concise, no walls of text
 @pxpipe unpin 2

--- a/src/node.ts
+++ b/src/node.ts
@@ -202,9 +202,14 @@ function printHelp(): void {
 Usage:
   pxpipe                run the proxy (no flags)
   pxpipe export [...]   render files/diff to PNG pages + cost report (see pxpipe export --help)
-  pxpipe warp -- CMD    run CMD behind the proxy without a custom base URL, so
+  pxpipe warp [--route PATTERN=TARGET]... -- CMD
+                        run CMD behind the proxy without a custom base URL, so
                         client-side first-party gates (/remote-control,
-                        claude.ai connectors) keep working
+                        claude.ai connectors) keep working.
+                        api.anthropic.com/v1/messages is routed by default;
+                        --route adds rules for agents that talk to another
+                        base URL, e.g.
+                          --route '127.0.0.1:8082/v1/*=http://127.0.0.1:47821'
 
 The proxy compresses eligible tools, schemas, reminders, tool_results,
 and history; tracks events to disk; and measures real saved_pct via
@@ -1031,11 +1036,34 @@ async function main(): Promise<void> {
   // traffic into the pxpipe already running. It starts no proxy of its own, so
   // it exits through its own branch below rather than falling through here.
   let warpCommand: string[] | undefined;
+  const warpRoutes: string[] = [];
   let cliArgv = argv;
   if (argv[0] === 'warp') {
     const sep = argv.indexOf('--');
     warpCommand = sep < 0 ? [] : argv.slice(sep + 1);
-    cliArgv = argv.slice(1, sep < 0 ? argv.length : sep);
+    // warp's own flags live before the `--`; parseCli accepts none of them, so
+    // they are consumed here rather than passed through.
+    const warpArgv = argv.slice(1, sep < 0 ? argv.length : sep);
+    const rest: string[] = [];
+    for (let i = 0; i < warpArgv.length; i += 1) {
+      const a = warpArgv[i]!;
+      if (a === '--route') {
+        const spec = warpArgv[i + 1];
+        if (spec === undefined) {
+          console.error('[pxpipe] warp: --route needs PATTERN=TARGET');
+          process.exit(2);
+        }
+        warpRoutes.push(spec);
+        i += 1;
+        continue;
+      }
+      if (a.startsWith('--route=')) {
+        warpRoutes.push(a.slice('--route='.length));
+        continue;
+      }
+      rest.push(a);
+    }
+    cliArgv = rest;
   }
   // Stats / sessions / cleanup tools live in the dashboard
   // (see http://127.0.0.1:${port}/).
@@ -1046,7 +1074,7 @@ async function main(): Promise<void> {
   // does the transforming, the tracking and the dashboard. Everything below —
   // tracker, proxy pipeline, listener — belongs to that instance, not to us.
   if (warpCommand) {
-    createWarpRuntime({ port: opts.port }).launch(warpCommand);
+    createWarpRuntime({ port: opts.port, routes: warpRoutes }).launch(warpCommand);
     return;
   }
   // A/B harness passthrough switch (see the `transform` callback below).

--- a/src/warp/connect.ts
+++ b/src/warp/connect.ts
@@ -68,12 +68,6 @@ function isLoopbackAddress(address: string | undefined): boolean {
   );
 }
 
-function stripPort(value: string): string {
-  if (value.startsWith('[')) return value.slice(1, value.indexOf(']'));
-  const i = value.lastIndexOf(':');
-  return i > 0 ? value.slice(0, i) : value;
-}
-
 function splitHostPort(value: string, fallbackPort: string): { host: string; port: string } {
   if (value.startsWith('[')) {
     const end = value.indexOf(']');
@@ -128,7 +122,8 @@ export function createWarpHandlers(options: WarpHandlerOptions): WarpHandlers {
   const forward = (
     req: IncomingMessage,
     res: ServerResponse,
-    host: string,
+    /** "host" or "host:port": routes may select on the port. */
+    hostPort: string,
     requestUri: string,
     // Where the bytes actually go when no route matches. Passed in rather than
     // rebuilt from `host`: a plain `http://host:8080` request reaching us in
@@ -136,12 +131,12 @@ export function createWarpHandlers(options: WarpHandlerOptions): WarpHandlers {
     origin: string,
   ) => {
     const path = requestUri.split('?')[0] ?? '/';
-    const route = matchRoute(routes, host, path);
+    const route = matchRoute(routes, hostPort, path);
 
     const target = new URL(route ? rewriteUrl(route, requestUri) : `${origin}${requestUri}`);
     if (route && !announced.has(route.pattern)) {
       announced.add(route.pattern);
-      onDivert?.(host, path, target.origin);
+      onDivert?.(hostPort, path, target.origin);
     }
 
     const send = target.protocol === 'https:' ? httpsRequest : httpRequest;
@@ -190,7 +185,7 @@ export function createWarpHandlers(options: WarpHandlerOptions): WarpHandlers {
     // A client that CONNECTed to a non-443 port repeats it in Host, which is
     // the only place the original port survives the hijack into mitmServer.
     const { host, port } = splitHostPort(req.headers.host || servername, '443');
-    forward(req, res, host, req.url ?? '/', `https://${authority(host, port)}`);
+    forward(req, res, authority(host, port), req.url ?? '/', `https://${authority(host, port)}`);
   };
 
   /**
@@ -242,7 +237,7 @@ export function createWarpHandlers(options: WarpHandlerOptions): WarpHandlers {
     }
     const { host, port } = splitHostPort(req.url ?? '', '443');
 
-    if (!hostCouldMatch(routes, host)) {
+    if (!hostCouldMatch(routes, authority(host, port))) {
       const upstream = netConnect({ host, port: Number(port) }, () => {
         clientSocket.write('HTTP/1.1 200 Connection established\r\n\r\n');
         if (head?.length) upstream.write(head);
@@ -281,7 +276,7 @@ export function createWarpHandlers(options: WarpHandlerOptions): WarpHandlers {
     }
     // target.origin, not a rebuilt https:// URL: scheme and non-default port
     // are part of where this request was actually going.
-    forward(req, res, stripPort(target.host), target.pathname + target.search, target.origin);
+    forward(req, res, target.host, target.pathname + target.search, target.origin);
   };
 
   return { handleConnect, handleAbsoluteForm };

--- a/src/warp/index.ts
+++ b/src/warp/index.ts
@@ -27,6 +27,12 @@ import { parseRoute, routeDestination, type Route } from './route.js';
 export interface WarpRuntimeOptions {
   /** Port the pxpipe proxy is already serving on: where matches are sent. */
   port: number;
+  /**
+   * Extra PATTERN=TARGET rules, in priority order ahead of the default
+   * Anthropic rule. Agents that reach their provider over a base URL rather
+   * than api.anthropic.com (codex, opencode) need one rule each.
+   */
+  routes?: readonly string[];
 }
 
 export interface WarpRuntime {
@@ -45,7 +51,12 @@ function defaultRoutes(port: number): Route[] {
 
 export function createWarpRuntime(options: WarpRuntimeOptions): WarpRuntime {
   const { port } = options;
-  const routes = defaultRoutes(port);
+  // Explicit rules first: an operator route for a specific host:port must win
+  // over anything built in.
+  const routes = [
+    ...(options.routes ?? []).map((spec) => parseRoute(spec)),
+    ...defaultRoutes(port),
+  ];
   const ca = CertificateAuthority.loadOrCreate(join(homedir(), '.pxpipe'));
 
   const handlers = createWarpHandlers({

--- a/src/warp/route.ts
+++ b/src/warp/route.ts
@@ -22,6 +22,13 @@ export interface Route {
    * all — a CONNECT carries no path.
    */
   readonly hostRe: RegExp;
+  /**
+   * Whether the pattern named a port. Loopback targets make the port the only
+   * thing distinguishing two hosts (127.0.0.1:8082 vs 127.0.0.1:47821), so a
+   * pattern that names one must be matched against "host:port" and a pattern
+   * that does not must keep matching any port.
+   */
+  readonly hasPort: boolean;
   readonly target: URL;
   /**
    * Target path prefix, normalized to "" or "/foo" (no trailing slash). Kept
@@ -88,15 +95,29 @@ export function parseRoute(spec: string): Route {
 
   const hostGlob = pattern.split('/')[0]!;
   const hostRe = new RegExp(`^${hostGlob.toLowerCase().split('*').map(quoteMeta).join('.*')}$`);
+  const hasPort = /:\d/.test(hostGlob);
 
-  return { pattern, re, hostRe, target, prefix };
+  return { pattern, re, hostRe, hasPort, target, prefix };
 }
 
-/** First match wins, so earlier rules shadow later ones. */
-export function matchRoute(routes: readonly Route[], host: string, path: string): Route | null {
-  const subject = host.toLowerCase() + path;
+/** Drop a trailing ":port", leaving IPv6 literals in brackets intact. */
+function stripPort(hostPort: string): string {
+  if (hostPort.startsWith('[')) return hostPort.slice(0, hostPort.indexOf(']') + 1);
+  const i = hostPort.lastIndexOf(':');
+  return i > 0 ? hostPort.slice(0, i) : hostPort;
+}
+
+/**
+ * First match wins, so earlier rules shadow later ones.
+ *
+ * `hostPort` carries the port so a pattern may select on it; patterns that name
+ * no port are matched against the bare host and so still match any port.
+ */
+export function matchRoute(routes: readonly Route[], hostPort: string, path: string): Route | null {
+  const lower = hostPort.toLowerCase();
+  const bare = stripPort(lower);
   for (const route of routes) {
-    if (route.re.test(subject)) return route;
+    if (route.re.test((route.hasPort ? lower : bare) + path)) return route;
   }
   return null;
 }
@@ -106,9 +127,10 @@ export function matchRoute(routes: readonly Route[], host: string, path: string)
  * time, before a path exists, so this is deliberately permissive: guessing
  * "yes" costs a needless MITM, guessing "no" silently breaks the route.
  */
-export function hostCouldMatch(routes: readonly Route[], host: string): boolean {
-  const lower = host.toLowerCase();
-  return routes.some((route) => route.hostRe.test(lower));
+export function hostCouldMatch(routes: readonly Route[], hostPort: string): boolean {
+  const lower = hostPort.toLowerCase();
+  const bare = stripPort(lower);
+  return routes.some((route) => route.hostRe.test(route.hasPort ? lower : bare));
 }
 
 /**

--- a/tests/warp-route.test.ts
+++ b/tests/warp-route.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { hostCouldMatch, matchRoute, parseRoute, rewriteUrl } from '../src/warp/route.js';
+
+describe('warp route port selection', () => {
+  const front = 'http://127.0.0.1:47821';
+
+  it('matches a pattern with no port against any port', () => {
+    const routes = [parseRoute(`api.anthropic.com/v1/messages*=${front}`)];
+    expect(matchRoute(routes, 'api.anthropic.com:443', '/v1/messages')).not.toBeNull();
+    expect(hostCouldMatch(routes, 'api.anthropic.com:443')).toBe(true);
+  });
+
+  it('honours the port when the pattern names one', () => {
+    const routes = [parseRoute(`127.0.0.1:8082/v1/*=${front}`)];
+    expect(matchRoute(routes, '127.0.0.1:8082', '/v1/responses')).not.toBeNull();
+    // Same host, different port: the pxpipe front door must not divert to itself.
+    expect(matchRoute(routes, '127.0.0.1:47821', '/v1/responses')).toBeNull();
+    expect(hostCouldMatch(routes, '127.0.0.1:47821')).toBe(false);
+  });
+
+  it('preserves the path and query when rewriting', () => {
+    const route = parseRoute(`127.0.0.1:8082/v1/*=${front}`);
+    expect(rewriteUrl(route, '/v1/responses?stream=true')).toBe(
+      'http://127.0.0.1:47821/v1/responses?stream=true',
+    );
+  });
+
+  it('rejects a spec with no target', () => {
+    expect(() => parseRoute('127.0.0.1:8082/v1/*')).toThrow(/PATTERN=http/);
+  });
+});


### PR DESCRIPTION
warp matched route patterns on hostname only, so an agent pointed at another local proxy (`127.0.0.1:8082`) could not be warped, and the pxpipe front door could divert to itself.

Threads `host:port` through connect/route matching instead of stripping the port, and adds `pxpipe warp --route PATTERN=TARGET` for agents that talk to a non-default base URL.

Pre-existing work, split out of the code-scanning branch so the security fixes review on their own.

```
npx vitest run tests/warp-route.test.ts   # 4 passed
npx tsc --noEmit                          # clean
```