### PR TITLE
fix(transform): classify total_tokens as a dynamic block

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -841,6 +841,11 @@ const DYNAMIC_BLOCK_TAGS = [
   'git_status',
   'directoryStructure',
   'system-reminder',
+  // A running per-turn counter. Left in the static slab it re-keys the slab image
+  // on every single turn, which is the worst possible cache shape: the prefix is
+  // paid for as a create and never read. It was showing up in
+  // `unknownStaticTags`, which is exactly the canary that list exists to be.
+  'total_tokens',
 ] as const;
 
 // Known-static slab tags — suppresses first-sighting `unknownStaticTags` noise

--- a/tests/dynamic-total-tokens.test.ts
+++ b/tests/dynamic-total-tokens.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `<total_tokens>` is a per-turn counter, so it must not sit in the static slab.
+ *
+ * The slab is the cacheable prefix: it is rendered to a PNG whose bytes have to
+ * repeat across turns for the provider to serve a cache read. A block whose value
+ * changes every turn re-keys that image every turn, which turns the prefix into a
+ * permanent cache create - the most expensive possible shape, and one that looks
+ * like "compression is not saving anything" rather than like a bug.
+ *
+ * The two requests below differ in one number and nothing else. The imaged slab
+ * must be byte-identical between them; only the dynamic tail may move.
+ *
+ * Run just this file:  pnpm vitest run tests/dynamic-total-tokens.test.ts
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { transformRequest } from '../src/core/transform.js';
+import { resetSessionState } from '../src/core/session-state.js';
+
+const big = (n: number) => 'x'.repeat(n);
+const enc = (obj: unknown) => new TextEncoder().encode(JSON.stringify(obj));
+
+/** Claude-Code-shaped system content carrying a running token counter. */
+function systemWithTotalTokens(totalTokens: number): string {
+  return [
+    'You are a helpful assistant.',
+    big(40_000),
+    `<total_tokens>${totalTokens}</total_tokens>`,
+  ].join('\n');
+}
+
+function bodyWithTotalTokens(totalTokens: number) {
+  return enc({
+    model: 'claude-3-5-sonnet',
+    system: [{ type: 'text', text: systemWithTotalTokens(totalTokens) }],
+    messages: [{ role: 'user', content: 'go' }],
+  });
+}
+
+describe('total_tokens is classified as dynamic', () => {
+  beforeEach(() => resetSessionState());
+
+  it('keeps the static slab byte-identical when only the counter moves', async () => {
+    const first = await transformRequest(bodyWithTotalTokens(1_234));
+    resetSessionState();
+    const second = await transformRequest(bodyWithTotalTokens(9_876_543));
+
+    // Precondition: this request really did produce an imaged slab.
+    expect(first.info.imageCount).toBeGreaterThan(0);
+    expect(first.info.systemSha8).toBeDefined();
+
+    // The headline: the cacheable image is unchanged across the two turns.
+    expect(second.info.systemSha8).toBe(first.info.systemSha8);
+  });
+
+  it('does not report the tag as an unknown static block', async () => {
+    const { info } = await transformRequest(bodyWithTotalTokens(4_242));
+    expect(info.unknownStaticTags ?? []).not.toContain('total_tokens');
+  });
+
+  it('routes the counter into the dynamic text, where per-turn churn is free', async () => {
+    const first = await transformRequest(bodyWithTotalTokens(1_234));
+    resetSessionState();
+    const second = await transformRequest(bodyWithTotalTokens(9_876_543));
+
+    // Both turns carry a dynamic section, and it is the part that differs.
+    expect(first.info.dynamicChars ?? 0).toBeGreaterThan(0);
+    expect(second.info.dynamicChars).not.toBe(first.info.dynamicChars);
+  });
+});


### PR DESCRIPTION
Fixes #196.

One list entry. `<total_tokens>` is a running per-turn counter, so leaving it in the static slab re-keys the cached image every turn and makes the prefix a permanent cache create.

Deliberately scoped to this one classification. The Windows and restart work that arrived alongside it upstream is a separate concern with separate risk and deserves its own review.

## Verification

Three tests, all failing before the change: two requests differing only in the counter produce a byte-identical imaged slab, the tag is no longer reported in `unknownStaticTags`, and the counter lands in the dynamic tail where per-turn churn costs nothing.

The second of those also documents that the canary was already firing on current main.

`pnpm run typecheck` clean, `pnpm test` 1027 passing.