### PR TITLE
docs: state the model default the runtime actually applies

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ without running the proxy.
 - **`claude-opus-5`:** weaker recall than Fable 5 (verbatim **2/15 vs 13/15**), good
   enough otherwise (100/100 arithmetic, 0/16 never-stated), **~4.7×** context before
   `/compact`. Suggested effort: **medium**. Details: [FINDINGS.md](FINDINGS.md).
-- **Model scope:** default `PXPIPE_MODELS=claude-fable-5,claude-opus-5,gemini-3.6-flash`. Sol, GPT 5.5,
+- **Model scope:** default `PXPIPE_MODELS=claude-fable-5,gemini-3.6-flash`. Opus 5, Sol, GPT 5.5,
   and **Grok** are opt-in only (dashboard chips or
   `PXPIPE_MODELS`). The exact Sol id still matters. Sibling variants such as
   `gpt-5.6-terra` do not

--- a/src/core/applicability.ts
+++ b/src/core/applicability.ts
@@ -38,7 +38,13 @@ let runtimeModelBases: readonly string[] | null = null;
  *    task pass rate holds but dense recall does not.
  *  All remain available for explicit opt-in.
  *  Silently imaging weak or unvalidated readers is the wrong default. */
-const DEFAULT_MODEL_BASES = ['claude-fable-5', 'gemini-3.6-flash'];
+/** Model bases imaged with no configuration at all.
+ *
+ *  Exported so documentation can be checked against it instead of restating it.
+ *  The README and this list disagreed once already: Opus 5 was dropped here after
+ *  a measured recall regression and stayed in the README's stated default, so a
+ *  reader following the docs believed a model was being imaged that was not. */
+export const DEFAULT_MODEL_BASES = ['claude-fable-5', 'gemini-3.6-flash'];
 
 function falsey(v: string): boolean {
   return /^(0|false|no|off|none)$/i.test(v.trim());

--- a/tests/readme-model-default.test.ts
+++ b/tests/readme-model-default.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The README's stated zero-config model scope must be the one the code applies.
+ *
+ * These two drifted apart once already. Opus 5 was removed from the runtime
+ * default after a measured recall regression, and the README kept listing it, so
+ * a reader who set nothing believed Opus 5 traffic was being imaged when it was
+ * passing through untouched. A wrong default in the docs is not a typo: it
+ * decides which model a user thinks the published fidelity numbers apply to.
+ *
+ * Asserting against the exported list rather than restating it keeps the next
+ * scope change from being a documentation problem.
+ *
+ * Run just this file:  pnpm vitest run tests/readme-model-default.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DEFAULT_MODEL_BASES } from '../src/core/applicability.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
+
+describe('README model scope', () => {
+  it('states exactly one zero-config default', () => {
+    const matches = readme.match(/default `PXPIPE_MODELS=([^`]+)`/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('states the same default the runtime applies', () => {
+    const match = readme.match(/default `PXPIPE_MODELS=([^`]+)`/);
+    expect(match).not.toBeNull();
+    const documented = (match?.[1] ?? '').split(',').map((m) => m.trim()).filter(Boolean);
+    expect(documented).toEqual([...DEFAULT_MODEL_BASES]);
+  });
+
+  it('does not present an opt-in model as part of the default', () => {
+    const match = readme.match(/default `PXPIPE_MODELS=([^`]+)`/);
+    const documented = (match?.[1] ?? '').split(',').map((m) => m.trim());
+    // Opus 5 is a supported profile but an explicit opt-in, and the difference is
+    // the whole point of the recall caveat published next to it.
+    expect(documented).not.toContain('claude-opus-5');
+  });
+});


### PR DESCRIPTION
Fixes #197.

The README advertised `claude-fable-5,claude-opus-5,gemini-3.6-flash` as the zero-config default. The runtime default is `['claude-fable-5', 'gemini-3.6-flash']`.

`DEFAULT_MODEL_BASES` is now exported so the documented default is asserted against the list the code uses instead of being restated by hand. Opus 5 moves to the opt-in sentence next to Sol, GPT 5.5 and Grok, which is what it is.

## Verification

Three tests, two of which fail on the previous README text: exactly one default is stated, it equals the exported list, and no opt-in model is presented as part of it.

`pnpm run typecheck` clean, full suite passing.