### PR TITLE
docs: add pxpipe-go to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ accuracy claim.
 Third-party projects listed here are not maintained or supported by pxpipe.
 
 - [pxpipe-windows](https://github.com/DivyeshPatro/pxpipe-windows) — Windows support for `pxpipe mitm` (node-forge CA in place of openssl, Task Scheduler autostart).
-- [pxpipe-go](https://github.com/evan-choi/pxpipe-go) — A Go port of pxpipe's core with a CLI wrapper, standalone proxy, and embeddable library for Anthropic Messages and OpenAI Chat/Responses.
 - [OmniGlyph](https://github.com/diegosouzapw/OmniGlyph) — A community-maintained project derived from pxpipe and used by [OmniRoute](https://github.com/diegosouzapw/OmniRoute).
+- [pxpipe-go](https://github.com/evan-choi/pxpipe-go) — A Go port of pxpipe's core with a CLI wrapper, standalone proxy, and embeddable library for Anthropic Messages and OpenAI Chat/Responses.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ accuracy claim.
 Third-party projects listed here are not maintained or supported by pxpipe.
 
 - [pxpipe-windows](https://github.com/DivyeshPatro/pxpipe-windows) — Windows support for `pxpipe mitm` (node-forge CA in place of openssl, Task Scheduler autostart).
+- [pxpipe-go](https://github.com/evan-choi/pxpipe-go) — A Go port of pxpipe's core with a CLI wrapper, standalone proxy, and embeddable library for Anthropic Messages and OpenAI Chat/Responses.
 - [OmniGlyph](https://github.com/diegosouzapw/OmniGlyph) — A community-maintained project derived from pxpipe and used by [OmniRoute](https://github.com/diegosouzapw/OmniRoute).
 
 ## License


### PR DESCRIPTION
Thank you for building pxpipe and documenting its strengths and limitations with such care. 
pxpipe-go is built on that work and keeps the original project and attribution visible.

This PR adds [pxpipe-go](https://github.com/evan-choi/pxpipe-go) below the existing projects. 
It ports the core Anthropic and OpenAI transforms to Go for command-line and library use.

## Verify

```text
$ mise exec node@24 -- pnpm test
Test Files  72 passed (72)
Tests  1153 passed (1153)

$ mise exec node@24 -- pnpm typecheck
> tsc --noEmit
```

Node 26.5.0 produced two failures in `tests/image-byte-budget.test.ts`; CI uses Node 24, where the full suite passes. This README-only diff does not touch those tests.

- [x] Rebased on current `main`
- [x] `pnpm test` and `pnpm typecheck` pass
- [x] No raw prompts, credentials, session files, or machine identifiers