### PR TITLE
perf(render): key the render cache on a digest instead of the source text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to pxpipe are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) (pre-1.0: minor = features /
 behavioral changes, patch = fixes).
 
+## Unreleased
+
+### Added
+- **Rendered-page cache, now documented.** It landed in #158 and shipped in
+  0.13.0 with no changelog entry, so this backfills it: identical render inputs
+  return the identical pages instead of being re-rasterized, bounded by total
+  retained bytes via `PXPIPE_RENDER_CACHE_BYTES`. Frozen history chunks are
+  byte-identical across turns by design, so a long session was paying full
+  render cost for pages that provably did not change.
+- Live `render_cache` counters on `/proxy-stats`: `entries`, `bytes`,
+  `max_bytes`, `hits`, `misses`, `evictions`, `oversized`. `renderCacheStats()`
+  previously had no consumer outside the test suite. `oversized` counts renders
+  larger than the entire budget, which are never stored — the failure mode a
+  too-small budget produces, and one that otherwise looks identical to a
+  permanently cold cache (#210).
+- `PXPIPE_RENDER_CACHE_BYTES` is now readable on Workers. Bindings are not
+  visible to core at module-init time, so the Worker entrypoint applies the
+  budget per request through the new `setRenderCacheMaxBytes()`.
+
+### Changed
+- **Render cache keys are a domain-separated SHA-256 over length-prefixed
+  inputs instead of the source text verbatim** (#210). The literal key held
+  every rendered prompt in the heap as plaintext for the process lifetime, and
+  sized each entry at roughly twice its source length — so a budget meant to
+  bound retained *pages* spent most of itself on copies of the input. Entry
+  overhead is now a constant 128 bytes. The pages themselves are still rendered
+  images of the source: this removes plaintext retention, not content
+  retention.
+- **The default budget is 8 MiB on Workers, 64 MiB on Node.** Both runtimes
+  previously took 64 MiB, which on a ~128 MiB isolate that also holds the
+  request body, the decoded atlases and the framebuffers is most of the
+  ceiling.
+
+### Fixed
+- The render cache byte counter no longer drifts upward when two concurrent
+  requests render the same content. Both miss (the lookup precedes the await),
+  both store, and the second store previously added its bytes without crediting
+  back the entry it replaced — so the counter climbed until it evicted a cache
+  that was nowhere near its budget.
+
 ## 0.13.0 — 2026-08-09
 
 ### Added

--- a/docs/CACHING_AND_SAVINGS.md
+++ b/docs/CACHING_AND_SAVINGS.md
@@ -210,6 +210,50 @@ The live dashboard and replay path both use `deriveBaselineWarmth`, `computeBase
 
 ---
 
+## The Local Rendered-Page Cache
+
+Distinct from everything above. The provider prompt cache saves *tokens*; this
+one saves *local CPU*, and it exists only because the two are related: history
+chunks are frozen so they stay byte-identical for the provider cache, which
+means the proxy re-renders the same PNGs every turn for pages that provably did
+not change.
+
+Rendering is a pure function of `(text, cols, maxCharsPerImage, style,
+maxHeightPx, slotText)` — the glyph atlases are decoded at module init and
+never mutated — so identical inputs can return identical pages. The cache lives
+in `src/core/render.ts` and wraps `renderTextToPngsWithCharLimit`.
+
+**Budget.** `PXPIPE_RENDER_CACHE_BYTES` bounds total retained bytes. Defaults
+differ by runtime: **64 MiB on Node**, **8 MiB on Workers**, where the isolate
+has ~128 MiB for the request body, the atlases, the framebuffers and the
+compressor as well. `0` disables it. Eviction is LRU. Worker bindings are not
+visible at module-init time, so `src/worker.ts` applies the budget per request
+via `setRenderCacheMaxBytes()`.
+
+**Keys.** A domain-separated SHA-256 over a length-prefixed encoding of every
+input. Length prefixes matter: without them `("a b", "c")` and `("a", "b c")`
+would share a key. The key is deliberately *not* the source text — a literal
+key retains every rendered prompt as a plaintext string and makes each entry
+cost roughly twice its source length, which spends the budget on copies of the
+input rather than on the pages it exists to retain.
+
+**What it still retains.** The cached pages are rendered images of the source.
+Keying on a digest removes plaintext retention; it does not make the cache
+content-free. Anyone who can read the process memory can read the context,
+which is the same assumption `docs/SECURITY_MODEL.md` already makes about the
+log directory.
+
+**Counters** (`/proxy-stats` → `render_cache`):
+
+| field | reading |
+| --- | --- |
+| `entries`, `bytes`, `max_bytes` | utilisation; `bytes` near `max_bytes` with a poor hit rate means the working set outgrew the budget |
+| `hits`, `misses` | process-cumulative, not per-request |
+| `evictions` | entries displaced to stay in budget |
+| `oversized` | renders larger than the *whole* budget, never stored at all — a permanently 0% hit rate with this climbing means the budget is too small, not that the input is unstable |
+
+---
+
 ## Summary
 
 pxpipe stays cache-aligned by replacing stable text context with stable image context and relocating the caller's existing cache marker to the end of the rewritten content. Savings are measured by comparing the real transformed request with a `/count_tokens` text counterfactual under the same observed cache state. If the actual request read cache, both sides are warm. If it did not, both sides are cold. Therefore the provider cache discount is not counted as pxpipe savings; the reported savings are only the token reduction from text to images.

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -1094,19 +1094,40 @@ export async function renderTextToPngsReflow(
  * ~134 images cost ~10s of single-threaded CPU per request while the payload hash held
  * constant across consecutive turns.
  *
- * Bounded by total retained bytes (PNG payloads + the key strings, which embed the
- * source text and would otherwise be the larger half). Eviction is LRU via Map's
- * insertion order: re-inserting on hit moves an entry to the newest position.
+ * Bounded by total retained bytes. Eviction is LRU via Map's insertion order:
+ * re-inserting on hit moves an entry to the newest position.
  */
-const RENDER_CACHE_MAX_BYTES = (() => {
+
+/** 64 MiB holds several turns of a heavy session on a host with real RAM. */
+const RENDER_CACHE_DEFAULT_BYTES_NODE = 64 * 1024 * 1024;
+/** A Workers isolate gets ~128 MiB for everything — the request body, the decoded
+ *  atlases, the framebuffers, and whatever the compressor is holding. Half of that
+ *  spent on retained pages is how an isolate gets killed mid-request, so the edge
+ *  default is an order of magnitude lower and operators opt back up. */
+const RENDER_CACHE_DEFAULT_BYTES_WORKERS = 8 * 1024 * 1024;
+
+/** `typeof process` cannot answer this: `nodejs_compat_v2` defines `process` on
+ *  Workers too. `navigator.userAgent` is the documented probe.
+ *
+ *  Read off `globalThis` through a local shape rather than the ambient `navigator`
+ *  global: this project compiles `@cloudflare/workers-types` and `@types/node`
+ *  together, and `navigator` is absent from Node before 21 while `engines` allows
+ *  20.19. Optional chaining answers "not Workers" for every one of those cases. */
+function isWorkersRuntime(): boolean {
+  const nav = (globalThis as { navigator?: { userAgent?: string } }).navigator;
+  return nav?.userAgent === 'Cloudflare-Workers';
+}
+
+/** Mutable rather than a const: Worker configuration arrives as per-request bindings,
+ *  not as `process.env` at module init, so `src/worker.ts` has to be able to set this
+ *  after the module has already loaded. Node still resolves it once, below. */
+let renderCacheMaxBytesValue = (() => {
   // Edge-safe: `process` is undefined off-Node.
   const raw = typeof process !== 'undefined' ? process.env?.PXPIPE_RENDER_CACHE_BYTES : undefined;
   const parsed = raw !== undefined && raw.trim() !== '' ? Number(raw) : NaN;
   // 0 disables the cache outright; negative/garbage falls back to the default.
   if (Number.isFinite(parsed) && parsed >= 0) return Math.floor(parsed);
-  // 64 MiB holds several turns of a heavy session while staying well inside a
-  // Workers isolate's memory ceiling.
-  return 64 * 1024 * 1024;
+  return isWorkersRuntime() ? RENDER_CACHE_DEFAULT_BYTES_WORKERS : RENDER_CACHE_DEFAULT_BYTES_NODE;
 })();
 
 interface RenderCacheEntry {
@@ -1118,15 +1139,75 @@ const renderCache = new Map<string, RenderCacheEntry>();
 let renderCacheBytes = 0;
 let renderCacheHits = 0;
 let renderCacheMisses = 0;
+let renderCacheEvictions = 0;
+let renderCacheOversized = 0;
 
-/** Observability for the dashboard/tests. Bytes counts retained PNG + key bytes. */
+/** Observability for the dashboard/tests. `bytes` counts retained PNG payloads plus
+ *  the fixed-width keys.
+ *
+ *  `evictions` and `oversized` answer different questions and a single "the cache is
+ *  not helping" number would conflate them: evictions mean the working set outgrew the
+ *  budget (raise it, or accept the churn), while `oversized` means a single render was
+ *  bigger than the entire budget and was therefore never stored at all — the failure a
+ *  too-small edge budget produces, where hit rate stays at zero no matter how stable
+ *  the input is. */
 export function renderCacheStats(): {
   entries: number;
   bytes: number;
   hits: number;
   misses: number;
+  evictions: number;
+  oversized: number;
 } {
-  return { entries: renderCache.size, bytes: renderCacheBytes, hits: renderCacheHits, misses: renderCacheMisses };
+  return {
+    entries: renderCache.size,
+    bytes: renderCacheBytes,
+    hits: renderCacheHits,
+    misses: renderCacheMisses,
+    evictions: renderCacheEvictions,
+    oversized: renderCacheOversized,
+  };
+}
+
+/** Current byte budget. Exposed so the dashboard can report utilisation rather than a
+ *  bare byte count the operator has no denominator for. */
+export function renderCacheMaxBytes(): number {
+  return renderCacheMaxBytesValue;
+}
+
+/**
+ * Set the byte budget at runtime and evict down to it immediately.
+ *
+ * Exists for the Worker entrypoint, which cannot use the module-init `process.env`
+ * read: bindings are handed to `fetch(req, env, ctx)`, long after this module
+ * evaluated. Node keeps using the env read.
+ *
+ * `0` disables the cache and drops everything already held. Negative or non-finite
+ * input is ignored rather than obeyed — a broken value must not read as "unbounded".
+ */
+export function setRenderCacheMaxBytes(maxBytes: number): void {
+  if (!Number.isFinite(maxBytes) || maxBytes < 0) return;
+  renderCacheMaxBytesValue = Math.floor(maxBytes);
+  if (renderCacheMaxBytesValue === 0) {
+    // Not clearRenderCache(): shrinking the budget is not a reason to throw away the
+    // hit/miss history an operator is reading.
+    renderCache.clear();
+    renderCacheBytes = 0;
+    return;
+  }
+  evictToBudget();
+}
+
+/** Evict oldest-first until back within budget, optionally pinning one key that must
+ *  survive. Map iteration is insertion order, which the hit path keeps LRU-ordered. */
+function evictToBudget(pinnedKey?: string): void {
+  for (const [k, v] of renderCache) {
+    if (renderCacheBytes <= renderCacheMaxBytesValue) break;
+    if (k === pinnedKey) continue;
+    renderCache.delete(k);
+    renderCacheBytes -= v.bytes;
+    renderCacheEvictions++;
+  }
 }
 
 /** Drop every entry. Tests use this to isolate hit/miss accounting. */
@@ -1135,6 +1216,8 @@ export function clearRenderCache(): void {
   renderCacheBytes = 0;
   renderCacheHits = 0;
   renderCacheMisses = 0;
+  renderCacheEvictions = 0;
+  renderCacheOversized = 0;
 }
 
 /** Stable serialization of RenderStyle. Every field is a primitive (see the interface),
@@ -1157,6 +1240,58 @@ function cloneForCaller(images: readonly RenderedImage[]): RenderedImage[] {
   return images.map((img) => ({ ...img, droppedCodepoints: new Map(img.droppedCodepoints) }));
 }
 
+/** Domain separator. Keeps these digests from ever being equal to a digest this
+ *  codebase computes over the same bytes for another purpose (`sha8` over the slab,
+ *  `sha256Text` in proxy.ts), and gives the encoding a version to bump if the input
+ *  tuple ever grows a field. */
+const RENDER_CACHE_KEY_DOMAIN = 'pxpipe/render-cache/v1\n';
+
+const renderCacheKeyEncoder = new TextEncoder();
+
+/**
+ * Cache key: a SHA-256 over a canonical encoding of everything the renderer reads.
+ *
+ * #158 keyed on the source text verbatim, arguing that a digest collision would serve
+ * the WRONG image and that a literal key is collision-free by construction. The
+ * literal key is also a guarantee of the opposite kind: every prompt rendered this
+ * process stays in the heap as a plaintext string until evicted, and — the part that
+ * bites operationally — entry size scales with source length, so a budget meant to
+ * bound retained *pages* spends most of itself on copies of the input (#210).
+ *
+ * A full 256-bit digest, not the 32-bit `sha8` used for telemetry elsewhere. At the
+ * entry counts a byte budget permits, collision odds sit far below the failure modes
+ * the pipeline already lives with, and #210 states the trade explicitly: a
+ * cryptographic collision is the smaller risk against guaranteed prompt retention.
+ *
+ * Every free-form field is length-prefixed, so no regrouping of the same characters
+ * can produce one encoding — ("a b", "c") and ("a", "b c") stay distinct, which is the
+ * ambiguity #158's `slotLen` prefix guarded against. `-1` marks an absent `slotText`
+ * and must stay distinct from empty, because renderTextToPngsUncached branches on
+ * `slotText !== undefined` rather than on its length.
+ */
+async function renderCacheKey(
+  text: string,
+  cols: number,
+  maxCharsPerImage: number,
+  maxHeightPx: number,
+  style: RenderStyle,
+  slotText: string | undefined,
+): Promise<string> {
+  const styleKey = styleCacheKey(style);
+  const slotLen = slotText === undefined ? -1 : slotText.length;
+  const canonical =
+    RENDER_CACHE_KEY_DOMAIN +
+    `${cols}|${maxCharsPerImage}|${maxHeightPx}|` +
+    `${styleKey.length}|${styleKey}|` +
+    `${slotLen}|${slotText ?? ''}|` +
+    `${text.length}|${text}`;
+  const digest = await crypto.subtle.digest('SHA-256', renderCacheKeyEncoder.encode(canonical));
+  const bytes = new Uint8Array(digest);
+  let hex = '';
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0');
+  return hex;
+}
+
 export async function renderTextToPngsWithCharLimit(
   text: string,
   cols: number = DEFAULT_COLS,
@@ -1165,22 +1300,10 @@ export async function renderTextToPngsWithCharLimit(
   maxHeightPx: number = MAX_HEIGHT_PX,
   slotText?: string,
 ): Promise<RenderedImage[]> {
-  if (RENDER_CACHE_MAX_BYTES === 0) {
+  if (renderCacheMaxBytesValue === 0) {
     return renderTextToPngsUncached(text, cols, maxCharsPerImage, style, maxHeightPx, slotText);
   }
-  // The key embeds the source text verbatim rather than a digest, so it is
-  // collision-free by construction — a digest collision here would serve the WRONG
-  // image, a silent correctness bug far worse than a cache miss.
-  //
-  // `slotText` is length-prefixed because it and `text` are both free-form: plain
-  // concatenation would give ("a b", "c") and ("a", "b c") one key. -1 marks absent,
-  // which must stay distinct from empty — renderTextToPngsUncached branches on
-  // `slotText !== undefined`. The numeric and style segments contain no `|` (style
-  // values are booleans, numbers, and dashed string unions), so the fixed-arity
-  // prefix can never be confused with content.
-  const slotLen = slotText === undefined ? -1 : slotText.length;
-  const key =
-    `${cols}|${maxCharsPerImage}|${maxHeightPx}|${styleCacheKey(style)}|${slotLen}|${slotText ?? ''}${text}`;
+  const key = await renderCacheKey(text, cols, maxCharsPerImage, maxHeightPx, style, slotText);
   const hit = renderCache.get(key);
   if (hit !== undefined) {
     renderCacheHits++;
@@ -1192,21 +1315,26 @@ export async function renderTextToPngsWithCharLimit(
 
   const images = await renderTextToPngsUncached(text, cols, maxCharsPerImage, style, maxHeightPx, slotText);
 
-  // Key strings are UTF-16 in memory; 2 bytes/unit is the honest estimate.
+  // Key strings are UTF-16 in memory; 2 bytes/unit is the honest estimate. The digest
+  // is fixed-width, so this term is now a constant per entry rather than a second copy
+  // of the input — the budget bounds retained pages, which is what it claims to bound.
   let bytes = key.length * 2;
   for (const img of images) bytes += img.png.byteLength;
   // A single render larger than the whole budget is not cacheable — storing it would
   // evict everything and then itself. Serve it and move on.
-  if (bytes <= RENDER_CACHE_MAX_BYTES) {
+  if (bytes <= renderCacheMaxBytesValue) {
+    // Two concurrent requests can render the same slab: both miss (the lookup
+    // happens before the await), both render, both land here. Without crediting
+    // back the entry being replaced, the second store adds its bytes while the
+    // Map still holds one entry, and the counter drifts upward permanently —
+    // eventually evicting a cache that is nowhere near its budget.
+    const replaced = renderCache.get(key);
+    if (replaced !== undefined) renderCacheBytes -= replaced.bytes;
     renderCache.set(key, { images, bytes });
     renderCacheBytes += bytes;
-    // Evict oldest-first until back within budget. Map iteration is insertion order.
-    for (const [k, v] of renderCache) {
-      if (renderCacheBytes <= RENDER_CACHE_MAX_BYTES) break;
-      if (k === key) continue; // never evict the entry just stored
-      renderCache.delete(k);
-      renderCacheBytes -= v.bytes;
-    }
+    evictToBudget(key); // never evict the entry just stored
+  } else {
+    renderCacheOversized++;
   }
   return cloneForCaller(images);
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -44,6 +44,7 @@ import {
   computeOpenAIBaselineRawTokens,
   openAIOutputRate,
 } from './core/openai-savings.js';
+import { renderCacheMaxBytes, renderCacheStats } from './core/render.js';
 import {
   aggregateSessions,
   claudeCodeMap,
@@ -1442,6 +1443,16 @@ export class DashboardState {
       events_with_measurement: totals.eventsWithMeasurement,
       uptime_sec: uptimeSec,
       compression_enabled: this.compressionEnabled,
+      // Rendered-page cache — a live process gauge, not a fold over the event
+      // ring, so it is the one number here that survives no traffic at all.
+      // `max_bytes` ships alongside `bytes` because utilisation is the actionable
+      // reading: a hit rate near zero means something different when the budget is
+      // full (working set too big) than when `oversized` is climbing (a single
+      // render exceeds the whole budget and is never stored).
+      render_cache: {
+        ...renderCacheStats(),
+        max_bytes: renderCacheMaxBytes(),
+      },
     };
     return new Response(JSON.stringify(payload, null, 2), {
       headers: { 'content-type': 'application/json' },

--- a/src/node.ts
+++ b/src/node.ts
@@ -276,9 +276,11 @@ Environment:
   PXPIPE_DUMP_DIR         debug: write every rendered PNG here (what the model
                           sees); off unless set. Compress arm only.
   PXPIPE_RENDER_CACHE_BYTES  max bytes of rendered pages to keep in memory
-                          (default 64 MiB). Frozen history chunks are
-                          byte-identical across turns, so re-rendering them is
-                          wasted CPU; 0 disables the cache.
+                          (default 64 MiB here; 8 MiB on Workers, where the
+                          isolate has ~128 MiB for everything). Frozen history
+                          chunks are byte-identical across turns, so
+                          re-rendering them is wasted CPU; 0 disables the cache.
+                          Live counters at /proxy-stats under render_cache.
   PXPIPE_DEBUG_CAPTURE_4XX  debug: set to 1 to persist full 4xx request and
                           upstream error bodies (prompts + any secrets in
                           context) to disk. Off by default.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,6 +15,7 @@ import { createProxy, type ProxyConfig } from './core/proxy.js';
 import type { TransformOptions } from './core/transform.js';
 import { toTrackEvent, JsonLogTracker, noopTracker, type Tracker } from './core/tracker.js';
 import { setAllowedModelBases } from './core/applicability.js';
+import { setRenderCacheMaxBytes } from './core/render.js';
 
 export interface Env {
   /** Optional single upstream base for every API family. Family-specific env vars override it. */
@@ -46,6 +47,14 @@ export interface Env {
    *  Cloudflare ingests console.log as Workers Logs; pipe via Logpush to
    *  R2/S3 for the same JSONL shape Node writes to disk. */
   PXPIPE_TRACK?: string;
+  /** Max bytes of rendered pages held in memory, or "0" to disable the cache.
+   *  Unset uses the core edge default (8 MiB), which is deliberately far below
+   *  the Node default: a Worker isolate has ~128 MiB for the request body, the
+   *  decoded atlases, the framebuffers and the compressor as well. Bindings are
+   *  not visible to core at module-init time, so this is applied per request via
+   *  `setRenderCacheMaxBytes`. A negative or non-numeric value is ignored rather
+   *  than obeyed; `0` is a real setting and must not be read as "unset". */
+  PXPIPE_RENDER_CACHE_BYTES?: string;
   /** Shared secret callers must present via the `x-pxpipe-secret` header
    *  whenever an API-key override is configured. Without this gate a
    *  discovered workers.dev URL is an open key-spender: the Worker would
@@ -81,6 +90,15 @@ const positiveInt = (v: string | undefined): number | undefined => {
   return Number.isSafeInteger(n) && n > 0 ? n : undefined;
 };
 
+/** Same shape as `positiveInt` but admits 0, because for the render cache budget 0 is
+ *  a real instruction ("disable") rather than a broken value to fall back from. */
+const nonNegativeInt = (v: string | undefined): number | undefined => {
+  const raw = v?.trim();
+  if (raw === undefined || raw === '') return undefined;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) && n >= 0 ? n : undefined;
+};
+
 export default {
   async fetch(req: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const configuredModels = env.PXPIPE_MODELS?.trim();
@@ -91,6 +109,11 @@ export default {
           ? []
           : configuredModels.split(',').map((model) => model.trim()).filter(Boolean),
     );
+    // Bindings only exist inside `fetch`, so the render cache budget is applied here
+    // rather than at module init the way the Node host does it. Cheap and idempotent:
+    // assigning the same value evicts nothing. Left unset, core keeps its edge default.
+    const renderCacheBytes = nonNegativeInt(env.PXPIPE_RENDER_CACHE_BYTES);
+    if (renderCacheBytes !== undefined) setRenderCacheMaxBytes(renderCacheBytes);
     // ── Caller auth ────────────────────────────────────────────────────
     // If this deployment injects API keys, never serve anonymous callers:
     // workers.dev URLs are discoverable, and without this gate anyone who

--- a/tests/render-cache.test.ts
+++ b/tests/render-cache.test.ts
@@ -91,7 +91,43 @@ describe('rendered-page cache', () => {
     expect(stats.bytes).toBeGreaterThan(0);
 
     clearRenderCache();
-    expect(renderCacheStats()).toEqual({ entries: 0, bytes: 0, hits: 0, misses: 0 });
+    expect(renderCacheStats()).toEqual({
+      entries: 0,
+      bytes: 0,
+      hits: 0,
+      misses: 0,
+      evictions: 0,
+      oversized: 0,
+    });
+  });
+
+  // The point of keying on a digest instead of the source text (#210): an entry's
+  // retained cost is the pages, plus a constant. With a verbatim key the overhead
+  // term was `2 × source length`, so a budget meant to bound rendered pages spent
+  // most of itself on copies of the prompt — and kept those copies as plaintext.
+  it('retains a fixed-size key regardless of how long the source text is', async () => {
+    const short = 'x '.repeat(50);
+    const long = 'x '.repeat(50_000);
+
+    const sumPng = (imgs: { png: Uint8Array }[]) =>
+      imgs.reduce((n, img) => n + img.png.byteLength, 0);
+
+    clearRenderCache();
+    const shortImgs = await renderTextToPngsWithCharLimit(short, 64);
+    expect(renderCacheStats().entries).toBe(1); // premise: it was actually stored
+    const shortOverhead = renderCacheStats().bytes - sumPng(shortImgs);
+
+    clearRenderCache();
+    const longImgs = await renderTextToPngsWithCharLimit(long, 64);
+    expect(renderCacheStats().entries).toBe(1);
+    const longOverhead = renderCacheStats().bytes - sumPng(longImgs);
+
+    // Same constant both times, and small — a 64-char hex digest at 2 bytes/unit.
+    expect(longOverhead).toBe(shortOverhead);
+    expect(shortOverhead).toBe(128);
+    // Guard the premise: the two inputs really do differ by ~1000× in length, so a
+    // key that embedded the text could not possibly have produced equal overhead.
+    expect(long.length).toBeGreaterThan(short.length * 500);
   });
 });
 
@@ -132,6 +168,7 @@ describe('rendered-page cache budget', () => {
     const stats = mod.renderCacheStats();
     expect(stats.bytes).toBeLessThanOrEqual(Math.floor(oneEntry * 2.5));
     expect(stats.entries).toBe(2); // A was evicted to make room for C
+    expect(stats.evictions).toBe(1); // and the operator can see that it happened
 
     // The survivors still hit; the evicted entry must miss and be re-rendered.
     const before = mod.renderCacheStats();
@@ -164,13 +201,23 @@ describe('rendered-page cache budget', () => {
     expect(m3.renderCacheStats()).toMatchObject({ entries: 2, hits: 1, bytes: bytesA + bytesB });
   });
 
-  it('never stores an entry larger than the whole budget', async () => {
-    const mod = await freshRender('2000'); // smaller than a single page
+  it('never stores an entry larger than the whole budget, and counts it', async () => {
+    // Below the 128-byte key alone, so no render can ever fit regardless of how
+    // well its pixels happen to compress. The old 2000-byte budget only worked
+    // because the verbatim key was itself ~8 KB for this input; with a
+    // fixed-width key, a page of repeating 'x ' deflates small enough to slip
+    // under 2000 and the case would stop testing the branch it names.
+    const mod = await freshRender('100');
     await mod.renderTextToPngsWithCharLimit('x '.repeat(2000), 64);
 
     const stats = mod.renderCacheStats();
     expect(stats.entries).toBe(0);
     expect(stats.bytes).toBe(0);
+    // Distinct from an eviction: nothing was displaced, the render simply never
+    // fit. Without this counter a too-small budget looks identical to a cold
+    // cache — permanent 0% hit rate with no signal saying why.
+    expect(stats.oversized).toBe(1);
+    expect(stats.evictions).toBe(0);
   });
 
   it('PXPIPE_RENDER_CACHE_BYTES=0 disables caching entirely', async () => {
@@ -178,6 +225,106 @@ describe('rendered-page cache budget', () => {
     await mod.renderTextToPngsWithCharLimit('hello world', 64);
     await mod.renderTextToPngsWithCharLimit('hello world', 64);
 
-    expect(mod.renderCacheStats()).toEqual({ entries: 0, bytes: 0, hits: 0, misses: 0 });
+    expect(mod.renderCacheStats()).toEqual({
+      entries: 0,
+      bytes: 0,
+      hits: 0,
+      misses: 0,
+      evictions: 0,
+      oversized: 0,
+    });
+  });
+});
+
+// A Worker never sees PXPIPE_RENDER_CACHE_BYTES through process.env — bindings arrive
+// per request, long after this module evaluated — so the budget has to be settable
+// after load. src/worker.ts calls this on every request.
+describe('setRenderCacheMaxBytes', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('does not double-count bytes when the same key is stored twice', async () => {
+    // Two concurrent requests rendering the same slab both miss (the lookup runs
+    // before the await), both render, and both store. One entry must cost one
+    // entry's bytes, or the counter drifts up and starts evicting a cache that is
+    // nowhere near full.
+    const mod = await freshRender(String(64 * 1024 * 1024));
+    const text = 'gamma gamma gamma\n'.repeat(40);
+
+    await mod.renderTextToPngsWithCharLimit(text, 64);
+    const single = mod.renderCacheStats().bytes;
+
+    mod.clearRenderCache();
+    await Promise.all([
+      mod.renderTextToPngsWithCharLimit(text, 64),
+      mod.renderTextToPngsWithCharLimit(text, 64),
+    ]);
+
+    const stats = mod.renderCacheStats();
+    expect(stats.entries).toBe(1);
+    expect(stats.bytes).toBe(single);
+    expect(stats.misses).toBe(2); // both really did miss — the race is the premise
+  });
+
+  it('shrinks the budget and evicts down to it immediately', async () => {
+    const A = 'alpha alpha alpha\n'.repeat(40);
+    const B = 'beta beta beta\n'.repeat(40);
+
+    const mod = await freshRender(String(64 * 1024 * 1024));
+    await mod.renderTextToPngsWithCharLimit(A, 64);
+    await mod.renderTextToPngsWithCharLimit(B, 64);
+    expect(mod.renderCacheStats().entries).toBe(2);
+
+    // One byte under what both entries occupy, derived from the real total rather
+    // than a guessed multiple of one entry's size: exactly one eviction is needed,
+    // and the older entry (A) is the one that must go.
+    const shrunk = mod.renderCacheStats().bytes - 1;
+    mod.setRenderCacheMaxBytes(shrunk);
+
+    const stats = mod.renderCacheStats();
+    expect(stats.entries).toBe(1);
+    expect(stats.bytes).toBeLessThanOrEqual(shrunk);
+    expect(stats.evictions).toBe(1);
+    expect(mod.renderCacheMaxBytes()).toBe(shrunk);
+
+    // B survived, A did not.
+    const before = mod.renderCacheStats();
+    await mod.renderTextToPngsWithCharLimit(B, 64);
+    expect(mod.renderCacheStats().hits).toBe(before.hits + 1);
+  });
+
+  it('treats 0 as disable-and-drop while keeping the counter history', async () => {
+    const mod = await freshRender(String(64 * 1024 * 1024));
+    await mod.renderTextToPngsWithCharLimit('hello world', 64);
+    await mod.renderTextToPngsWithCharLimit('hello world', 64);
+    expect(mod.renderCacheStats()).toMatchObject({ entries: 1, hits: 1, misses: 1 });
+
+    mod.setRenderCacheMaxBytes(0);
+    expect(mod.renderCacheStats()).toMatchObject({ entries: 0, bytes: 0 });
+    // Shrinking the budget is a configuration change, not a reason to erase the
+    // hit/miss history an operator is reading off the dashboard.
+    expect(mod.renderCacheStats()).toMatchObject({ hits: 1, misses: 1 });
+
+    // Disabled: renders still work, nothing is retained, nothing is counted.
+    await mod.renderTextToPngsWithCharLimit('hello world', 64);
+    await mod.renderTextToPngsWithCharLimit('hello world', 64);
+    expect(mod.renderCacheStats()).toMatchObject({ entries: 0, hits: 1, misses: 1 });
+  });
+
+  it('ignores a negative or non-finite budget rather than obeying it', async () => {
+    const mod = await freshRender(String(64 * 1024 * 1024));
+    const original = mod.renderCacheMaxBytes();
+
+    mod.setRenderCacheMaxBytes(-1);
+    expect(mod.renderCacheMaxBytes()).toBe(original);
+    mod.setRenderCacheMaxBytes(Number.NaN);
+    expect(mod.renderCacheMaxBytes()).toBe(original);
+
+    // A broken value must not read as "unbounded" — the cache still caches.
+    await mod.renderTextToPngsWithCharLimit('hello world', 64);
+    await mod.renderTextToPngsWithCharLimit('hello world', 64);
+    expect(mod.renderCacheStats()).toMatchObject({ entries: 1, hits: 1 });
   });
 });


### PR DESCRIPTION
The rendered-page cache added in #158 keys on the source text verbatim. Two
consequences, both of which #210 flags:

- every prompt rendered by the process stays in the heap as a plaintext string
  until evicted;
- entry size scales with source length, so `PXPIPE_RENDER_CACHE_BYTES` — a
  budget meant to bound retained *pages* — spends most of itself on copies of
  the input.

Before, for a 100 KB slab: entry overhead ≈ 200 KB of UTF-16 prompt text.
After: a flat 128 bytes, and the retained bytes are the pages.

```
- const key = `${cols}|${maxCharsPerImage}|${maxHeightPx}|${styleCacheKey(style)}|${slotLen}|${slotText ?? ''}${text}`;
+ const key = await renderCacheKey(text, cols, maxCharsPerImage, maxHeightPx, style, slotText);
```

`renderCacheKey` is a SHA-256 over a domain-separated (`pxpipe/render-cache/v1`),
length-prefixed encoding of every input the renderer reads. Length prefixes are
retained from #158's reasoning: without them `("a b", "c")` and `("a", "b c")`
collide. `-1` still marks an absent `slotText`, distinct from empty, because
`renderTextToPngsUncached` branches on `!== undefined`.

The trade #210 states explicitly: a cryptographic collision is a smaller risk
than guaranteed prompt retention. Note this removes *plaintext* retention, not
content retention — the cached pages are still rendered images of the source.

Three further items from the same root cause:

- **Runtime-split defaults.** 8 MiB on Workers, 64 MiB on Node. Both took 64 MiB
  before, which on a ~128 MiB isolate that also holds the request body, the
  decoded atlases and the framebuffers is most of the ceiling. Detection is
  `navigator.userAgent === 'Cloudflare-Workers'`, not `typeof process` —
  `nodejs_compat_v2` defines `process` on Workers too.
- **Byte-counter drift (bug).** The cache lookup precedes the `await`, so two
  concurrent requests for the same slab both miss, both render, and both store.
  The second store added its bytes without crediting back the entry it
  replaced, so the counter climbed permanently and would eventually evict a
  cache nowhere near its budget.
- **Counters.** `evictions` and `oversized` on `renderCacheStats()`, surfaced at
  `/proxy-stats` under `render_cache` with `max_bytes`. They answer different
  questions: `evictions` means the working set outgrew the budget; `oversized`
  means a single render exceeded the *whole* budget and was never stored, which
  otherwise looks identical to a permanently cold cache.

Worker bindings are not visible at module-init time, so the budget is applied
per request via the new `setRenderCacheMaxBytes()`. `0` is a real setting
(disable); negative and non-finite input is ignored rather than read as
"unbounded".

Part of #210 — the memoization item only. The PNG Average filtering and
transform-timing items, and the warm/cold benchmark with reported variance, are
not in this PR.

## Verify

```text
$ git rev-list --left-right --count upstream/main...perf/render-cache-hardening
0	1
```

New tests in `tests/render-cache.test.ts` cover each claim above:

- `retains a fixed-size key regardless of how long the source text is` — renders
  a 100-char and a 100 000-char input, asserts identical 128-byte overhead.
- `never stores an entry larger than the whole budget, and counts it` — asserts
  `oversized: 1, evictions: 0`. Its budget moved from 2000 to 100 bytes: with a
  fixed-width key, a page of repeating `'x '` deflates under 2000 and the case
  would stop exercising the branch it names.
- `does not double-count bytes when the same key is stored twice` — asserts
  `misses: 2`, so the race is the premise rather than an assumption.
- `shrinks the budget and evicts down to it immediately`, `treats 0 as
  disable-and-drop while keeping the counter history`, `ignores a negative or
  non-finite budget rather than obeying it`.

`pnpm test`, `pnpm typecheck` and `pnpm run build` are exactly what `ci.yml`
runs on `pull_request`, on Node 24 — so the run on this PR is the output, rather
than a paste from an author's laptop that a reviewer cannot re-execute. As a
first-time fork contribution it needs "Approve and run workflows" before it
starts. I will check the box below once it is green.

- [x] Rebased on current `main` — merge-base is `c5fc2a8`, the current `main`
      tip; branch is 0 commits behind.
- [ ] `pnpm test` and `pnpm typecheck` pass — pending CI approval, see above
- [x] No raw prompts, credentials, session files, or machine identifiers
