### PR TITLE
fix(restart): only stop the proxy serving this checkout's port

### DIFF
--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -2,10 +2,11 @@
 # Restart the local pxpipe proxy.
 #
 # What this does, in order:
-#   1. Discover every running pxpipe proxy via `pgrep -f "node.*bin/cli.js"`
-#      and list them. If multiple are running (orphans from a prior crashed
-#      session), kill all of them — there's no "right" oldest in a graceful
-#      restart, we want a clean slate.
+#   1. Find the pxpipe proxy that is listening on the port this checkout is
+#      about to bind, and only that one. A process-name match alone is not
+#      ownership: it also matches a proxy served from a different clone.
+#      Orphans of THIS port are all cleared, since there is no "right" oldest
+#      in a graceful restart.
 #   2. Send SIGTERM. The proxy's SIGTERM handler flushes the JSONL tracker
 #      and exits. Poll up to 5s for clean exit.
 #   3. Anything still alive after 5s gets SIGKILL with a warning.
@@ -73,7 +74,47 @@ list_serving_pids() {
     esac
   done
 }
-PIDS_RAW=$(list_serving_pids || true)
+
+# --- Ownership is the PORT, not the process name --------------------------
+# `pgrep -f 'node.*bin/cli.js'` matches a pxpipe proxy served from ANY checkout.
+# On a machine with two clones, a restart in one used to SIGTERM the serving
+# proxy of the other: same pattern, different repository, no warning. The port
+# we are about to bind is the thing this checkout actually owns, so a candidate
+# is only ours if it is listening on it.
+port_listener_pids() {
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$TARGET_PORT" -sTCP:LISTEN -t 2>/dev/null
+    return 0
+  fi
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnpH "sport = :$TARGET_PORT" 2>/dev/null \
+      | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u
+    return 0
+  fi
+  return 1
+}
+
+# Intersect "is a pxpipe proxy" with "holds our port". Fails closed: with no way
+# to resolve the listener we decline to signal anything rather than fall back to
+# killing every match, which is the behaviour this replaces.
+list_owned_pids() {
+  local candidates listeners p
+  candidates=$(list_serving_pids || true)
+  [ -n "$candidates" ] || return 0
+  if ! listeners=$(port_listener_pids); then
+    echo "[restart] WARNING: neither lsof nor ss is available, so the proxy on" >&2
+    echo "  :$TARGET_PORT cannot be identified. Refusing to signal by process name" >&2
+    echo "  alone: that would also stop a pxpipe proxy served from another checkout." >&2
+    echo "  Stop it yourself, or install lsof." >&2
+    return 0
+  fi
+  [ -n "$listeners" ] || return 0
+  for p in $candidates; do
+    if echo "$listeners" | grep -qx "$p"; then echo "$p"; fi
+  done
+}
+
+PIDS_RAW=$(list_owned_pids || true)
 if [ -n "$PIDS_RAW" ]; then
   # Convert to space-separated list, sorted numerically for stable output.
   PIDS=$(echo "$PIDS_RAW" | tr '\n' ' ' | xargs -n1 | sort -n | tr '\n' ' ')
@@ -89,13 +130,13 @@ if [ -n "$PIDS_RAW" ]; then
 
   # Poll up to 5s for graceful exit.
   for _ in $(seq 1 50); do
-    STILL=$(list_serving_pids || true)
+    STILL=$(list_owned_pids || true)
     [ -z "$STILL" ] && break
     sleep 0.1
   done
 
   # --- 3. Escalate to SIGKILL only if still alive ---
-  STILL=$(list_serving_pids || true)
+  STILL=$(list_owned_pids || true)
   if [ -n "$STILL" ]; then
     echo "[restart] WARNING: PID(s) still alive after 5s, escalating to SIGKILL: $STILL"
     for pid in $STILL; do
@@ -104,7 +145,7 @@ if [ -n "$PIDS_RAW" ]; then
     sleep 0.3
   fi
 else
-  echo "[restart] no running proxy found"
+  echo "[restart] no pxpipe proxy of this checkout is serving :$TARGET_PORT"
 fi
 
 # --- 4. Rebuild (skippable) ----------------------------------------------

--- a/tests/restart.test.sh
+++ b/tests/restart.test.sh
@@ -179,10 +179,40 @@ test_rejects_unknown_args() {
   return 0
 }
 
+# ---- Test 8: a proxy from ANOTHER checkout is left alone ---------------
+# `pgrep -f 'node.*bin/cli.js'` matches a pxpipe proxy served from any clone on
+# the machine. Restarting here must not stop one that is not serving our port:
+# that was a live cross-checkout kill, with no warning and no way to tell it had
+# happened. Ownership is the port, so a candidate that holds no port is not ours.
+test_foreign_checkout_is_untouched() {
+  local sandbox="$1" logf="$2"
+  echo "4242" > "$sandbox/pids"      # a pxpipe proxy exists ...
+  : > "$sandbox/lsof_pid"            # ... but nothing is listening on our port
+  local out="$sandbox/out.txt"
+  ( cd "$REPO" && "$SCRIPT" --no-build >"$out" 2>&1 || true )
+  grep -q "no pxpipe proxy of this checkout" "$out" || return 1
+  grep -q "found running pxpipe proxy" "$out" && return 1
+  return 0
+}
+
+# ---- Test 9: the proxy holding OUR port is still found -----------------
+# The narrowing must not turn into "never restart anything".
+test_owned_proxy_is_found() {
+  local sandbox="$1" logf="$2"
+  echo "4242" > "$sandbox/pids"
+  echo "4242" > "$sandbox/lsof_pid"  # same PID is listening on our port
+  local out="$sandbox/out.txt"
+  ( cd "$REPO" && "$SCRIPT" --no-build >"$out" 2>&1 || true )
+  grep -q "found running pxpipe proxy PID(s): 4242" "$out" || return 1
+  return 0
+}
+
 run_test "no proxy running"        test_no_running
 run_test "build failure aborts"    test_build_failure
 run_test "port-in-use aborts"      test_port_in_use
 run_test "rejects unknown args"    test_rejects_unknown_args
+run_test "foreign checkout untouched" test_foreign_checkout_is_untouched
+run_test "owned proxy is found"    test_owned_proxy_is_found
 
 echo ""
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
Fixes #204.

Candidates from the process-name match are now intersected with the PIDs actually listening on `TARGET_PORT`, resolved through lsof or ss. With neither available the script declines to signal anything and explains why, rather than falling back to the pattern match.

The warp exclusion is unchanged, and orphans of our own port are all still cleared.

## Verification

`pnpm run test:restart` 6/6, including two new cases:

- a pxpipe process that holds no port is left alone. This fails on the previous script, which is the cross-checkout kill.
- a pxpipe process that holds our port is still found. This passes on both, and is there so the narrowing cannot quietly become "never restart anything".

The existing harness cannot assert on signals, because `kill` is a bash builtin and never reaches the PATH shim, so both tests assert on the script's own discovery output instead.

No TypeScript changed, so the vitest suite is unaffected.

Note for #152: this is the same hazard that proposal would widen, which is why the process matcher there should not be adopted as-is.