### PR TITLE
fix(transform): budget decoded image bytes, not just image count

### DIFF
--- a/docs/RENDER_SIZING.md
+++ b/docs/RENDER_SIZING.md
@@ -41,6 +41,23 @@ the vision encoder without the old 0.555× resample.
 OpenAI-shaped profiles use portrait strips. GPT 5.6 Sol uses 84×9+8, a 764px
 strip up to 1954px; Grok uses 84×9+8, a 764px strip up to 512px.
 
+There are two ceilings, not one. The documented provider limit is a count: 100
+images per request, enforced through `imageHeadroom`. The second is weight, and
+it is empirical: past roughly 20MiB of decoded image bytes, production requests
+start failing as 500s, 502s, empty 200s and stalls (#157), and `/compact`
+traverses the same oversized path, so a session cannot compact its way out.
+
+`maxImageBytes` bounds that second budget, defaulting to 18MiB, deliberately
+under the observed cliff rather than at it. The caller's own images are counted
+first and are never removed to make room. Admission is atomic per semantic
+group: the slab, one tool result, and the history collapse are each imaged whole
+or kept as text whole, because a half-imaged group ships pages without the text
+they replaced, and a partially imaged slab re-keys the cache prefix whenever the
+budget arithmetic moves. `imageByteSkips` counts groups refused by weight, kept
+separate from `imageBudgetSkips` because fewer pages and smaller pages are
+different fixes; `imageBytesNearLimit` flags a request that finished inside the
+top 10% of the budget.
+
 ## Font and Unicode
 
 Atlases are generated at build time; runtime never loads font files. The compact

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -100,6 +100,13 @@ export interface TransformOptions {
   /** Hard upper bound on images per tool_result; source text truncated with a paging
    *  marker above this to stay under Anthropic's 100-image/request cap. Default 10. */
   maxImagesPerToolResult?: number;
+  /** Ceiling on total decoded image bytes in one request, caller images
+   *  included. The provider's hard limit is a count, not a size, so the image
+   *  cap alone lets a long session assemble a request that is legal by count and
+   *  fails by weight: production traffic degrades sharply past roughly 20 MiB
+   *  with 500s, 502s, empty 200s and stalls (#157). Groups are admitted whole,
+   *  and a group that does not fit keeps its source text. */
+  maxImageBytes?: number;
   /** Chars-per-token assumption for `isCompressionProfitable()`. Default 4. */
   charsPerToken?: number;
   /** Multi-turn amortization horizon for the history-collapse gate. N≥2 evaluates as
@@ -146,6 +153,9 @@ const DEFAULTS: Required<TransformOptions> = {
   // 312 cols × 5 px + 8 px pad = 1568 px (Anthropic no-resize edge).
   cols: ANTHROPIC_SLAB_COLS,
   maxImagesPerToolResult: 10,
+  // Deliberately under the ~20 MiB cliff observed in production rather than at
+  // it: the measured threshold is empirical and varies by route and provider.
+  maxImageBytes: 18 * 1024 * 1024,
   charsPerToken: 4,
   historyAmortizationHorizon: 1,
   priorWarmTokens: 0,
@@ -655,6 +665,17 @@ export interface TransformInfo {
   nativeImages?: number;
   /** Imaging steps skipped because the cap was exhausted (telemetry for tuning). */
   imageBudgetSkips?: number;
+  /** Decoded bytes of the CLIENT's own image blocks, counted once before any
+   *  rewrite. They occupy the same weight budget ours do, and they are never
+   *  removed to make room: a caller's screenshot outranks our compression. */
+  nativeImageBytes?: number;
+  /** Imaging groups skipped because the byte budget, not the count cap, was
+   *  exhausted. Distinct from {@link imageBudgetSkips} because the two have
+   *  different fixes: one wants fewer pages, the other wants smaller ones. */
+  imageByteSkips?: number;
+  /** Set when the request landed within 10% of the byte budget. Nothing was
+   *  dropped, but the next turn of the same session probably will be. */
+  imageBytesNearLimit?: boolean;
   /** Image blocks actually present in the outgoing body — ours AND the client's.
    *  This is the only number the provider counts. It is <= imageCount + nativeImages
    *  because the history collapse can absorb messages that already carried images. */
@@ -743,6 +764,10 @@ export interface TransformInfo {
     | 'below_min_tokens'
     | 'not_profitable'
     | 'too_many_images'
+    /** Rendered, then not applied: the collapse group did not fit the decoded
+     *  image-byte budget, so the original text stands. Distinct from
+     *  `too_many_images`, which is the provider's count cap. */
+    | 'image_bytes'
     | 'render_empty'
     | 'over_budget'
     | 'collapsed';
@@ -1780,6 +1805,44 @@ export function imageHeadroom(info: TransformInfo): number {
   );
 }
 
+/** Bytes still available for image content, caller images already deducted.
+ *
+ *  Separate from {@link imageHeadroom} because the two limits fail differently.
+ *  The count cap is the provider's documented limit and rejects with a clear
+ *  error. The byte budget is empirical: past roughly 20 MiB production requests
+ *  start failing as 500s, 502s, empty 200s and stalls, which read as flakiness
+ *  rather than as "too big". */
+export function imageByteHeadroom(info: TransformInfo, limit: number): number {
+  return Math.max(0, limit - info.imageBytes - (info.nativeImageBytes ?? 0));
+}
+
+/** True when this request finished close enough to the budget that the next turn
+ *  of the same session is likely to hit it. */
+function nearByteLimit(info: TransformInfo, limit: number): boolean {
+  return limit > 0 && info.imageBytes + (info.nativeImageBytes ?? 0) >= limit * 0.9;
+}
+
+/** Decoded bytes of the caller's own images, at both nesting levels. Runs BEFORE
+ *  any rewrite, for the same reason {@link countNativeImages} does. */
+export function countNativeImageBytes(messages: readonly Message[] | undefined): number {
+  let bytes = 0;
+  const add = (blk: unknown): void => {
+    const b = blk as ImageBlock | null;
+    if (b?.type === 'image' && typeof b.source?.data === 'string') bytes += approxBlockBytes(b);
+  };
+  for (const m of messages ?? []) {
+    if (!Array.isArray(m.content)) continue;
+    for (const blk of m.content) {
+      add(blk);
+      const tr = blk as ToolResultBlock | null;
+      if (tr?.type === 'tool_result' && Array.isArray(tr.content)) {
+        for (const inner of tr.content) add(inner);
+      }
+    }
+  }
+  return bytes;
+}
+
 /** Count image blocks already present in the caller's messages. Runs BEFORE any
  *  rewrite, so it sees the client's images only — ours do not exist yet. */
 export function countNativeImages(messages: readonly Message[] | undefined): number {
@@ -1887,7 +1950,20 @@ async function runHistoryCollapseAndFinalize(
     if (histInfo.freezeStep !== undefined) info.historyFreezeStep = histInfo.freezeStep;
     if (histInfo.budgetTrimmed) info.historyBudgetTrimmed = true;
     if (tuning.packFill) info.historyPackFill = true;
-    if (histInfo.collapsedTurns > 0) {
+    // Atomic admission by weight. The collapse is one semantic group: applying
+    // it means every collapsed message becomes pages, so a group that does not
+    // fit the byte budget is not applied at all and the original text stands.
+    // Rendering it first and discarding it costs CPU, which is the cheap half of
+    // the trade: the alternative is estimating PNG size from character counts and
+    // being wrong on the request that mattered.
+    if (
+      histInfo.collapsedTurns > 0 &&
+      histInfo.collapsedImageBytes > imageByteHeadroom(info, o.maxImageBytes)
+    ) {
+      bumpPassthrough(info, 'image_budget');
+      info.imageByteSkips = (info.imageByteSkips ?? 0) + 1;
+      info.historyReason = 'image_bytes';
+    } else if (histInfo.collapsedTurns > 0) {
       req.messages = newMessages;
       info.collapsedTurns = histInfo.collapsedTurns;
       info.collapsedChars = histInfo.collapsedChars;
@@ -1927,6 +2003,7 @@ async function runHistoryCollapseAndFinalize(
   // messages that absorbed them. With the stages ordered correctly the same shape
   // measures 92 rendered and 92 on the wire.
   info.wireImages = countNativeImages(req.messages);
+  if (nearByteLimit(info, o.maxImageBytes)) info.imageBytesNearLimit = true;
   const outBody = new TextEncoder().encode(JSON.stringify(req));
   return { body: outBody, info, collapsed: collapsedFlag };
 }
@@ -1995,6 +2072,7 @@ export async function transformRequest(
   // same wire cap we are about to spend from. Counted once, here, because every
   // later path (slab, tool_results, history) rewrites content in place.
   info.nativeImages = countNativeImages(req.messages);
+  info.nativeImageBytes = countNativeImageBytes(req.messages);
 
   // 0. User-pinned instructions. Fold the transcript's pin commands, then remove
   //    them from the outbound copy — the client's own transcript is untouched, so
@@ -2299,10 +2377,16 @@ export async function transformRequest(
   // (measured: 94 client images + 400k slab -> 109 on the wire -> 400). All or
   // nothing, because the slab is part of the cache prefix — imaging half of it
   // would re-key that prefix on every turn whose client-image count moved.
-  if (images.length > imageHeadroom(info)) {
-    info.reason = `image_budget (slab needs ${images.length}, headroom ${imageHeadroom(info)})`;
+  const slabBytes = images.reduce((sum, img) => sum + img.png.length, 0);
+  const slabOverCount = images.length > imageHeadroom(info);
+  const slabOverBytes = slabBytes > imageByteHeadroom(info, o.maxImageBytes);
+  if (slabOverCount || slabOverBytes) {
+    info.reason = slabOverCount
+      ? `image_budget (slab needs ${images.length}, headroom ${imageHeadroom(info)})`
+      : `image_bytes (slab needs ${slabBytes}, headroom ${imageByteHeadroom(info, o.maxImageBytes)})`;
     bumpPassthrough(info, 'image_budget');
-    info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
+    if (slabOverBytes && !slabOverCount) info.imageByteSkips = (info.imageByteSkips ?? 0) + 1;
+    else info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
     const finalized = await runHistoryCollapseAndFinalize(req, info, o, opts, droppedCodepoints, pins);
     if (finalized.collapsed) {
       info.compressed = true;
@@ -2436,7 +2520,20 @@ export async function transformRequest(
     if (histInfo.freezeStep !== undefined) info.historyFreezeStep = histInfo.freezeStep;
     if (histInfo.budgetTrimmed) info.historyBudgetTrimmed = true;
     if (tuning.packFill) info.historyPackFill = true;
-    if (histInfo.collapsedTurns > 0) {
+    // Atomic admission by weight. The collapse is one semantic group: applying
+    // it means every collapsed message becomes pages, so a group that does not
+    // fit the byte budget is not applied at all and the original text stands.
+    // Rendering it first and discarding it costs CPU, which is the cheap half of
+    // the trade: the alternative is estimating PNG size from character counts and
+    // being wrong on the request that mattered.
+    if (
+      histInfo.collapsedTurns > 0 &&
+      histInfo.collapsedImageBytes > imageByteHeadroom(info, o.maxImageBytes)
+    ) {
+      bumpPassthrough(info, 'image_budget');
+      info.imageByteSkips = (info.imageByteSkips ?? 0) + 1;
+      info.historyReason = 'image_bytes';
+    } else if (histInfo.collapsedTurns > 0) {
       req.messages = newMessages;
       info.collapsedTurns = histInfo.collapsedTurns;
       info.collapsedChars = histInfo.collapsedChars;
@@ -2565,9 +2662,20 @@ export async function transformRequest(
               // o.cols; when they differ the real page count can exceed the plan.
               // Verify against the actual render and drop OUR images rather than
               // ship a request the provider rejects outright.
+              // Atomic admission: this tool_result is one semantic group. It
+              // is imaged whole or kept as text whole, by count and by weight
+              // alike. A half-imaged result would ship pages without the text
+              // they replaced.
+              const groupBytes = imgs.reduce((sum, img) => sum + approxBlockBytes(img), 0);
               if (imgs.length > imageHeadroom(info)) {
                 bumpPassthrough(info, 'image_budget');
                 info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
+                rewritten.push(blk);
+                continue;
+              }
+              if (groupBytes > imageByteHeadroom(info, o.maxImageBytes)) {
+                bumpPassthrough(info, 'image_budget');
+                info.imageByteSkips = (info.imageByteSkips ?? 0) + 1;
                 rewritten.push(blk);
                 continue;
               }
@@ -2665,9 +2773,16 @@ export async function transformRequest(
               // o.cols; when they differ the real page count can exceed the plan.
               // Verify against the actual render and drop OUR images rather than
               // ship a request the provider rejects outright.
+              const partBytes = imgs.reduce((sum, img) => sum + approxBlockBytes(img), 0);
               if (imgs.length > imageHeadroom(info)) {
                 bumpPassthrough(info, 'image_budget');
                 info.imageBudgetSkips = (info.imageBudgetSkips ?? 0) + 1;
+                newInner.push(ib as TextBlock | ImageBlock);
+                continue;
+              }
+              if (partBytes > imageByteHeadroom(info, o.maxImageBytes)) {
+                bumpPassthrough(info, 'image_budget');
+                info.imageByteSkips = (info.imageByteSkips ?? 0) + 1;
                 newInner.push(ib as TextBlock | ImageBlock);
                 continue;
               }
@@ -2753,6 +2868,7 @@ export async function transformRequest(
   info.outgoingTextChars = countOutgoingTextChars(req);
   // Ground truth for the main path too — see the note at the other call site.
   info.wireImages = countNativeImages(req.messages);
+  if (nearByteLimit(info, o.maxImageBytes)) info.imageBytesNearLimit = true;
   const outBody = new TextEncoder().encode(JSON.stringify(req));
   return { body: outBody, info };
 }

--- a/tests/image-byte-budget.test.ts
+++ b/tests/image-byte-budget.test.ts
@@ -1,0 +1,193 @@
+/**
+ * DECODED IMAGE BYTES are a second budget, and the count cap does not stand in
+ * for them.
+ *
+ * The provider's documented limit is 100 images, and pxpipe enforced only that.
+ * A long session can assemble a request that is legal by count and fails by
+ * weight: production traffic degrades sharply somewhere around 20 MiB, and it
+ * degrades as 500s, 502s, empty 200s and stalls, which read as flakiness rather
+ * than as "too big" (#157). `/compact` traverses the same oversized path, so the
+ * session cannot recover by compacting either.
+ *
+ * Two properties matter more than the exact ceiling:
+ *
+ *  - admission is atomic per semantic group. A group is imaged whole or kept as
+ *    text whole, because half a group ships pages without the text they replaced;
+ *  - the caller's own images are counted first and never removed. A user's
+ *    screenshot outranks our compression.
+ *
+ * Run just this file:  pnpm vitest run tests/image-byte-budget.test.ts
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  countNativeImageBytes,
+  imageByteHeadroom,
+  transformRequest,
+} from '../src/core/transform.js';
+import { resetSessionState } from '../src/core/session-state.js';
+import type { Message } from '../src/core/types.js';
+
+const big = (n: number) => 'x'.repeat(n);
+const enc = (obj: unknown) => new TextEncoder().encode(JSON.stringify(obj));
+const dec = (b: Uint8Array): any => JSON.parse(new TextDecoder().decode(b));
+
+/** A caller image whose decoded payload is about `bytes` long. */
+function callerImage(bytes: number) {
+  const b64Chars = Math.ceil(bytes / 3) * 4;
+  return {
+    type: 'image' as const,
+    source: {
+      type: 'base64' as const,
+      media_type: 'image/png' as const,
+      data: 'A'.repeat(b64Chars),
+    },
+  };
+}
+
+function toolResult(id: string, chars = 40_000): Message {
+  return {
+    role: 'user',
+    content: [{ type: 'tool_result', tool_use_id: id, content: `RESULT ${id}\n` + big(chars) }],
+  } as unknown as Message;
+}
+
+function withSlab(messages: Message[], slabChars = 60_000) {
+  return enc({
+    model: 'claude-3-5-sonnet',
+    system: [{ type: 'text', text: 'SLAB\n' + big(slabChars) }],
+    messages,
+  });
+}
+
+/** Total decoded image bytes actually on the wire, at both nesting levels. */
+function wireImageBytes(msgs: any[]): number {
+  let total = 0;
+  const add = (b: any): void => {
+    if (b?.type === 'image' && typeof b.source?.data === 'string') {
+      const d = b.source.data as string;
+      const pad = d.endsWith('==') ? 2 : d.endsWith('=') ? 1 : 0;
+      total += Math.floor((d.length * 3) / 4) - pad;
+    }
+  };
+  for (const m of msgs) {
+    if (!Array.isArray(m.content)) continue;
+    for (const b of m.content) {
+      add(b);
+      if (b?.type === 'tool_result' && Array.isArray(b.content)) for (const ib of b.content) add(ib);
+    }
+  }
+  return total;
+}
+
+describe('counting what the caller already spent', () => {
+  it('sees caller images at both nesting levels', () => {
+    const msgs = [
+      { role: 'user', content: [callerImage(3_000)] },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: [callerImage(6_000)] }],
+      },
+    ] as unknown as Message[];
+    const counted = countNativeImageBytes(msgs);
+    expect(counted).toBeGreaterThan(8_800);
+    expect(counted).toBeLessThan(9_200);
+  });
+
+  it('is safe on absent, empty and string content', () => {
+    expect(countNativeImageBytes(undefined)).toBe(0);
+    expect(countNativeImageBytes([])).toBe(0);
+    expect(countNativeImageBytes([{ role: 'user', content: 'plain' }])).toBe(0);
+  });
+
+  it('deducts caller bytes from the headroom, and never reports a deficit', () => {
+    const info = { imageBytes: 100, nativeImageBytes: 400 } as any;
+    expect(imageByteHeadroom(info, 1_000)).toBe(500);
+    expect(imageByteHeadroom(info, 100)).toBe(0);
+  });
+});
+
+describe('a group that does not fit keeps its text', () => {
+  beforeEach(() => resetSessionState());
+
+  it('skips the slab whole rather than imaging part of it', async () => {
+    const { body: out, info } = await transformRequest(
+      withSlab([{ role: 'user', content: 'go' }]),
+      { maxImageBytes: 1_000 },
+    );
+    // Nothing imaged at all: the slab is part of the cache prefix, so a partial
+    // slab would re-key that prefix whenever the budget arithmetic moved.
+    expect(info.imageCount).toBe(0);
+    expect(info.reason).toMatch(/^image_bytes/);
+    expect(JSON.stringify(dec(out))).toContain('SLAB');
+  });
+
+  it('keeps a tool_result as text when its pages do not fit', async () => {
+    // Measured on this fixture: the slab renders to 12,683 bytes and the
+    // tool_result group to about 6,358 more. A budget between the two admits the
+    // slab and leaves the tool group without room, which is the case worth
+    // pinning: partial admission is what must not happen.
+    const { body: out, info } = await transformRequest(
+      withSlab([{ role: 'user', content: 'go' }, toolResult('t1')]),
+      { maxImageBytes: 15_000 },
+    );
+    expect(info.imageCount ?? 0).toBeGreaterThan(0); // the slab was admitted
+    expect(info.toolResultImgs ?? 0).toBe(0); // the tool group was not
+    expect(info.imageByteSkips ?? 0).toBeGreaterThan(0);
+    // Degrading must never drop content.
+    expect(JSON.stringify(dec(out).messages)).toContain('RESULT t1');
+  });
+
+  it('stays within the budget it was given', async () => {
+    const limit = 15_000;
+    const { body: out } = await transformRequest(
+      withSlab([{ role: 'user', content: 'go' }, toolResult('t1'), toolResult('t2')]),
+      { maxImageBytes: limit },
+    );
+    expect(wireImageBytes(dec(out).messages)).toBeLessThanOrEqual(limit);
+  });
+});
+
+describe('the caller outranks us', () => {
+  beforeEach(() => resetSessionState());
+
+  it('never removes a caller image to make room', async () => {
+    const before = callerImage(30_000);
+    const { body: out, info } = await transformRequest(
+      withSlab([
+        { role: 'user', content: [before] } as unknown as Message,
+        { role: 'user', content: 'go' },
+      ]),
+      { maxImageBytes: 32_000 },
+    );
+    expect(info.nativeImageBytes ?? 0).toBeGreaterThan(29_000);
+    // The caller's image is still on the wire, and we added nothing on top.
+    const wire = dec(out).messages;
+    expect(wireImageBytes(wire)).toBeGreaterThan(29_000);
+    expect(info.imageCount).toBe(0);
+  });
+});
+
+describe('telemetry distinguishes the two ceilings', () => {
+  beforeEach(() => resetSessionState());
+
+  it('reports a byte skip, not a count skip, when weight is what ran out', async () => {
+    const { info } = await transformRequest(
+      withSlab([{ role: 'user', content: 'go' }, toolResult('t1')]),
+      { maxImageBytes: 15_000 },
+    );
+    // Five images is far under the 100-image cap, so nothing here is a count
+    // problem. The two ceilings need different fixes and must not be conflated.
+    expect(info.imageByteSkips ?? 0).toBeGreaterThan(0);
+    expect(info.imageBudgetSkips ?? 0).toBe(0);
+  });
+
+  it('warns before the next turn walks into the wall', async () => {
+    const { info } = await transformRequest(withSlab([{ role: 'user', content: 'go' }]), {
+      // The slab measures 12,683 bytes, so a 14,000-byte budget admits it at
+      // about 91% full: nothing is dropped this turn, and the next one will be.
+      maxImageBytes: 14_000,
+    });
+    expect(info.imageCount ?? 0).toBeGreaterThan(0);
+    expect(info.imageBytesNearLimit).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #195. Related to #157.

Adds `maxImageBytes`, defaulting to 18 MiB, deliberately under the observed cliff rather than at it.

- Admission is atomic per semantic group. The slab, one tool result and the history collapse are each imaged whole or kept as text whole. The history group is admitted after rendering and simply not applied when it does not fit, which spends CPU to avoid estimating PNG size from character counts and being wrong on the request that mattered.
- Caller images are counted first through `countNativeImageBytes` and are never removed to make room.
- `imageByteSkips` is kept separate from `imageBudgetSkips` because fewer pages and smaller pages are different fixes. `imageBytesNearLimit` marks a request that finished inside the top 10% of the budget.

## Verification

Thresholds in the tests are measured, not guessed: the fixture slab renders to 12,683 bytes and its tool_result group to about 6,358 more, so a 15,000-byte budget admits the slab and refuses the group. Nine tests cover caller-byte accounting at both nesting levels, all-or-nothing admission, source text surviving every refusal, the wire staying inside the budget, caller images being untouchable, and the two skip counters not being conflated.

`pnpm run typecheck` clean, `pnpm test` 1033 passing, `pnpm run build` clean.