### PR TITLE
fix(proxy): decide OpenAI-route credentials by an explicit policy

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -47,7 +47,7 @@ software supply-chain boundary.
 | Threat | Existing control | Contributor requirement |
 | --- | --- | --- |
 | Public deployment spends a configured API key | Worker requires `PXPIPE_WORKER_SECRET` and fails closed | Preserve the fail-closed check and constant-work comparison tests |
-| Provider credential is routed to the wrong upstream | Provider-specific routing and header tests | Add regression tests for every new route or provider |
+| Provider credential is routed to the wrong upstream | An explicit inbound-credential x route policy (`resolveOpenAIRouteAuth`): Anthropic-shaped credentials never reach an OpenAI upstream, subscription OAuth is preserved rather than substituted, and a host key replaces only ordinary keys. Classification is by header shape; no local token store is read | Extend the policy table, not the call site, for every new route or provider, and keep the full matrix under test |
 | Prompt or secret leaks through telemetry | Full 4xx body capture is opt-in; normal events retain hashes/metadata; local artifacts are owner-only | Do not add raw content to logs; document any new persistence |
 | Dashboard exposes captured context | Dashboard routes require loopback source and host; cross-site mutations are rejected | Treat every dashboard route as sensitive and preserve both checks |
 | Oversized dashboard request exhausts memory | Dashboard request bodies are bounded | Keep bounds before parsing and add negative tests for new endpoints |

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -843,6 +843,89 @@ function resolveAuthToken(config: ProxyConfig): string | undefined {
   return typeof config.authToken === 'function' ? config.authToken() : config.authToken;
 }
 
+/** What the client presented, by shape only.
+ *
+ *  Classification never inspects a credential's contents beyond its prefix and
+ *  segment structure, and never reads a local token store: pxpipe does not know
+ *  or want to know which account a token belongs to. Shape is enough to decide
+ *  routing, and it is the only thing safe to decide it on. */
+export type InboundCredential =
+  | 'none'
+  /** `x-api-key`, which only Anthropic uses. */
+  | 'anthropic-key'
+  /** `Bearer sk-ant-…`: an Anthropic key or subscription token. */
+  | 'anthropic-bearer'
+  /** `Bearer <jwt>`: how Codex and ChatGPT subscription auth arrive. */
+  | 'oauth-jwt'
+  /** `Bearer sk-…` that is not Anthropic: an OpenAI-style API key. */
+  | 'api-key-bearer'
+  /** A bearer of unrecognised shape. Gateways and self-hosted upstreams use these. */
+  | 'opaque-bearer';
+
+const ANTHROPIC_BEARER_RE = /^Bearer\s+sk-ant-/i;
+const API_KEY_BEARER_RE = /^Bearer\s+sk-/i;
+/** Three base64url segments whose first decodes to a JSON header (`eyJ…`). */
+const JWT_BEARER_RE = /^Bearer\s+eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*$/;
+
+export function classifyInboundCredential(headers: Headers): InboundCredential {
+  const authorization = headers.get('authorization') ?? '';
+  if (ANTHROPIC_BEARER_RE.test(authorization)) return 'anthropic-bearer';
+  if (JWT_BEARER_RE.test(authorization)) return 'oauth-jwt';
+  if (API_KEY_BEARER_RE.test(authorization)) return 'api-key-bearer';
+  if (authorization.trim() !== '') return 'opaque-bearer';
+  if ((headers.get('x-api-key') ?? '').trim() !== '') return 'anthropic-key';
+  return 'none';
+}
+
+/** The decision for the outgoing `authorization` header. */
+export type OutboundAuth =
+  /** Forward what the client sent, unchanged. */
+  | { action: 'keep-inbound'; reason: string }
+  /** Install the host's configured key in its place. */
+  | { action: 'replace'; reason: string }
+  /** Send no authorization at all. */
+  | { action: 'drop'; reason: string };
+
+/**
+ * Credential policy for a direct OpenAI-family route: `/v1/responses`,
+ * `/v1/chat/completions`, `/v1/models` and the provider-prefixed equivalents,
+ * where the client speaks to the OpenAI upstream itself rather than through a
+ * Messages bridge.
+ *
+ * Three rules, in priority order:
+ *
+ *  1. An Anthropic-shaped credential never reaches an OpenAI upstream. That is a
+ *     cross-provider credential disclosure, and a guaranteed 401 on top. The
+ *     route classifier already refuses this for the ambiguous `/v1/models` path;
+ *     this applies the same rule to every OpenAI route.
+ *  2. Subscription OAuth is preserved even when the host has an API key
+ *     configured. A Codex user proxying through pxpipe means to spend their own
+ *     subscription; silently substituting the host key bills the wrong account
+ *     and usually fails, and the user has no way to see why.
+ *  3. Otherwise a configured key replaces whatever arrived, and is used as the
+ *     fallback when nothing arrived. This is the documented "host supplies the
+ *     credential" mode.
+ */
+export function resolveOpenAIRouteAuth(
+  inbound: InboundCredential,
+  hasConfiguredKey: boolean,
+): OutboundAuth {
+  if (inbound === 'anthropic-bearer' || inbound === 'anthropic-key') {
+    return hasConfiguredKey
+      ? { action: 'replace', reason: 'anthropic-credential-never-crosses-providers' }
+      : { action: 'drop', reason: 'anthropic-credential-never-crosses-providers' };
+  }
+  if (inbound === 'oauth-jwt') {
+    return { action: 'keep-inbound', reason: 'subscription-oauth-belongs-to-the-caller' };
+  }
+  if (hasConfiguredKey) {
+    return { action: 'replace', reason: 'host-configured-key' };
+  }
+  return inbound === 'none'
+    ? { action: 'drop', reason: 'no-credential-available' }
+    : { action: 'keep-inbound', reason: 'caller-credential-forwarded' };
+}
+
 function isCanonicalOpenAIPath(pathname: string, headers: Headers, hasOpenAIKey: boolean): boolean {
   const isModelsPath = pathname === '/v1/models' || pathname.startsWith('/v1/models/');
   // `/v1/models` exists on BOTH APIs, so it is routed by auth style — but an
@@ -1380,10 +1463,8 @@ export function createProxy(config: ProxyConfig = {}) {
 
     const outHeaders = filterHeaders(req.headers, STRIP_REQ_HEADERS);
     if (isOpenAIPath || bridgedGptMessages || bridgedChatMessages) {
+      // `x-api-key` is Anthropic-only and never belongs on an OpenAI upstream.
       outHeaders.delete('x-api-key');
-      // Never forward a Messages client's bearer credential across providers.
-      // A configured upstream key is installed below; otherwise auth stays absent.
-      if (bridgedGptMessages || bridgedChatMessages) outHeaders.delete('authorization');
       const anthropicHeaders: string[] = [];
       outHeaders.forEach((_value, name) => {
         if (name.toLowerCase().startsWith('anthropic-')) anthropicHeaders.push(name);
@@ -1393,7 +1474,24 @@ export function createProxy(config: ProxyConfig = {}) {
       const bridgeKey = bridgedChatMessages
         ? config.cloudflareApiKey
         : config.openAIApiKey;
-      if (bridgeKey) outHeaders.set('authorization', `Bearer ${bridgeKey}`);
+      if (bridgedGptMessages || bridgedChatMessages) {
+        // A bridged request came in as Anthropic Messages, so whatever credential
+        // it carries is an Anthropic one by construction. Drop it unconditionally
+        // and use only what the host configured for the bridge target.
+        outHeaders.delete('authorization');
+        if (bridgeKey) outHeaders.set('authorization', `Bearer ${bridgeKey}`);
+      } else {
+        // A direct OpenAI-family route. The client's own credential may be the
+        // right one to forward, so decide by shape instead of by whether a host
+        // key happens to be set. See resolveOpenAIRouteAuth for the three rules.
+        const decision = resolveOpenAIRouteAuth(
+          classifyInboundCredential(req.headers),
+          bridgeKey !== undefined && bridgeKey !== '',
+        );
+        if (decision.action === 'drop') outHeaders.delete('authorization');
+        else if (decision.action === 'replace') outHeaders.set('authorization', `Bearer ${bridgeKey}`);
+        // 'keep-inbound' leaves the header filterHeaders already copied.
+      }
     } else if (!providerPrefixed || url.pathname.startsWith('/anthropic/')) {
       if (config.apiKey) outHeaders.set('x-api-key', config.apiKey);
       const bearer = resolveAuthToken(config);

--- a/tests/credential-route-policy.test.ts
+++ b/tests/credential-route-policy.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Which credential reaches which upstream.
+ *
+ * pxpipe sits on the wire with every request's authorization header in hand, so
+ * the rule for what it forwards has to be a rule, not a side effect of which
+ * branch a route fell into. Before this policy existed, two behaviours followed
+ * from the same `if`:
+ *
+ *  - a Codex client's ChatGPT subscription OAuth was overwritten by the host's
+ *    configured OpenAI key whenever one was set, billing the wrong account and
+ *    usually failing with no visible reason;
+ *  - an Anthropic-shaped bearer arriving on a direct OpenAI route was forwarded
+ *    to OpenAI, because the `authorization` deletion only covered bridged
+ *    requests. The route classifier already refused exactly this for the
+ *    ambiguous `/v1/models` path, calling it "a credential leak, and a
+ *    guaranteed 401"; the rule simply was not applied anywhere else.
+ *
+ * The table below is the contract. Classification is by shape only: no local
+ * token store is ever read, and no credential content beyond its prefix and
+ * segment structure is examined.
+ *
+ * Run just this file:  pnpm vitest run tests/credential-route-policy.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  classifyInboundCredential,
+  createProxy,
+  resolveOpenAIRouteAuth,
+  type InboundCredential,
+  type ProxyConfig,
+} from '../src/core/proxy.js';
+
+let ambientPxpipeModels: string | undefined;
+beforeAll(() => {
+  ambientPxpipeModels = process.env.PXPIPE_MODELS;
+  process.env.PXPIPE_MODELS = 'off';
+});
+afterAll(() => {
+  if (ambientPxpipeModels === undefined) delete process.env.PXPIPE_MODELS;
+  else process.env.PXPIPE_MODELS = ambientPxpipeModels;
+});
+
+/** A structurally valid JWT. Contents are inert: header `{"alg":"none"}`. */
+const JWT = 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.c2ln';
+const ANTHROPIC_OAUTH = 'sk-ant-oat01-example';
+const ANTHROPIC_KEY = 'sk-ant-api03-example';
+const OPENAI_KEY = 'sk-proj-example';
+const HOST_KEY = 'sk-host-configured';
+
+function headers(init: Record<string, string>): Headers {
+  return new Headers(init);
+}
+
+describe('classifyInboundCredential reads shape, never content', () => {
+  const cases: Array<[Record<string, string>, InboundCredential]> = [
+    [{}, 'none'],
+    [{ 'x-api-key': ANTHROPIC_KEY }, 'anthropic-key'],
+    [{ authorization: `Bearer ${ANTHROPIC_OAUTH}` }, 'anthropic-bearer'],
+    [{ authorization: `Bearer ${ANTHROPIC_KEY}` }, 'anthropic-bearer'],
+    [{ authorization: `Bearer ${JWT}` }, 'oauth-jwt'],
+    [{ authorization: `Bearer ${OPENAI_KEY}` }, 'api-key-bearer'],
+    [{ authorization: 'Bearer opaque-gateway-token' }, 'opaque-bearer'],
+    // An Anthropic bearer outranks a co-present x-api-key: it is the stronger
+    // signal and the one that would actually be forwarded.
+    [{ authorization: `Bearer ${ANTHROPIC_OAUTH}`, 'x-api-key': ANTHROPIC_KEY }, 'anthropic-bearer'],
+  ];
+  it.each(cases)('classifies %j', (init, expected) => {
+    expect(classifyInboundCredential(headers(init))).toBe(expected);
+  });
+
+  it('does not mistake an empty header for a credential', () => {
+    expect(classifyInboundCredential(headers({ authorization: '   ' }))).toBe('none');
+    expect(classifyInboundCredential(headers({ 'x-api-key': '' }))).toBe('none');
+  });
+});
+
+describe('resolveOpenAIRouteAuth: inbound credential x configured key', () => {
+  const matrix: Array<[InboundCredential, boolean, 'keep-inbound' | 'replace' | 'drop']> = [
+    // An Anthropic credential must never reach OpenAI, key configured or not.
+    ['anthropic-bearer', false, 'drop'],
+    ['anthropic-bearer', true, 'replace'],
+    ['anthropic-key', false, 'drop'],
+    ['anthropic-key', true, 'replace'],
+    // Subscription OAuth is the caller's, and outranks a configured host key.
+    ['oauth-jwt', false, 'keep-inbound'],
+    ['oauth-jwt', true, 'keep-inbound'],
+    // Ordinary keys: the host key replaces when present, otherwise forward.
+    ['api-key-bearer', false, 'keep-inbound'],
+    ['api-key-bearer', true, 'replace'],
+    ['opaque-bearer', false, 'keep-inbound'],
+    ['opaque-bearer', true, 'replace'],
+    // Nothing to keep.
+    ['none', false, 'drop'],
+    ['none', true, 'replace'],
+  ];
+  it.each(matrix)('%s with configured=%s -> %s', (inbound, configured, action) => {
+    expect(resolveOpenAIRouteAuth(inbound, configured).action).toBe(action);
+  });
+
+  it('never returns replace when no key is configured', () => {
+    const inbounds: InboundCredential[] = [
+      'none',
+      'anthropic-key',
+      'anthropic-bearer',
+      'oauth-jwt',
+      'api-key-bearer',
+      'opaque-bearer',
+    ];
+    for (const inbound of inbounds) {
+      expect(resolveOpenAIRouteAuth(inbound, false).action).not.toBe('replace');
+    }
+  });
+
+  it('always states a reason, so a decision can be explained', () => {
+    expect(resolveOpenAIRouteAuth('oauth-jwt', true).reason).toContain('subscription');
+    expect(resolveOpenAIRouteAuth('anthropic-bearer', false).reason).toContain('never-crosses');
+  });
+});
+
+interface Seen {
+  authorization: string | null;
+  apiKey: string | null;
+  restore: () => void;
+}
+
+function captureUpstream(): Seen {
+  const real = globalThis.fetch;
+  const seen: Seen = {
+    authorization: null,
+    apiKey: null,
+    restore: () => {
+      globalThis.fetch = real;
+    },
+  };
+  globalThis.fetch = (async (input: Request | string | URL, init?: RequestInit) => {
+    const r = input instanceof Request ? input : new Request(String(input), init);
+    seen.authorization = r.headers.get('authorization');
+    seen.apiKey = r.headers.get('x-api-key');
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return seen;
+}
+
+function proxy(openAIApiKey?: string): ReturnType<typeof createProxy> {
+  const config: ProxyConfig = {
+    upstream: 'https://anthropic.invalid',
+    openAIUpstream: 'https://openai.invalid',
+    transform: { compress: false },
+    ...(openAIApiKey === undefined ? {} : { openAIApiKey }),
+  };
+  return createProxy(config);
+}
+
+function responsesRequest(auth: Record<string, string>): Request {
+  return new Request('http://127.0.0.1:47821/v1/responses', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...auth },
+    body: JSON.stringify({ model: 'gpt-5.6-sol', input: 'hi' }),
+  });
+}
+
+describe('the policy holds on a real OpenAI route', () => {
+  it('preserves subscription OAuth even when a host key is configured', async () => {
+    const seen = captureUpstream();
+    try {
+      await proxy(HOST_KEY)(responsesRequest({ authorization: `Bearer ${JWT}` }));
+      expect(seen.authorization).toBe(`Bearer ${JWT}`);
+    } finally {
+      seen.restore();
+    }
+  });
+
+  it('does not forward an Anthropic bearer to the OpenAI upstream', async () => {
+    const seen = captureUpstream();
+    try {
+      await proxy()(responsesRequest({ authorization: `Bearer ${ANTHROPIC_OAUTH}` }));
+      expect(seen.authorization).toBeNull();
+    } finally {
+      seen.restore();
+    }
+  });
+
+  it('substitutes the host key for an Anthropic bearer rather than leaking it', async () => {
+    const seen = captureUpstream();
+    try {
+      await proxy(HOST_KEY)(responsesRequest({ authorization: `Bearer ${ANTHROPIC_OAUTH}` }));
+      expect(seen.authorization).toBe(`Bearer ${HOST_KEY}`);
+      expect(seen.authorization).not.toContain('sk-ant-');
+    } finally {
+      seen.restore();
+    }
+  });
+
+  it('never forwards x-api-key to the OpenAI upstream', async () => {
+    const seen = captureUpstream();
+    try {
+      await proxy()(responsesRequest({ 'x-api-key': ANTHROPIC_KEY }));
+      expect(seen.apiKey).toBeNull();
+    } finally {
+      seen.restore();
+    }
+  });
+
+  it('forwards an OpenAI key unchanged when the host configured none', async () => {
+    const seen = captureUpstream();
+    try {
+      await proxy()(responsesRequest({ authorization: `Bearer ${OPENAI_KEY}` }));
+      expect(seen.authorization).toBe(`Bearer ${OPENAI_KEY}`);
+    } finally {
+      seen.restore();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #194.

`resolveOpenAIRouteAuth` states the rule as a policy over (inbound credential shape) x (host key configured), instead of leaving it to which branch a route fell into:

1. An Anthropic-shaped credential never reaches an OpenAI upstream: dropped, or replaced by the host key when one exists.
2. Subscription OAuth is preserved even when a host key is configured. It belongs to the caller.
3. Otherwise a configured key replaces what arrived, and supplies the credential when nothing arrived.

Classification is by header shape only, prefix and segment structure. No local credential store is read and no token content is inspected. Bridged Messages requests are unchanged: their credential is Anthropic by construction, so it is still dropped unconditionally.

Authorization values were already safe in telemetry and were left alone. The dedupe key hashes headers with SHA-256, and 4xx capture stores the body only.

## Verification

28 tests: the twelve-cell matrix, the shape classifier including an empty-header case, and five end-to-end assertions on a real `/v1/responses` route. The two measured behaviours in the issue are asserted directly and both flip.

`pnpm run typecheck` clean, `pnpm test` 1052 passing.