### PR TITLE
fix(proxy): bound inbound request bodies before allocating

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -51,6 +51,7 @@ software supply-chain boundary.
 | Prompt or secret leaks through telemetry | Full 4xx body capture is opt-in; normal events retain hashes/metadata; local artifacts are owner-only | Do not add raw content to logs; document any new persistence |
 | Dashboard exposes captured context | Dashboard routes require loopback source and host; cross-site mutations are rejected | Treat every dashboard route as sensitive and preserve both checks |
 | Oversized dashboard request exhausts memory | Dashboard request bodies are bounded | Keep bounds before parsing and add negative tests for new endpoints |
+| Oversized proxy request exhausts memory | Transformable routes refuse past `maxRequestBytes` (`PXPIPE_MAX_REQUEST_BYTES`, 16 MiB default) before allocating, using the streamed size rather than the declared one; label-only routes bound their model sniff and stream the remainder untouched | Never read an inbound body to completion before the limit is proven; add exact-boundary, missing-length and under-declared-length tests for new routes |
 | Malicious dependency or compromised release | Frozen lockfile, three-day release-age gate, restricted lifecycle scripts, OIDC trusted publishing, provenance | Keep least-privilege workflow permissions and review lockfile/lifecycle changes |
 | Vulnerable dependency remains installed | Dependabot, CodeQL/GitHub security scanning, a high-severity CI audit gate, targeted overrides | Run `pnpm audit` and remove overrides when direct dependencies adopt fixed ranges |
 

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -73,6 +73,18 @@ export interface ProxyConfig {
    *  fails open. Prevents one stalled request from permanently 409-ing its retries.
    *  0 disables dedupe entirely. */
   duplicateHoldMs?: number;
+  /** Hard ceiling, in bytes, on an inbound request body pxpipe will hold in
+   *  memory. Transformable routes have to read the whole body, so without a
+   *  ceiling one client decides how much the proxy allocates: a Worker or a Node
+   *  instance bound to anything other than loopback is then one long request away
+   *  from memory exhaustion. Over-limit bodies get a provider-shaped 413 before
+   *  any upstream call. Routes pxpipe only labels are never rejected by this -
+   *  they carry uploads and audio - but their model sniff is bounded too.
+   *
+   *  Defaults to {@link DEFAULT_MAX_REQUEST_BYTES}. A non-integer, zero or
+   *  negative value is ignored in favour of that default: an unusable limit must
+   *  not silently become no limit. */
+  maxRequestBytes?: number;
 }
 
 export interface ProxyEvent {
@@ -232,6 +244,150 @@ function withClientDisconnect(
  *  transform. Chat requests naming a model are far below this; uploads that blow
  *  past it stream through unbuffered. */
 const MODEL_SNIFF_MAX_BYTES = 1 << 20;
+
+/** Default ceiling on a buffered inbound body: 16 MiB.
+ *
+ *  Chosen against what the transform actually has to hold, not against what a
+ *  provider accepts. Real Claude Code requests measured on production traffic sit
+ *  far below this even with a 400k system slab and a long tool-heavy history, so
+ *  the limit is not reachable by ordinary use. Hosts that genuinely need more can
+ *  raise it explicitly; nothing raises it implicitly. */
+export const DEFAULT_MAX_REQUEST_BYTES = 16 << 20;
+
+/** Validate a host-supplied ceiling. Garbage falls back to the default rather
+ *  than disabling the check, because "0" or NaN meaning "unlimited" is exactly
+ *  the failure mode this option exists to remove. */
+function resolveMaxRequestBytes(configured: number | undefined): number {
+  if (configured === undefined) return DEFAULT_MAX_REQUEST_BYTES;
+  if (!Number.isSafeInteger(configured) || configured <= 0) return DEFAULT_MAX_REQUEST_BYTES;
+  return configured;
+}
+
+function concatChunks(chunks: readonly Uint8Array[], total: number): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, at);
+    at += chunk.byteLength;
+  }
+  return out;
+}
+
+type BoundedBody =
+  | { ok: true; bytes: Uint8Array<ArrayBuffer> }
+  | { ok: false; observedBytes: number; declaredBytes?: number };
+
+/**
+ * Read a whole request body, refusing anything over `limit`.
+ *
+ * The declared `content-length` is used only as a shortcut to reject without
+ * reading a byte. It is never the authority: chunked senders omit it, and a
+ * wrong value costs the sender nothing. The streaming loop is what enforces the
+ * cap, so a body that lies about its size is bounded by the same number as one
+ * that declares nothing.
+ *
+ * Peak memory is the limit plus at most one chunk: the loop stops pulling the
+ * moment the running total crosses the line and cancels the stream instead of
+ * draining a body it has already refused.
+ */
+async function readBodyBounded(req: Request, limit: number): Promise<BoundedBody> {
+  const declaredRaw = req.headers.get('content-length');
+  const declared = declaredRaw === null ? NaN : Number(declaredRaw);
+  const declaredBytes = Number.isFinite(declared) && declared >= 0 ? declared : undefined;
+  if (declaredBytes !== undefined && declaredBytes > limit) {
+    return { ok: false, observedBytes: 0, declaredBytes };
+  }
+
+  const body = req.body;
+  if (!body) return { ok: true, bytes: new Uint8Array(0) };
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      total += value.byteLength;
+      if (total > limit) {
+        await reader.cancel().catch(() => {});
+        return { ok: false, observedBytes: total, ...(declaredBytes !== undefined ? { declaredBytes } : {}) };
+      }
+      chunks.push(value);
+    }
+  } catch (err) {
+    // A client that hangs up mid-body lands here. Release the socket and let the
+    // host's error path answer, which is what an unbounded read did too.
+    await reader.cancel().catch(() => {});
+    throw err;
+  }
+  return { ok: true, bytes: concatChunks(chunks, total) };
+}
+
+/**
+ * Read at most `maxPrefix` bytes for inspection while keeping the body
+ * forwardable byte-for-byte.
+ *
+ * Used on routes pxpipe does not transform, where the only thing wanted from the
+ * body is the model name for a dashboard label. Rejecting those requests is not
+ * an option - the same route carries uploads and audio - so instead of buffering
+ * everything, the consumed prefix is replayed ahead of the untouched remainder.
+ * Memory stays at one prefix regardless of how large the upload is.
+ */
+async function sniffPrefixRestoringBody(
+  req: Request,
+  maxPrefix: number,
+): Promise<{ prefix: Uint8Array<ArrayBuffer>; body: BodyInit | null }> {
+  const body = req.body;
+  if (!body) return { prefix: new Uint8Array(0), body: null };
+
+  const reader = body.getReader();
+  const prefixChunks: Uint8Array[] = [];
+  let total = 0;
+  let exhausted = false;
+  try {
+    while (total < maxPrefix) {
+      const { done, value } = await reader.read();
+      if (done) {
+        exhausted = true;
+        break;
+      }
+      if (!value || value.byteLength === 0) continue;
+      prefixChunks.push(value);
+      total += value.byteLength;
+    }
+  } catch (err) {
+    await reader.cancel().catch(() => {});
+    throw err;
+  }
+
+  const prefix = concatChunks(prefixChunks, total);
+  // The whole body fit inside the prefix, so those bytes ARE the body.
+  if (exhausted) return { prefix, body: prefix };
+
+  const restored = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of prefixChunks) controller.enqueue(chunk);
+    },
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        if (value && value.byteLength > 0) controller.enqueue(value);
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+  return { prefix, body: restored };
+}
 
 /** Read the actual top-level `model` field. The body is already buffered for
  * transformation, so parsing it is both safer and simpler than a prefix regex
@@ -964,6 +1120,7 @@ export function createProxy(config: ProxyConfig = {}) {
   const headersTimeoutMs = config.upstreamHeadersTimeoutMs ?? DEFAULT_UPSTREAM_HEADERS_TIMEOUT_MS;
   const idleTimeoutMs = config.upstreamIdleTimeoutMs ?? DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS;
   const duplicateHoldMs = config.duplicateHoldMs ?? DEFAULT_DUPLICATE_HOLD_MS;
+  const maxRequestBytes = resolveMaxRequestBytes(config.maxRequestBytes);
   // Explicit precedence: Cloudflare > OpenAI > normal family routing.
   for (const model of config.openAIModels ?? []) {
     const id = model.trim();
@@ -1153,7 +1310,26 @@ export function createProxy(config: ProxyConfig = {}) {
     let baselineStatusApplies = false;
 
     if (isMessages || isOpenAIChat || isOpenAIResponses || isGoogle) {
-      const bodyIn = new Uint8Array(await req.arrayBuffer());
+      // Transformable routes have to hold the whole body, so this is the one
+      // place a client could otherwise choose how much the proxy allocates.
+      // Refuse past the ceiling before any allocation the caller controls, and
+      // before any upstream call: a 413 the provider would have sent anyway is
+      // cheaper for everyone than an out-of-memory host.
+      const bounded = await readBodyBounded(req, maxRequestBytes);
+      if (!bounded.ok) {
+        const message =
+          `request body exceeds the ${maxRequestBytes}-byte pxpipe limit ` +
+          `(${bounded.declaredBytes !== undefined ? `declared ${bounded.declaredBytes}, ` : ''}` +
+          `read ${bounded.observedBytes})`;
+        const error = isMessages
+          ? { type: 'error', error: { type: 'request_too_large', message } }
+          : { error: { type: 'request_too_large', message } };
+        return new Response(JSON.stringify(error), {
+          status: 413,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      const bodyIn = bounded.bytes;
       try {
         const transformOpts =
           typeof config.transform === 'function' ? config.transform() : config.transform;
@@ -1362,15 +1538,21 @@ export function createProxy(config: ProxyConfig = {}) {
       // before. A missing content-length is not evidence of a big body —
       // chunked clients omit it — so only an explicit over-cap declaration
       // disqualifies.
+      // A declared length over the sniff cap still disqualifies early, but it is
+      // no longer the only bound: an undeclared or under-declared body used to
+      // reach `arrayBuffer()` and buffer without limit. Now the read itself stops
+      // at the cap and the untouched remainder streams on, so the model label is
+      // best-effort and the memory cost is fixed either way.
       const declaredType = req.headers.get('content-type') ?? '';
       const declaredLength = Number(req.headers.get('content-length') ?? NaN);
-      const worthBuffering =
+      const worthSniffing =
         declaredType.toLowerCase().includes('json') &&
         !(Number.isFinite(declaredLength) && declaredLength > MODEL_SNIFF_MAX_BYTES);
-      if (worthBuffering) {
-        const bodyIn = new Uint8Array(await req.arrayBuffer());
-        requestModel ??= readModelField(bodyIn) ?? undefined;
-        bodyOut = bodyIn;
+      if (worthSniffing) {
+        const sniffCap = Math.min(MODEL_SNIFF_MAX_BYTES, maxRequestBytes);
+        const { prefix, body: restoredBody } = await sniffPrefixRestoringBody(req, sniffCap);
+        requestModel ??= readModelField(prefix) ?? undefined;
+        bodyOut = restoredBody;
       } else {
         bodyOut = req.body; // pass through unchanged, model stays unknown
       }

--- a/src/node.ts
+++ b/src/node.ts
@@ -60,6 +60,10 @@ interface RuntimeConfig {
   /** Persist 4xx request and upstream error bodies for debugging. Off unless
    *  PXPIPE_DEBUG_CAPTURE_4XX=1. */
   captureErrorReqBody: boolean;
+  /** Ceiling on a buffered inbound request body. Unset leaves the core default
+   *  (16 MiB). Raise it only if a real client needs more; the default binding is
+   *  loopback, but HOST can expose this process to a network. */
+  maxRequestBytes?: number;
 }
 
 const DEFAULT_CONFIG_FILE = path.join(os.homedir(), '.config', 'pxpipe', 'config.json');
@@ -186,7 +190,24 @@ function parseCli(argv: string[]): RuntimeConfig {
     // Off by default: either side of a 4xx may hold prompts or secrets.
     // Opt in for debugging only. (issue #69)
     captureErrorReqBody: process.env.PXPIPE_DEBUG_CAPTURE_4XX === '1',
+    maxRequestBytes: parseMaxRequestBytes(process.env.PXPIPE_MAX_REQUEST_BYTES),
   };
+}
+
+/** A bad limit exits instead of being ignored. The core also refuses to treat a
+ *  broken value as "no limit", but a host that was asked for 8MB and silently ran
+ *  at 16 would be a worse answer than a startup error. */
+function parseMaxRequestBytes(value: string | undefined): number | undefined {
+  const raw = value?.trim();
+  if (raw === undefined || raw === '') return undefined;
+  const bytes = Number(raw);
+  if (!Number.isSafeInteger(bytes) || bytes <= 0) {
+    console.error(
+      `[pxpipe] PXPIPE_MAX_REQUEST_BYTES must be a positive whole number of bytes, got: ${value}`,
+    );
+    process.exit(2);
+  }
+  return bytes;
 }
 
 function parseProvider(v: string | undefined): 'cloudflare-ai-gateway' | undefined {
@@ -1176,6 +1197,7 @@ async function main(): Promise<void> {
     openAIModels: opts.openAIModels,
     cloudflareModels: opts.cloudflareModels,
     captureErrorReqBody: opts.captureErrorReqBody,
+    maxRequestBytes: opts.maxRequestBytes,
     // Per-request transform options:
     //   1. Runtime kill switch — when the dashboard "passthrough" toggle
     //      is off, force compress=false so /v1/messages forwards

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -37,6 +37,11 @@ export interface Env {
   COLS?: string;
   /** Comma-separated model bases eligible for compression. */
   PXPIPE_MODELS?: string;
+  /** Ceiling on a buffered inbound request body, in bytes. A Worker is publicly
+   *  reachable by default, so this is the setting that keeps one caller from
+   *  choosing the isolate's memory ceiling. Unset uses the core 16 MiB default;
+   *  a non-numeric or non-positive value is ignored rather than obeyed. */
+  PXPIPE_MAX_REQUEST_BYTES?: string;
   /** When "0" / "false", disable per-request event JSON logs. Default-on.
    *  Cloudflare ingests console.log as Workers Logs; pipe via Logpush to
    *  R2/S3 for the same JSONL shape Node writes to disk. */
@@ -66,6 +71,15 @@ async function secretsMatch(a: string, b: string): Promise<boolean> {
 
 const truthy = (v: string | undefined, fallback: boolean): boolean =>
   v == null ? fallback : v === '1' || v.toLowerCase() === 'true';
+
+/** Parse a positive whole number, or undefined for anything else. Used for limits
+ *  where a broken value must not read as "unlimited". */
+const positiveInt = (v: string | undefined): number | undefined => {
+  const raw = v?.trim();
+  if (raw === undefined || raw === '') return undefined;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) && n > 0 ? n : undefined;
+};
 
 export default {
   async fetch(req: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
@@ -142,6 +156,11 @@ export default {
       cloudflareApiKey: cfToken,
       openAIModels: parseModels(env.OPENAI_MODELS),
       cloudflareModels: parseModels(env.CLOUDFLARE_MODELS),
+      // A Worker cannot exit on bad config the way the Node host does, so an
+      // unparseable value is dropped here and the core default applies.
+      ...(positiveInt(env.PXPIPE_MAX_REQUEST_BYTES) !== undefined
+        ? { maxRequestBytes: positiveInt(env.PXPIPE_MAX_REQUEST_BYTES) }
+        : {}),
       transform,
       onRequest: (e) => {
         // Terse human-readable line (separate from the JSON event below;

--- a/tests/request-body-limit.test.ts
+++ b/tests/request-body-limit.test.ts
@@ -1,0 +1,278 @@
+/**
+ * INBOUND request-body ceiling.
+ *
+ * Transformable routes have to hold the whole body in memory, so without a limit
+ * the caller decides how much the proxy allocates. The Node host binds loopback
+ * by default, but HOST can expose it, and a Worker is publicly reachable by
+ * construction: one long-running chunked POST was enough to walk the process out
+ * of memory.
+ *
+ * The header is not the bound. A chunked sender omits content-length entirely and
+ * a wrong value costs nothing to send, so these tests drive the honest case, the
+ * silent case and the lying case, and require the same answer from all three.
+ *
+ * Routes pxpipe only labels are held to a different contract: they carry uploads
+ * and audio, so they must never be rejected, and their body must reach the
+ * upstream byte-for-byte even though a bounded prefix was read off it.
+ *
+ * Run just this file:  pnpm vitest run tests/request-body-limit.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createProxy, DEFAULT_MAX_REQUEST_BYTES, type ProxyConfig, type ProxyEvent } from '../src/core/proxy.js';
+
+let ambientPxpipeModels: string | undefined;
+beforeAll(() => {
+  ambientPxpipeModels = process.env.PXPIPE_MODELS;
+  process.env.PXPIPE_MODELS = 'claude-fable-5';
+});
+afterAll(() => {
+  if (ambientPxpipeModels === undefined) delete process.env.PXPIPE_MODELS;
+  else process.env.PXPIPE_MODELS = ambientPxpipeModels;
+});
+
+interface Upstream {
+  calls: number;
+  bodies: string[];
+  restore: () => void;
+}
+
+function mockUpstream(): Upstream {
+  const real = globalThis.fetch;
+  const state: Upstream = {
+    calls: 0,
+    bodies: [],
+    restore: () => {
+      globalThis.fetch = real;
+    },
+  };
+  globalThis.fetch = (async (input: Request | string | URL, init?: RequestInit) => {
+    const r = input instanceof Request ? input : new Request(String(input), init);
+    // The count_tokens baseline probe is a side request, not a forward. Counting
+    // it would make every "did we forward?" assertion read one too high.
+    if (new URL(r.url).pathname.endsWith('/count_tokens')) {
+      return new Response(JSON.stringify({ input_tokens: 1 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    state.calls += 1;
+    state.bodies.push(await r.text());
+    return new Response(
+      JSON.stringify({ id: 'msg_1', type: 'message', role: 'assistant', content: [], usage: {} }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  }) as typeof fetch;
+  return state;
+}
+
+/** A body delivered in chunks, as a chunked sender does: no content-length. */
+function chunkedBody(payload: string, chunkBytes = 512): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(payload);
+  let at = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (at >= bytes.byteLength) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes.slice(at, at + chunkBytes));
+      at += chunkBytes;
+    },
+  });
+}
+
+/** A JSON request body padded to exactly `totalBytes`. */
+function jsonOfSize(totalBytes: number, model = 'claude-fable-5'): string {
+  const skeleton = JSON.stringify({ model, messages: [{ role: 'user', content: '' }] });
+  const padding = totalBytes - skeleton.length;
+  if (padding < 0) throw new Error(`cannot fit a request in ${totalBytes} bytes`);
+  return JSON.stringify({ model, messages: [{ role: 'user', content: 'x'.repeat(padding) }] });
+}
+
+/** `fire()` dispatches onRequest without awaiting it, so the event lands a tick
+ *  after the response resolves. Poll briefly rather than assuming ordering. */
+async function settledEvents(events: ProxyEvent[], want = 1): Promise<ProxyEvent[]> {
+  for (let i = 0; i < 50 && events.length < want; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  return events;
+}
+
+function post(path: string, body: BodyInit, headers: Record<string, string> = {}): Request {
+  const init: RequestInit = {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body,
+  };
+  if (body instanceof ReadableStream) {
+    // Required by spec when the body is a stream.
+    (init as RequestInit & { duplex: string }).duplex = 'half';
+  }
+  return new Request(`http://127.0.0.1:47821${path}`, init);
+}
+
+const LIMIT = 4096;
+
+function proxyWithLimit(
+  maxRequestBytes: number | undefined,
+  events?: ProxyEvent[],
+): ReturnType<typeof createProxy> {
+  const config: ProxyConfig = {
+    upstream: 'https://upstream.invalid',
+    openAIUpstream: 'https://openai.invalid',
+    transform: { compress: false },
+    ...(maxRequestBytes === undefined ? {} : { maxRequestBytes }),
+    ...(events ? { onRequest: (e: ProxyEvent) => void events.push(e) } : {}),
+  };
+  return createProxy(config);
+}
+
+describe('the ceiling is enforced on the body, not on its declared size', () => {
+  it('forwards a body of exactly the limit, byte for byte', async () => {
+    const up = mockUpstream();
+    try {
+      const payload = jsonOfSize(LIMIT);
+      expect(new TextEncoder().encode(payload).byteLength).toBe(LIMIT);
+      const res = await proxyWithLimit(LIMIT)(post('/v1/messages', payload));
+      expect(res.status).toBe(200);
+      expect(up.calls).toBe(1);
+      expect(up.bodies[0]).toBe(payload);
+    } finally {
+      up.restore();
+    }
+  });
+
+  it('refuses one byte over the limit and never calls upstream', async () => {
+    const up = mockUpstream();
+    try {
+      const res = await proxyWithLimit(LIMIT)(post('/v1/messages', jsonOfSize(LIMIT + 1)));
+      expect(res.status).toBe(413);
+      expect(up.calls).toBe(0);
+    } finally {
+      up.restore();
+    }
+  });
+
+  it('refuses a chunked body with no content-length at all', async () => {
+    const up = mockUpstream();
+    try {
+      const res = await proxyWithLimit(LIMIT)(
+        post('/v1/messages', chunkedBody(jsonOfSize(LIMIT * 4))),
+      );
+      expect(res.status).toBe(413);
+      expect(up.calls).toBe(0);
+    } finally {
+      up.restore();
+    }
+  });
+
+  it('refuses a body that under-declares its own length', async () => {
+    const up = mockUpstream();
+    try {
+      // The header says 10 bytes. The stream delivers four times the limit. A
+      // proxy that trusted the header would allocate all of it.
+      const res = await proxyWithLimit(LIMIT)(
+        post('/v1/messages', chunkedBody(jsonOfSize(LIMIT * 4)), { 'content-length': '10' }),
+      );
+      expect(res.status).toBe(413);
+      expect(up.calls).toBe(0);
+    } finally {
+      up.restore();
+    }
+  });
+
+  it('rejects an over-declared length without calling upstream', async () => {
+    const up = mockUpstream();
+    try {
+      const res = await proxyWithLimit(LIMIT)(
+        post('/v1/messages', jsonOfSize(LIMIT + 1), { 'content-length': String(LIMIT * 100) }),
+      );
+      expect(res.status).toBe(413);
+      expect(up.calls).toBe(0);
+    } finally {
+      up.restore();
+    }
+  });
+});
+
+describe('the refusal is shaped like the provider it stands in for', () => {
+  it('uses the Anthropic error envelope on a Messages route', async () => {
+    const up = mockUpstream();
+    try {
+      const res = await proxyWithLimit(LIMIT)(post('/v1/messages', jsonOfSize(LIMIT + 1)));
+      expect(res.status).toBe(413);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const parsed = (await res.json()) as { type?: string; error?: { type?: string } };
+      expect(parsed.type).toBe('error');
+      expect(parsed.error?.type).toBe('request_too_large');
+    } finally {
+      up.restore();
+    }
+  });
+
+  it('uses the OpenAI error envelope on a chat-completions route', async () => {
+    const up = mockUpstream();
+    try {
+      const body = JSON.stringify({ model: 'gpt-5.6-sol', messages: [{ role: 'user', content: 'x'.repeat(LIMIT) }] });
+      const res = await proxyWithLimit(LIMIT)(post('/v1/chat/completions', body));
+      expect(res.status).toBe(413);
+      const parsed = (await res.json()) as { type?: string; error?: { type?: string } };
+      expect(parsed.type).toBeUndefined();
+      expect(parsed.error?.type).toBe('request_too_large');
+    } finally {
+      up.restore();
+    }
+  });
+});
+
+describe('label-only routes are bounded but never rejected', () => {
+  it('streams an oversized upload through untouched', async () => {
+    const up = mockUpstream();
+    try {
+      // Four times the ceiling on a route pxpipe does not transform. Rejecting it
+      // would break uploads; buffering it would be the same defect under a
+      // different route name.
+      const payload = 'y'.repeat(LIMIT * 4);
+      const res = await proxyWithLimit(LIMIT)(post('/v1/files', chunkedBody(payload)));
+      expect(res.status).toBe(200);
+      expect(up.calls).toBe(1);
+      expect(up.bodies[0]).toBe(payload);
+    } finally {
+      up.restore();
+    }
+  });
+
+  it('still reads the model label off a small body and forwards it intact', async () => {
+    const up = mockUpstream();
+    const events: ProxyEvent[] = [];
+    try {
+      const payload = JSON.stringify({ model: 'some-labelled-model', input: 'hello' });
+      const res = await proxyWithLimit(LIMIT, events)(post('/v1/files', chunkedBody(payload)));
+      expect(res.status).toBe(200);
+      expect(up.bodies[0]).toBe(payload);
+      expect((await settledEvents(events)).at(-1)?.model).toBe('some-labelled-model');
+    } finally {
+      up.restore();
+    }
+  });
+});
+
+describe('an unusable limit falls back to the default instead of to none', () => {
+  it.each([[0], [-1], [1.5], [Number.NaN]])('ignores %s', async (bad) => {
+    const up = mockUpstream();
+    try {
+      // Well under the 16 MiB default, so acceptance proves the default applied
+      // rather than the broken value being read as "unlimited".
+      const res = await proxyWithLimit(bad)(post('/v1/messages', jsonOfSize(LIMIT)));
+      expect(res.status).toBe(200);
+      expect(up.calls).toBe(1);
+    } finally {
+      up.restore();
+    }
+  });
+
+  it('exports a default that is a positive whole number of bytes', () => {
+    expect(Number.isSafeInteger(DEFAULT_MAX_REQUEST_BYTES)).toBe(true);
+    expect(DEFAULT_MAX_REQUEST_BYTES).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fixes #193.

Adds `maxRequestBytes` to `ProxyConfig`, wired from `PXPIPE_MAX_REQUEST_BYTES` on both hosts, defaulting to 16 MiB.

- Transformable routes stream through a bounded reader and answer a provider-shaped 413 before any upstream call. The declared length is only a shortcut for rejecting early; the running total enforces the cap, so a body that lies about its size is bounded by the same number as one that declares nothing. Peak memory is the limit plus one chunk.
- Label-only routes are never rejected, because the same route carries uploads and audio. Their model sniff reads a bounded prefix and replays it ahead of the untouched remainder, so the forwarded body stays byte-identical while memory stays at one prefix.
- Node exits on an unparseable value. The Worker cannot exit, so it drops the value and uses the default. The core never treats a broken value as "unlimited", which is the failure mode the option exists to remove.
- A client that hangs up mid-body cancels the reader and surfaces the same way an unbounded read did.

`docs/SECURITY_MODEL.md` gains the matching row next to the dashboard one that already existed.

## Verification

14 tests: exact boundary, one byte over, no content-length, under-declared length, over-declared length, both provider error envelopes, an oversized upload passing through byte-for-byte on a label-only route, the model label still read from a small one, and each unusable config value falling back to the default.

`pnpm run typecheck` clean, `pnpm test` 1038 passing, `pnpm run test:restart` 4/4, `pnpm run build` clean.

Note: this is new behaviour rather than a repaired API, so the tests cannot be run against the previous tree; the exported default does not exist there. The enforcement they assert is behaviour the old code provably lacked, since `arrayBuffer()` was called with no cap.