### PR TITLE
fix(transform): collapse history before imaging tool results

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1910,12 +1910,17 @@ async function runHistoryCollapseAndFinalize(
   }
   applyPins(req, info, pins);
   info.outgoingTextChars = countOutgoingTextChars(req);
-  // Ground truth, counted from the bytes we are about to send. `imageCount` is
-  // what we RENDERED, and the two differ: the collapse replaces whole messages,
-  // so any tool_result image inside the collapsed range never reaches the wire.
-  // Measured on a tool-heavy shape: 95 rendered, 27 on the wire. The provider
-  // only ever sees this number, so telemetry and any future headroom math must
-  // read it and not the render counter.
+  // Ground truth, counted from the bytes we are about to send. The provider only
+  // ever sees this number, so telemetry and any future headroom math must read it
+  // and not the render counter. The collapse replaces whole messages, so a client
+  // image sitting inside the collapsed range is counted in `nativeImages` but is
+  // not on the wire, and only a count taken here sees that.
+  //
+  // This comment used to cite "95 rendered, 27 on the wire" as if the gap were a
+  // property of the design. It was not. It was tool_result imaging running before
+  // the collapse on the main path, so 68 renders were discarded together with the
+  // messages that absorbed them. With the stages ordered correctly the same shape
+  // measures 92 rendered and 92 on the wire.
   info.wireImages = countNativeImages(req.messages);
   const outBody = new TextEncoder().encode(JSON.stringify(req));
   return { body: outBody, info, collapsed: collapsedFlag };
@@ -2382,238 +2387,13 @@ export async function transformRequest(
       ];
     }
 
-    // 5b. Compress tool_result content across ALL user messages.
-    if (o.compressToolResults) {
-      for (const msg of req.messages ?? []) {
-        if (msg.role !== 'user' || !Array.isArray(msg.content)) continue;
-        const rewritten: ContentBlock[] = [];
-        let changed = false;
-        for (const blk of msg.content) {
-          if (blk && (blk as ToolResultBlock).type === 'tool_result') {
-            const tr = blk as ToolResultBlock;
-            // Anthropic rejects images inside is_error tool_results — leave alone.
-            if (tr.is_error === true) {
-              rewritten.push(blk);
-              continue;
-            }
-            const innerRaw = tr.content;
-            if (typeof innerRaw === 'string') {
-              // Caller fidelity override: pin this tool_result as text.
-              if (callerKeepsSharp(o.keepSharp, { kind: 'tool_result', text: innerRaw, toolUseId: tr.tool_use_id })) {
-                bumpPassthrough(info, 'kept_sharp');
-                info.keptSharpBlocks = (info.keptSharpBlocks ?? 0) + 1;
-                rewritten.push(blk);
-                continue;
-              }
-              // Hard wire cap: the client's own images plus ours must stay
-              // under the provider's limit, else the WHOLE request is rejected.
-              // Out of headroom → keep the text sharp; a big body beats a 400.
-              if (imageHeadroom(info) <= 0) {
-                bumpPassthrough(info, 'image_budget');
-                info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
-                rewritten.push(blk);
-                continue;
-              }
-              const inner = compactSlabWhitespace(innerRaw);
-              // classifyContent sees pre-reflow `inner` so shape bucketing reflects real structure.
-              const innerR = maybeReflow(inner, o.reflow);
-              if (innerR.length < o.minToolResultChars) {
-                bumpPassthrough(info, 'below_threshold');
-                rewritten.push(blk);
-              } else if (!isCompressionProfitable(innerR, denseGeo.cols, o.maxImagesPerToolResult, o.charsPerToken, 0, 0, true, denseGeo.maxChars, denseGeo)) {
-                bumpPassthrough(info, 'not_profitable');
-                rewritten.push(blk);
-              } else {
-                // Paging: truncate before render if it would blow the image cap.
-                // The per-result cap is the SMALLER of the configured max and what
-                // is actually left on the wire — the headroom shrinks as earlier
-                // results spend it, so each result sees the live number.
-                const resultImageCap = Math.min(o.maxImagesPerToolResult, imageHeadroom(info));
-                const linesPerImage = Math.max(
-                  1,
-                  Math.floor((denseGeo.maxHeightPx - 2 * PAD_Y) / renderCellHeight(denseGeo.style)),
-                );
-                const paged = truncateForBudget(
-                  innerR,
-                  resultImageCap,
-                  denseGeo.cols,
-                  denseGeo.maxChars,
-                  linesPerImage,
-                );
-                if (paged.truncated) {
-                  info.truncatedToolResults = (info.truncatedToolResults ?? 0) + 1;
-                  info.omittedChars = (info.omittedChars ?? 0) + paged.omittedChars;
-                }
-                const { blocks: imgs, pngs: rawPngs, dims: rawDims, droppedChars, droppedCodepoints: dcp, pixels } =
-                  await textToImageBlocks(
-                    paged.text,
-                    o.cols,
-                    true,
-                    denseGeo.style,
-                    denseGeo.maxHeightPx,
-                  );
-                // Paging is budgeted at denseGeo.cols but rendering happens at
-                // o.cols; when they differ the real page count can exceed the plan.
-                // Verify against the actual render and drop OUR images rather than
-                // ship a request the provider rejects outright.
-                if (imgs.length > imageHeadroom(info)) {
-                  bumpPassthrough(info, 'image_budget');
-                  info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
-                  rewritten.push(blk);
-                  continue;
-                }
-                (info.imagePngs ??= []).push(...rawPngs);
-                (info.imageDims ??= []).push(...rawDims);
-                for (const img of imgs) info.imageBytes += approxBlockBytes(img);
-                info.imagePixels = (info.imagePixels ?? 0) + pixels;
-                info.toolResultImgs = (info.toolResultImgs ?? 0) + imgs.length;
-                info.imageCount += imgs.length;
-                await recordRecoverable(info, o.emitRecoverable, {
-                  kind: 'tool_result',
-                  toolUseId: tr.tool_use_id,
-                  text: innerRaw,
-                  imageCount: imgs.length,
-                });
-                info.compressedChars += innerRaw.length; // original length = what text billing would be
-                info.droppedChars = (info.droppedChars ?? 0) + droppedChars;
-                for (const [cp, n] of dcp) {
-                  droppedCodepoints.set(cp, (droppedCodepoints.get(cp) ?? 0) + n);
-                }
-                const trFactSheet = factSheetText(innerRaw);
-                rewritten.push({
-                  ...tr,
-                  content: trFactSheet ? [...imgs, { type: 'text' as const, text: trFactSheet }] : imgs,
-                });
-                changed = true;
-                bumpBucket(info, toolResultBucket(classifyContent(inner)), innerRaw.length);
-              }
-            } else if (Array.isArray(innerRaw)) {
-              const newInner: Array<TextBlock | ImageBlock> = [];
-              let innerChanged = false;
-              for (const ib of innerRaw) {
-                const isTextBlock =
-                  ib &&
-                  (ib as TextBlock).type === 'text' &&
-                  typeof (ib as TextBlock).text === 'string';
-                if (!isTextBlock) {
-                  newInner.push(ib as TextBlock | ImageBlock);
-                  continue;
-                }
-                const innerTextRaw = (ib as TextBlock).text;
-                // Caller fidelity override: pin this tool_result part as text.
-                if (callerKeepsSharp(o.keepSharp, { kind: 'tool_result_part', text: innerTextRaw, toolUseId: tr.tool_use_id })) {
-                  bumpPassthrough(info, 'kept_sharp');
-                  info.keptSharpBlocks = (info.keptSharpBlocks ?? 0) + 1;
-                  newInner.push(ib as TextBlock | ImageBlock);
-                  continue;
-                }
-                // Hard wire cap — see the string-content path above.
-                if (imageHeadroom(info) <= 0) {
-                  bumpPassthrough(info, 'image_budget');
-                  info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
-                  newInner.push(ib as TextBlock | ImageBlock);
-                  continue;
-                }
-                // Lossless whitespace compaction before gate + render.
-                const innerText = compactSlabWhitespace(innerTextRaw);
-                // R3: gate/page/render on reflowed text; classify pre-reflow.
-                const innerTextR = maybeReflow(innerText, o.reflow);
-                if (innerTextR.length < o.minToolResultChars) {
-                  bumpPassthrough(info, 'below_threshold');
-                  newInner.push(ib as TextBlock | ImageBlock);
-                  continue;
-                }
-                if (!isCompressionProfitable(innerTextR, denseGeo.cols, o.maxImagesPerToolResult, o.charsPerToken, 0, 0, true, denseGeo.maxChars, denseGeo)) {
-                  bumpPassthrough(info, 'not_profitable');
-                  newInner.push(ib as TextBlock | ImageBlock);
-                  continue;
-                }
-                const linesPerImage = Math.max(
-                  1,
-                  Math.floor((denseGeo.maxHeightPx - 2 * PAD_Y) / renderCellHeight(denseGeo.style)),
-                );
-                const resultImageCap = Math.min(o.maxImagesPerToolResult, imageHeadroom(info));
-                const paged = truncateForBudget(
-                  innerTextR,
-                  resultImageCap,
-                  denseGeo.cols,
-                  denseGeo.maxChars,
-                  linesPerImage,
-                );
-                if (paged.truncated) {
-                  info.truncatedToolResults = (info.truncatedToolResults ?? 0) + 1;
-                  info.omittedChars = (info.omittedChars ?? 0) + paged.omittedChars;
-                }
-                const { blocks: imgs, pngs: rawPngs, dims: rawDims, droppedChars, droppedCodepoints: dcp, pixels } =
-                  await textToImageBlocks(
-                    paged.text,
-                    o.cols,
-                    true,
-                    denseGeo.style,
-                    denseGeo.maxHeightPx,
-                  );
-                // Paging is budgeted at denseGeo.cols but rendering happens at
-                // o.cols; when they differ the real page count can exceed the plan.
-                // Verify against the actual render and drop OUR images rather than
-                // ship a request the provider rejects outright.
-                if (imgs.length > imageHeadroom(info)) {
-                  bumpPassthrough(info, 'image_budget');
-                  info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
-                  newInner.push(ib as TextBlock | ImageBlock);
-                  continue;
-                }
-                (info.imagePngs ??= []).push(...rawPngs);
-                (info.imageDims ??= []).push(...rawDims);
-                const srcCacheControl = demoteRelocatedCacheControl((ib as { cache_control?: unknown }).cache_control);
-                for (let i = 0; i < imgs.length; i++) {
-                  const img = imgs[i]!;
-                  const out =
-                    i === imgs.length - 1 && srcCacheControl !== undefined
-                      ? { ...img, cache_control: srcCacheControl }
-                      : img;
-                  newInner.push(out as ImageBlock);
-                  info.imageBytes += approxBlockBytes(img);
-                }
-                const partFactSheet = factSheetText(innerTextRaw);
-                if (partFactSheet) newInner.push({ type: 'text', text: partFactSheet });
-                info.imagePixels = (info.imagePixels ?? 0) + pixels;
-                info.toolResultImgs = (info.toolResultImgs ?? 0) + imgs.length;
-                info.imageCount += imgs.length;
-                await recordRecoverable(info, o.emitRecoverable, {
-                  kind: 'tool_result_part',
-                  toolUseId: tr.tool_use_id,
-                  text: innerTextRaw,
-                  imageCount: imgs.length,
-                });
-                info.compressedChars += innerTextRaw.length;
-                info.droppedChars = (info.droppedChars ?? 0) + droppedChars;
-                for (const [cp, n] of dcp) {
-                  droppedCodepoints.set(cp, (droppedCodepoints.get(cp) ?? 0) + n);
-                }
-                bumpBucket(info, toolResultBucket(classifyContent(innerText)), innerTextRaw.length);
-                innerChanged = true;
-              }
-              if (innerChanged) {
-                rewritten.push({ ...tr, content: newInner });
-                changed = true;
-              } else {
-                rewritten.push(blk);
-              }
-            } else {
-              rewritten.push(blk);
-            }
-          } else {
-            rewritten.push(blk);
-          }
-        }
-        if (changed) msg.content = rewritten;
-      }
-    }
   }
 
   if (toolsRewritten) req.tools = toolsRewritten;
 
-  // 6. History-image compression (always runs after per-message rewrites).
+  // 6. History-image compression. Runs BEFORE tool_result imaging (step 5b), so
+  //    the collapse reads the original textual message graph. See the ordering
+  //    invariant documented on step 5b below.
   // History is single-col dense; use slab cpt unless host pinned charsPerToken.
   // protectedPrefix excludes the slab-bearing first user message — collapsing it
   // would reduce slab images to [image] placeholders and destroy the cache anchor.
@@ -2687,6 +2467,250 @@ export async function transformRequest(
       }
     } else if (histInfo.reason) {
       info.historyReason = histInfo.reason;
+    }
+  }
+
+  // 5b. Compress tool_result content across ALL user messages.
+  //
+  // ORDERING INVARIANT: this runs AFTER the history collapse (step 6), never
+  // before it. Both stages are lossy, and composing them the other way lost
+  // content outright: once a tool_result has become image blocks, the collapse
+  // serializer (`blocksToText`) renders a nested image as the literal string
+  // "[image]". A tool_result that was imaged here and then absorbed by the
+  // collapse therefore reached the wire in neither form - not as text, because
+  // the text had been replaced, and not as an image, because the collapse
+  // replaces whole messages. Running the collapse first means it sees the
+  // original textual graph, and only messages that survive outside the
+  // collapsed prefix are still eligible for imaging here.
+  //
+  // Consequence to keep in mind when reading the budget calls below: the
+  // history images are already counted in `info` by the time we get here, so
+  // `imageHeadroom(info)` is the headroom left after the collapse spent its
+  // share. Out of headroom degrades to sharp text, which is the safe direction.
+  if (o.compressToolResults) {
+    for (const msg of req.messages ?? []) {
+      if (msg.role !== 'user' || !Array.isArray(msg.content)) continue;
+      const rewritten: ContentBlock[] = [];
+      let changed = false;
+      for (const blk of msg.content) {
+        if (blk && (blk as ToolResultBlock).type === 'tool_result') {
+          const tr = blk as ToolResultBlock;
+          // Anthropic rejects images inside is_error tool_results — leave alone.
+          if (tr.is_error === true) {
+            rewritten.push(blk);
+            continue;
+          }
+          const innerRaw = tr.content;
+          if (typeof innerRaw === 'string') {
+            // Caller fidelity override: pin this tool_result as text.
+            if (callerKeepsSharp(o.keepSharp, { kind: 'tool_result', text: innerRaw, toolUseId: tr.tool_use_id })) {
+              bumpPassthrough(info, 'kept_sharp');
+              info.keptSharpBlocks = (info.keptSharpBlocks ?? 0) + 1;
+              rewritten.push(blk);
+              continue;
+            }
+            // Hard wire cap: the client's own images plus ours must stay
+            // under the provider's limit, else the WHOLE request is rejected.
+            // Out of headroom → keep the text sharp; a big body beats a 400.
+            if (imageHeadroom(info) <= 0) {
+              bumpPassthrough(info, 'image_budget');
+              info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
+              rewritten.push(blk);
+              continue;
+            }
+            const inner = compactSlabWhitespace(innerRaw);
+            // classifyContent sees pre-reflow `inner` so shape bucketing reflects real structure.
+            const innerR = maybeReflow(inner, o.reflow);
+            if (innerR.length < o.minToolResultChars) {
+              bumpPassthrough(info, 'below_threshold');
+              rewritten.push(blk);
+            } else if (!isCompressionProfitable(innerR, denseGeo.cols, o.maxImagesPerToolResult, o.charsPerToken, 0, 0, true, denseGeo.maxChars, denseGeo)) {
+              bumpPassthrough(info, 'not_profitable');
+              rewritten.push(blk);
+            } else {
+              // Paging: truncate before render if it would blow the image cap.
+              // The per-result cap is the SMALLER of the configured max and what
+              // is actually left on the wire — the headroom shrinks as earlier
+              // results spend it, so each result sees the live number.
+              const resultImageCap = Math.min(o.maxImagesPerToolResult, imageHeadroom(info));
+              const linesPerImage = Math.max(
+                1,
+                Math.floor((denseGeo.maxHeightPx - 2 * PAD_Y) / renderCellHeight(denseGeo.style)),
+              );
+              const paged = truncateForBudget(
+                innerR,
+                resultImageCap,
+                denseGeo.cols,
+                denseGeo.maxChars,
+                linesPerImage,
+              );
+              if (paged.truncated) {
+                info.truncatedToolResults = (info.truncatedToolResults ?? 0) + 1;
+                info.omittedChars = (info.omittedChars ?? 0) + paged.omittedChars;
+              }
+              const { blocks: imgs, pngs: rawPngs, dims: rawDims, droppedChars, droppedCodepoints: dcp, pixels } =
+                await textToImageBlocks(
+                  paged.text,
+                  o.cols,
+                  true,
+                  denseGeo.style,
+                  denseGeo.maxHeightPx,
+                );
+              // Paging is budgeted at denseGeo.cols but rendering happens at
+              // o.cols; when they differ the real page count can exceed the plan.
+              // Verify against the actual render and drop OUR images rather than
+              // ship a request the provider rejects outright.
+              if (imgs.length > imageHeadroom(info)) {
+                bumpPassthrough(info, 'image_budget');
+                info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
+                rewritten.push(blk);
+                continue;
+              }
+              (info.imagePngs ??= []).push(...rawPngs);
+              (info.imageDims ??= []).push(...rawDims);
+              for (const img of imgs) info.imageBytes += approxBlockBytes(img);
+              info.imagePixels = (info.imagePixels ?? 0) + pixels;
+              info.toolResultImgs = (info.toolResultImgs ?? 0) + imgs.length;
+              info.imageCount += imgs.length;
+              await recordRecoverable(info, o.emitRecoverable, {
+                kind: 'tool_result',
+                toolUseId: tr.tool_use_id,
+                text: innerRaw,
+                imageCount: imgs.length,
+              });
+              info.compressedChars += innerRaw.length; // original length = what text billing would be
+              info.droppedChars = (info.droppedChars ?? 0) + droppedChars;
+              for (const [cp, n] of dcp) {
+                droppedCodepoints.set(cp, (droppedCodepoints.get(cp) ?? 0) + n);
+              }
+              const trFactSheet = factSheetText(innerRaw);
+              rewritten.push({
+                ...tr,
+                content: trFactSheet ? [...imgs, { type: 'text' as const, text: trFactSheet }] : imgs,
+              });
+              changed = true;
+              bumpBucket(info, toolResultBucket(classifyContent(inner)), innerRaw.length);
+            }
+          } else if (Array.isArray(innerRaw)) {
+            const newInner: Array<TextBlock | ImageBlock> = [];
+            let innerChanged = false;
+            for (const ib of innerRaw) {
+              const isTextBlock =
+                ib &&
+                (ib as TextBlock).type === 'text' &&
+                typeof (ib as TextBlock).text === 'string';
+              if (!isTextBlock) {
+                newInner.push(ib as TextBlock | ImageBlock);
+                continue;
+              }
+              const innerTextRaw = (ib as TextBlock).text;
+              // Caller fidelity override: pin this tool_result part as text.
+              if (callerKeepsSharp(o.keepSharp, { kind: 'tool_result_part', text: innerTextRaw, toolUseId: tr.tool_use_id })) {
+                bumpPassthrough(info, 'kept_sharp');
+                info.keptSharpBlocks = (info.keptSharpBlocks ?? 0) + 1;
+                newInner.push(ib as TextBlock | ImageBlock);
+                continue;
+              }
+              // Hard wire cap — see the string-content path above.
+              if (imageHeadroom(info) <= 0) {
+                bumpPassthrough(info, 'image_budget');
+                info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
+                newInner.push(ib as TextBlock | ImageBlock);
+                continue;
+              }
+              // Lossless whitespace compaction before gate + render.
+              const innerText = compactSlabWhitespace(innerTextRaw);
+              // R3: gate/page/render on reflowed text; classify pre-reflow.
+              const innerTextR = maybeReflow(innerText, o.reflow);
+              if (innerTextR.length < o.minToolResultChars) {
+                bumpPassthrough(info, 'below_threshold');
+                newInner.push(ib as TextBlock | ImageBlock);
+                continue;
+              }
+              if (!isCompressionProfitable(innerTextR, denseGeo.cols, o.maxImagesPerToolResult, o.charsPerToken, 0, 0, true, denseGeo.maxChars, denseGeo)) {
+                bumpPassthrough(info, 'not_profitable');
+                newInner.push(ib as TextBlock | ImageBlock);
+                continue;
+              }
+              const linesPerImage = Math.max(
+                1,
+                Math.floor((denseGeo.maxHeightPx - 2 * PAD_Y) / renderCellHeight(denseGeo.style)),
+              );
+              const resultImageCap = Math.min(o.maxImagesPerToolResult, imageHeadroom(info));
+              const paged = truncateForBudget(
+                innerTextR,
+                resultImageCap,
+                denseGeo.cols,
+                denseGeo.maxChars,
+                linesPerImage,
+              );
+              if (paged.truncated) {
+                info.truncatedToolResults = (info.truncatedToolResults ?? 0) + 1;
+                info.omittedChars = (info.omittedChars ?? 0) + paged.omittedChars;
+              }
+              const { blocks: imgs, pngs: rawPngs, dims: rawDims, droppedChars, droppedCodepoints: dcp, pixels } =
+                await textToImageBlocks(
+                  paged.text,
+                  o.cols,
+                  true,
+                  denseGeo.style,
+                  denseGeo.maxHeightPx,
+                );
+              // Paging is budgeted at denseGeo.cols but rendering happens at
+              // o.cols; when they differ the real page count can exceed the plan.
+              // Verify against the actual render and drop OUR images rather than
+              // ship a request the provider rejects outright.
+              if (imgs.length > imageHeadroom(info)) {
+                bumpPassthrough(info, 'image_budget');
+                info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
+                newInner.push(ib as TextBlock | ImageBlock);
+                continue;
+              }
+              (info.imagePngs ??= []).push(...rawPngs);
+              (info.imageDims ??= []).push(...rawDims);
+              const srcCacheControl = demoteRelocatedCacheControl((ib as { cache_control?: unknown }).cache_control);
+              for (let i = 0; i < imgs.length; i++) {
+                const img = imgs[i]!;
+                const out =
+                  i === imgs.length - 1 && srcCacheControl !== undefined
+                    ? { ...img, cache_control: srcCacheControl }
+                    : img;
+                newInner.push(out as ImageBlock);
+                info.imageBytes += approxBlockBytes(img);
+              }
+              const partFactSheet = factSheetText(innerTextRaw);
+              if (partFactSheet) newInner.push({ type: 'text', text: partFactSheet });
+              info.imagePixels = (info.imagePixels ?? 0) + pixels;
+              info.toolResultImgs = (info.toolResultImgs ?? 0) + imgs.length;
+              info.imageCount += imgs.length;
+              await recordRecoverable(info, o.emitRecoverable, {
+                kind: 'tool_result_part',
+                toolUseId: tr.tool_use_id,
+                text: innerTextRaw,
+                imageCount: imgs.length,
+              });
+              info.compressedChars += innerTextRaw.length;
+              info.droppedChars = (info.droppedChars ?? 0) + droppedChars;
+              for (const [cp, n] of dcp) {
+                droppedCodepoints.set(cp, (droppedCodepoints.get(cp) ?? 0) + n);
+              }
+              bumpBucket(info, toolResultBucket(classifyContent(innerText)), innerTextRaw.length);
+              innerChanged = true;
+            }
+            if (innerChanged) {
+              rewritten.push({ ...tr, content: newInner });
+              changed = true;
+            } else {
+              rewritten.push(blk);
+            }
+          } else {
+            rewritten.push(blk);
+          }
+        } else {
+          rewritten.push(blk);
+        }
+      }
+      if (changed) msg.content = rewritten;
     }
   }
 

--- a/tests/history-toolresult-composition.test.ts
+++ b/tests/history-toolresult-composition.test.ts
@@ -1,0 +1,173 @@
+/**
+ * COMPOSITION contract between the two lossy stages.
+ *
+ * transformRequest has two independently correct compressions: tool_result
+ * imaging and history collapse. Composed in the wrong order they lose content.
+ * Once a tool_result has become image blocks, `blocksToText` - the serializer
+ * the collapse feeds - renders a nested image as the literal string "[image]".
+ * If that same old message is then absorbed by the collapse, the original tool
+ * output reaches the wire in neither form: not as text, because the text was
+ * replaced by images, and not as pixels, because the collapse replaces whole
+ * messages and only renders what the serializer gave it.
+ *
+ * The invariant that pins the ordering, and the one asserted here, is an
+ * equality: what the collapse sees must not depend on whether tool_result
+ * imaging is enabled. When imaging runs first, that equality breaks by exactly
+ * the size of the imaged bodies - 40k characters of tool output become seven.
+ *
+ * Run just this file:  pnpm vitest run tests/history-toolresult-composition.test.ts
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { transformRequest } from '../src/core/transform.js';
+import { blocksToText } from '../src/core/history.js';
+import { resetSessionState } from '../src/core/session-state.js';
+import type { Message } from '../src/core/types.js';
+
+const big = (n: number) => 'x'.repeat(n);
+const enc = (obj: unknown) => new TextEncoder().encode(JSON.stringify(obj));
+const dec = (b: Uint8Array): any => JSON.parse(new TextDecoder().decode(b));
+
+const TOOL_BODY_CHARS = 40_000;
+const PLAIN_TURNS = 60;
+const PLAIN_TURN_CHARS = 3500;
+
+/** One closed tool round: the assistant calls, the user returns the result. */
+function toolRound(id: string, body: string): Message[] {
+  return [
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id, name: 'Read', input: { path: 'notes.txt' } }],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: id, content: body }],
+    },
+  ] as unknown as Message[];
+}
+
+/** N closed plain turns, long enough that the collapse gate accepts. */
+function plainTurns(n: number, offset = 0, chars = PLAIN_TURN_CHARS): Message[] {
+  const out: Message[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push({
+      role: (i + offset) % 2 === 0 ? 'user' : 'assistant',
+      content: `turn ${i + offset}: ` + big(chars),
+    });
+  }
+  return out;
+}
+
+/**
+ * Claude Code shape with one OLD tool round deep inside the collapse window:
+ *
+ *   [0]      user "go"            <- slab anchor, protected prefix
+ *   [1..2]   assistant/user       <- the old tool round, big enough to image
+ *   [3..62]  plain closed turns   <- pushes the round deep into the collapse window
+ *   tail     live region
+ */
+function bodyWithOldToolResult() {
+  const messages: Message[] = [
+    { role: 'user', content: 'go' } as Message,
+    ...toolRound('t_old', 'RESULT t_old\n' + big(TOOL_BODY_CHARS)),
+    ...plainTurns(PLAIN_TURNS, 3, PLAIN_TURN_CHARS),
+  ];
+  return enc({
+    model: 'claude-3-5-sonnet',
+    system: [{ type: 'text', text: 'SLAB\n' + big(80_000), cache_control: { type: 'ephemeral' } }],
+    messages,
+  });
+}
+
+/** Same shape plus a FRESH tool round in the live tail, which imaging must still reach. */
+function bodyWithOldAndLiveToolResults() {
+  const messages: Message[] = [
+    { role: 'user', content: 'go' } as Message,
+    ...toolRound('t_old', 'RESULT t_old\n' + big(TOOL_BODY_CHARS)),
+    ...plainTurns(PLAIN_TURNS, 3),
+    ...toolRound('t_live', 'RESULT t_live\n' + big(TOOL_BODY_CHARS)),
+  ];
+  return enc({
+    model: 'claude-3-5-sonnet',
+    system: [{ type: 'text', text: 'SLAB\n' + big(80_000), cache_control: { type: 'ephemeral' } }],
+    messages,
+  });
+}
+
+describe('blocksToText - the hazard the ordering protects against', () => {
+  it('serializes a nested image to a placeholder, not to its source text', () => {
+    const text = blocksToText([
+      {
+        type: 'tool_result',
+        tool_use_id: 't1',
+        content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' } }],
+      },
+    ] as any);
+    // This is correct behaviour for the serializer and exactly why an imaged
+    // tool_result must never be handed to it.
+    expect(text).toContain('[image]');
+  });
+});
+
+describe('tool_result imaging composed with history collapse', () => {
+  beforeEach(() => resetSessionState());
+
+  it('gives the collapse the same view whether or not imaging is enabled', async () => {
+    const withImaging = await transformRequest(bodyWithOldToolResult());
+    resetSessionState();
+    const withoutImaging = await transformRequest(bodyWithOldToolResult(), {
+      compressToolResults: false,
+    });
+
+    expect(withImaging.info.collapsedTurns).toBe(withoutImaging.info.collapsedTurns);
+    // The headline invariant: imaging must not change what history sees.
+    //
+    // Measured on this fixture with the stages in the losing order: 49 collapsed
+    // turns either way, but 85,139 chars with imaging against 125,137 without -
+    // 39,998 characters gone, the whole 40k tool body less the seven-character
+    // "[image]" that replaced it. Equality is what closes that hole, and a
+    // partial regression shows up here as a nonzero difference.
+    expect(withImaging.info.collapsedChars).toBe(withoutImaging.info.collapsedChars);
+    // Both runs must really have exercised the collapse window that holds the
+    // tool round, otherwise the equality above is vacuous.
+    expect(withImaging.info.collapsedChars ?? 0).toBeGreaterThan(TOOL_BODY_CHARS);
+  });
+
+  it('still images a tool_result that survives in the live region', async () => {
+    const { body: out, info } = await transformRequest(bodyWithOldAndLiveToolResults());
+
+    expect(info.collapsedTurns ?? 0).toBeGreaterThan(0);
+    // Reordering must not silently disable imaging: the live round is outside the
+    // collapsed prefix and is still eligible.
+    expect(info.toolResultImgs ?? 0).toBeGreaterThan(0);
+
+    const msgs = dec(out).messages as any[];
+    const liveImaged = msgs.some(
+      (m) =>
+        Array.isArray(m.content) &&
+        m.content.some(
+          (b: any) =>
+            b?.type === 'tool_result' &&
+            b.tool_use_id === 't_live' &&
+            Array.isArray(b.content) &&
+            b.content.some((ib: any) => ib?.type === 'image'),
+        ),
+    );
+    expect(liveImaged).toBe(true);
+  });
+
+  it('does not leave an orphaned tool_use without its tool_result', async () => {
+    const { body: out } = await transformRequest(bodyWithOldAndLiveToolResults());
+    const msgs = dec(out).messages as any[];
+
+    const useIds = new Set<string>();
+    const resultIds = new Set<string>();
+    for (const m of msgs) {
+      if (!Array.isArray(m.content)) continue;
+      for (const b of m.content) {
+        if (b?.type === 'tool_use' && b.id) useIds.add(b.id);
+        if (b?.type === 'tool_result' && b.tool_use_id) resultIds.add(b.tool_use_id);
+      }
+    }
+    for (const id of useIds) expect(resultIds.has(id)).toBe(true);
+  });
+});

--- a/tests/native-image-cap.test.ts
+++ b/tests/native-image-cap.test.ts
@@ -201,8 +201,15 @@ describe('wireImages — what the provider actually counts', () => {
 
     const actual = wireImages(dec(out).messages);
     expect(info.wireImages).toBe(actual);
-    // The whole point: we rendered materially more than we shipped.
-    expect(info.imageCount!).toBeGreaterThan(actual);
+    // This assertion used to read `imageCount > actual` — "we rendered materially
+    // more than we shipped" — and on this shape it measured 95 rendered against 27
+    // shipped. That gap was not a design property. It was tool_result imaging
+    // running before the history collapse: 68 of those renders were thrown away
+    // with the messages that absorbed them, and the tool output inside them
+    // reached the wire in no form at all. With the stages ordered so the collapse
+    // sees original text, the same fixture measures 92 rendered and 92 shipped.
+    // A gap reappearing here now means renders are being discarded again.
+    expect(info.imageCount!).toBe(actual - (info.nativeImages ?? 0));
     expect(actual).toBeLessThanOrEqual(ANTHROPIC_MAX_IMAGES);
   });
 


### PR DESCRIPTION
Fixes #192.

Step 5b now runs after step 6, so the history collapse reads the original textual message graph and only messages surviving outside the collapsed prefix are eligible for tool_result imaging.

The move is a relocation, not a rewrite. The block is unchanged apart from two levels of indentation, so `git diff -w` shows the real delta.

## Measured

On the tool-heavy fixture already in `tests/native-image-cap.test.ts`:

| | rendered | on the wire | discarded |
| --- | --- | --- | --- |
| before | 95 | 27 | 68 |
| after | 92 | 92 | 0 |

`collapsedImages` goes from 13 to 78, which is the history images now carrying the tool output as pixels instead of `[image]` placeholders.

## Two consequences to weigh

- Content that used to vanish is really shipped now, so a tool-heavy session spends materially more of the 100-image cap. The existing budget still holds the cap. This makes a cumulative image-byte budget more urgent, and #195 covers it.
- The image budget is spent by the collapse first, so a tool_result with no headroom left degrades to sharp text. That is the safe direction.

## Also in this PR

Two comments documented the defect as if it were a design property, and the assertion in `native-image-cap.test.ts` pinned the 95-versus-27 gap. Rendering more than you ship is not a feature, so both were corrected rather than preserved.

## Regression guard

`tests/history-toolresult-composition.test.ts` asserts that what the collapse sees does not depend on whether tool_result imaging is enabled. That equality fails on the previous ordering and holds on this one. Checked in both directions.

## Verification

`pnpm run typecheck` clean, `pnpm test` 1028 passing, `pnpm run test:restart` 4/4, `pnpm run build` clean. Baseline before the change was 1024 passing with no pre-existing failures.