### PR TITLE
feat(reliability): add coding-safe compression profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ normally — pxpipe compresses the *request* only, never the model's output.
 Recent turns stay text; the system prompt, tool docs, and older bulk history
 are imaged.
 
+### Compression profiles (optional)
+
+The Node host supports `PXPIPE_PROFILE` when a workload needs a stricter
+semantic boundary than the existing transform policy:
+
+- `coding-safe` keeps system authority, tool definitions, and live tool results
+  native, and only considers sufficiently old closed history for imaging.
+- `balanced` keeps the same live-state boundary with a shorter protected
+  history tail.
+- `aggressive` is the existing transform policy and remains the default when
+  `PXPIPE_PROFILE` is unset.
+- `passthrough` disables context transforms while leaving routing active.
+
+```bash
+PXPIPE_PROFILE=coding-safe npx pxpipe-proxy
+```
+
+Safe profiles do not promote experimental readers: their transform allowlist
+remains limited to pxpipe's evidence-backed default model set.
+
 ### `pxpipe warp`
 
 ```bash
@@ -101,8 +121,10 @@ without running the proxy.
   **13/15** on Fable 5 and **0/15** on Sol — misses are *silent
   confabulations*, not errors. Byte-exact values (IDs, hashes, secrets)
   must stay text; recent turns do. The factsheet selectively preserves up to
-  96 recognized precision-critical tokens, not every identifier. A dedicated
-  verbatim-risk guard is not built yet.
+  96 recognized precision-critical tokens, not every identifier.
+  `PXPIPE_PROFILE=coding-safe` keeps authority, tool definitions, and live tool
+  results native; old closed history may still be imaged, so byte-exact values
+  in historical image content are not guaranteed.
 - **Escape hatch:** subagents on non-allowlisted models pass through as
   text — route byte-exact work there
   (`CLAUDE_CODE_SUBAGENT_MODEL=claude-sonnet-4-6`, or `model: sonnet` in

--- a/src/core/applicability.ts
+++ b/src/core/applicability.ts
@@ -9,6 +9,8 @@ export type PxpipeApplicabilityReason =
   | 'unsupported_path'
   | 'empty_body';
 
+export type PxpipeSafetyScope = 'coding-safe' | 'balanced' | 'aggressive' | 'passthrough';
+
 export interface PxpipeApplicabilityInput {
   readonly model?: string | null;
   readonly method?: string | null;
@@ -26,37 +28,17 @@ function baseModelId(model: string): string {
 /** Dashboard runtime override; null = fall back to PXPIPE_MODELS env / built-in default. In-memory only. */
 let runtimeModelBases: readonly string[] | null = null;
 
-/** Built-in default scope when PXPIPE_MODELS is unset: Fable 5 and Gemini 3.6 Flash.
- *  Everything else is opt-in via dashboard chips or PXPIPE_MODELS:
- *  - Opus 4.7/4.8 — worse at reading imaged content (FINDINGS.md 2026-06-16:
- *    Opus 4.8 ~2pp arithmetic, 6/15 dense-hex vs Fable 100/100).
- *  - GPT 5.5 — degrades on imaged history/context.
- *  - GPT 5.6 Sol — 98/100 production arithmetic, but 79/93 completed gist,
- *    4/15 completed guard confabulations, and 0/15 dense hex.
- *  - Grok 4.5 — native 14px: 100/100 arithmetic, 97/98 gist, 17/18 state; hex 0/15.
- *  - Opus 5 — 2/15 exact recall on imaged context (DeepSWE v1.1 eval);
- *    task pass rate holds but dense recall does not.
- *  All remain available for explicit opt-in.
- *  Silently imaging weak or unvalidated readers is the wrong default. */
 /** Model bases imaged with no configuration at all.
  *
- *  Exported so documentation can be checked against it instead of restating it.
- *  The README and this list disagreed once already: Opus 5 was dropped here after
- *  a measured recall regression and stayed in the README's stated default, so a
- *  reader following the docs believed a model was being imaged that was not. */
+ * Exported so documentation can be checked against it instead of restating it. */
 export const DEFAULT_MODEL_BASES = ['claude-fable-5', 'gemini-3.6-flash'];
 
 function falsey(v: string): boolean {
   return /^(0|false|no|off|none)$/i.test(v.trim());
 }
 
-/** PXPIPE_MODELS env / built-in default, ignoring the runtime override. One CSV
- *  controls every family (Claude + GPT). Resolution (read per-call so scope flips LIVE):
- *  - unset or empty        → built-in default (Fable 5 + Gemini 3.6 Flash)
- *  - `off`/`0`/`false`/... → compress nothing
- *  - CSV of model bases    → exactly those families (e.g. `claude-fable-5,gpt-5.6-sol`) */
+/** PXPIPE_MODELS env / built-in default, ignoring the runtime override. */
 function envOrDefaultBases(): string[] {
-  // Edge-safe: `process` is undefined off-Node; `typeof` avoids a ReferenceError.
   const raw = typeof process !== 'undefined' ? process.env?.PXPIPE_MODELS : undefined;
   if (raw === undefined) return [...DEFAULT_MODEL_BASES];
   const trimmed = raw.trim();
@@ -65,9 +47,58 @@ function envOrDefaultBases(): string[] {
   return trimmed.split(',').map((s) => s.trim()).filter(Boolean);
 }
 
-function allowedModelBases(): string[] {
+function configuredModelBases(): string[] {
   if (runtimeModelBases !== null) return [...runtimeModelBases];
   return envOrDefaultBases();
+}
+
+function parseSafetyScope(raw: string | undefined): PxpipeSafetyScope {
+  const value = (raw ?? '').trim().toLowerCase();
+  // Backward-compatible: an unset profile keeps upstream's existing policy.
+  if (!value || value === 'aggressive' || value === 'legacy') return 'aggressive';
+  if (value === 'safe' || value === 'coding' || value === 'coding-safe') return 'coding-safe';
+  if (value === 'balanced') return 'balanced';
+  if (value === 'off' || value === 'disabled' || value === 'passthrough') return 'passthrough';
+  // Startup validation reports the bad profile; the applicability gate itself
+  // fails closed rather than broadening model eligibility.
+  return 'passthrough';
+}
+
+function activeSafetyScope(): PxpipeSafetyScope {
+  const raw = typeof process !== 'undefined' ? process.env?.PXPIPE_PROFILE : undefined;
+  return parseSafetyScope(raw);
+}
+
+/** Gateways qualify ids with routing segments such as `google/gemini-3.6-flash`. */
+function unqualifiedModelId(base: string): string | null {
+  const slash = base.lastIndexOf('/');
+  return slash >= 0 ? base.slice(slash + 1) : null;
+}
+
+function modelBaseMatches(id: string, candidate: string): boolean {
+  const target = candidate.toLowerCase();
+  return id === target || id.startsWith(`${target}-`);
+}
+
+function safetyAllowsConfiguredBase(candidate: string, scope: PxpipeSafetyScope): boolean {
+  if (scope === 'passthrough') return false;
+  if (scope === 'aggressive') return true;
+  const base = baseModelId(candidate).toLowerCase();
+  const unqualified = unqualifiedModelId(base);
+  // Safe profiles do not promote an explicitly configured experimental model.
+  // They are limited to the same evidence-backed bases upstream enables by default.
+  return DEFAULT_MODEL_BASES.some((safe) =>
+    modelBaseMatches(base, safe)
+      || (unqualified !== null && modelBaseMatches(unqualified, safe)),
+  );
+}
+
+function allowedModelBasesForScope(scope: PxpipeSafetyScope): string[] {
+  return configuredModelBases().filter((candidate) => safetyAllowsConfiguredBase(candidate, scope));
+}
+
+function allowedModelBases(): string[] {
+  return allowedModelBasesForScope(activeSafetyScope());
 }
 
 /** Current effective allowed-model scope (Claude + GPT). */
@@ -75,8 +106,7 @@ export function getAllowedModelBases(): string[] {
   return allowedModelBases();
 }
 
-/** PXPIPE_MODELS env / default scope, independent of runtime override.
- *  Dashboard unions this into its chip set so env-enabled models are always shown as toggles. */
+/** PXPIPE_MODELS env / default scope, independent of runtime override. */
 export function getConfiguredModelBases(): string[] {
   return envOrDefaultBases();
 }
@@ -86,52 +116,40 @@ export function setAllowedModelBases(list: readonly string[] | null): void {
   runtimeModelBases = list === null ? null : list.map((s) => s.trim()).filter(Boolean);
 }
 
-/** Gateways qualify ids with routing segments:
- *
- *    google/gemini-3.6-flash
- *    workers-ai/@cf/moonshotai/kimi-k3
- *
- *  The vendor picks the upstream, not the reader, so scope matching also
- *  compares the segment after the last slash. Otherwise PXPIPE_MODELS entries
- *  never match behind a gateway. */
-function unqualifiedModelId(base: string): string | null {
-  const slash = base.lastIndexOf('/');
-  return slash >= 0 ? base.slice(slash + 1) : null;
-}
-
-/** Membership test against the single allowed scope. Matches exact base or `-suffix`
- *  alias; [variant] tags stripped first. */
-function isAllowed(model: string | null | undefined): boolean {
+function isAllowedForScope(
+  model: string | null | undefined,
+  scope: PxpipeSafetyScope,
+): boolean {
   if (typeof model !== 'string') return false;
   const base = baseModelId(model).toLowerCase();
-  // Never compress an id that would be priced with another provider's formula
-  // (e.g. an unmeasured Gemini sibling falling through to the OpenAI fallback).
-  // Which ids those are is profile-table knowledge, not a rule maintained here.
   if (isMisresolvedModelId(base)) return false;
   const unqualified = unqualifiedModelId(base);
-  return allowedModelBases().some((b) => {
-    const target = b.toLowerCase();
-    const hit = (id: string): boolean => id === target || id.startsWith(`${target}-`);
-    return hit(base) || (unqualified !== null && hit(unqualified));
+  return allowedModelBasesForScope(scope).some((candidate) => {
+    const target = candidate.toLowerCase();
+    return modelBaseMatches(base, target)
+      || (unqualified !== null && modelBaseMatches(unqualified, target));
   });
 }
 
-/** True when pxpipe may transform this Anthropic model. */
+/** Pure model gate for a caller-selected semantic profile. */
+export function isPxpipeSupportedModelForScope(
+  model: string | null | undefined,
+  scope: PxpipeSafetyScope,
+): boolean {
+  return isAllowedForScope(model, scope);
+}
+
+/** True when pxpipe may transform this Anthropic model under the active profile. */
 export function isPxpipeSupportedModel(model: string | null | undefined): boolean {
-  return isAllowed(model);
+  return isAllowedForScope(model, activeSafetyScope());
 }
 
-/** True when pxpipe may transform this GPT model. Shares the single PXPIPE_MODELS scope. */
+/** True when pxpipe may transform this GPT model under the active profile. */
 export function isPxpipeSupportedGptModel(model: string | null | undefined): boolean {
-  return isAllowed(model);
+  return isAllowedForScope(model, activeSafetyScope());
 }
 
-/** Canonical set of Anthropic Messages routes pxpipe transforms. Shared with
- *  createProxy (src/core/proxy.ts) so the public applicability helper and the
- *  proxy router can never disagree on which paths are eligible — they did: the
- *  proxy accepts /anthropic/messages, but the helper's old `endsWith` check
- *  rejected it (and would have wrongly accepted /foo/v1/messages). Exact matches
- *  only, so /v1/messages/count_tokens stays unsupported. */
+/** Canonical set of Anthropic Messages routes pxpipe transforms. */
 export function isAnthropicMessagesPath(pathname: string): boolean {
   return pathname === '/v1/messages'
     || pathname === '/anthropic/v1/messages'

--- a/src/core/google.ts
+++ b/src/core/google.ts
@@ -26,6 +26,7 @@ import {
 } from './openai.js';
 import { factSheetText } from './factsheet.js';
 import { stripSchemaDescriptions } from './schema-strip.js';
+import type { GptHistoryOptions } from './openai-history.js';
 
 export interface GooglePart {
   text?: string;
@@ -409,10 +410,27 @@ async function planGoogleHistory(
   contents: GoogleContent[],
   modelName: string,
   reflowEnabled: boolean,
+  historyOptions: Partial<GptHistoryOptions> = {},
 ): Promise<GoogleHistoryPlan | null> {
   const profile = resolveGeminiProfile();
+
+  // Caller-selected safety profiles may tighten Gemini's measured history
+  // boundary, but they must never weaken the model defaults.
+  const keepTail = Math.max(
+    profile.history.keepTail,
+    historyOptions.keepTail ?? profile.history.keepTail,
+  );
+  const minCollapsePrefix = Math.max(
+    10,
+    historyOptions.minCollapsePrefix ?? 10,
+  );
+  const minCollapseTokens = Math.max(
+    profile.history.minCollapseTokens,
+    historyOptions.minCollapseTokens ?? profile.history.minCollapseTokens,
+  );
+
   const units = contents.map(googleHistoryUnit);
-  const cutoff = Math.max(0, units.length - profile.history.keepTail);
+  const cutoff = Math.max(0, units.length - keepTail);
   // In autonomous OpenCode turns the user's live task can be the oldest item,
   // followed by a long tool loop. Keep that request native instead of making it OCR-only.
   let latestPlainUser = -1;
@@ -428,11 +446,11 @@ async function planGoogleHistory(
     ? latestPlainUser + 1
     : 0;
   const boundary = googleClosedBoundary(units, start, cutoff);
-  if (boundary < start || boundary + 1 - start < 10) return null;
+  if (boundary < start || boundary + 1 - start < minCollapsePrefix) return null;
   const selected = units.slice(start, boundary + 1);
   const text = selected.map((unit) => unit.text).filter(Boolean).join('\n\n');
   const baselineTokens = selected.reduce((sum, unit) => sum + unit.baselineTokens, 0);
-  if (!text || baselineTokens < profile.history.minCollapseTokens) return null;
+  if (!text || baselineTokens < minCollapseTokens) return null;
   const safe = neutralizeSentinel(text);
   const renderedText = reflowEnabled ? reflow(safe) ?? safe : safe;
   const images = await renderTextToPngs(
@@ -491,6 +509,8 @@ export async function transformGoogleGenerateContent(
     compressTools?: boolean;
     compressToolResults?: boolean;
     collapseHistory?: boolean;
+    minCompressChars?: number;
+    gptHistory?: Partial<GptHistoryOptions>;
     minToolResultChars?: number;
     maxImagesPerToolResult?: number;
     cols?: number;
@@ -556,7 +576,13 @@ export async function transformGoogleGenerateContent(
   let fsText: string | null = null;
   let renderedText = '';
 
-  if (combinedRaw) {
+  // Preserve legacy Google behavior when no floor is supplied. Safe profiles
+  // set this to MAX_SAFE_INTEGER so authority remains native while old closed
+  // history can still be considered independently below.
+  const minCompressChars = Math.max(0, options.minCompressChars ?? 0);
+  const staticBelowMinChars = combinedRaw.length < minCompressChars;
+
+  if (combinedRaw && !staticBelowMinChars) {
     const combined = compactSlabWhitespace(combinedRaw).trimEnd();
     const reflowNote = options.reflow !== false
       ? ' The glyph ↵ (U+21B5) marks an original hard line break in content; treat it as a real newline.'
@@ -615,7 +641,12 @@ export async function transformGoogleGenerateContent(
 
   const historyPlan = options.collapseHistory === false
     ? null
-    : await planGoogleHistory(originalContents, modelName, options.reflow !== false);
+    : await planGoogleHistory(
+        originalContents,
+        modelName,
+        options.reflow !== false,
+        options.gptHistory,
+      );
   let contents = originalContents;
   if (historyPlan) {
     const historyParts: GooglePart[] = [
@@ -652,6 +683,8 @@ export async function transformGoogleGenerateContent(
   if (!hasStaticCompression && !hasHistoryCompression && !hasToolCompression) {
     if (!combinedRaw) {
       info.reason = 'no_static_context';
+    } else if (staticBelowMinChars) {
+      info.reason = `below_min_chars (${combinedRaw.length} < ${minCompressChars})`;
     } else if (!staticProfitable) {
       info.reason = 'not_profitable';
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,10 +3,12 @@ export {
   getConfiguredModelBases,
   isPxpipeSupportedGptModel,
   isPxpipeSupportedModel,
+  isPxpipeSupportedModelForScope,
   setAllowedModelBases,
   shouldTransformAnthropicMessages,
   type PxpipeApplicabilityInput,
   type PxpipeApplicabilityReason,
+  type PxpipeSafetyScope,
 } from './applicability.js';
 export {
   buildCountTokensBodies,
@@ -18,6 +20,7 @@ export {
 export {
   transformAnthropicMessages,
   renderTextToImages,
+  type CompressionProfileName,
   type PxpipeOptions,
   type PxpipeReason,
   type PxpipeTransformInput,
@@ -26,6 +29,12 @@ export {
   type RenderedTextImage,
   type RenderTextToImagesResult,
 } from './library.js';
+export {
+  resolveCompressionProfile,
+  mergeCompressionProfileOptions,
+  shouldKeepToolResultSharp,
+  type CompressionProfile,
+} from './safety-policy.js';
 export {
   transformRequest,
   type TransformInfo as PxpipeTransformInfo,

--- a/src/core/library.ts
+++ b/src/core/library.ts
@@ -1,4 +1,4 @@
-import { isPxpipeSupportedModel } from './applicability.js';
+import { isPxpipeSupportedModelForScope } from './applicability.js';
 import { countCacheControlMarkers } from './measurement.js';
 import {
   renderTextToPngsWithCharLimit,
@@ -18,8 +18,13 @@ import {
   type RecoverableBlock,
 } from './transform.js';
 import { resolveGptProfile } from './gpt-model-profiles.js';
+import {
+  mergeCompressionProfileOptions,
+  resolveCompressionProfile,
+  type CompressionProfileName,
+} from './safety-policy.js';
 
-export type { KeepSharpBlock, RecoverableBlock };
+export type { KeepSharpBlock, RecoverableBlock, CompressionProfileName };
 
 export type BytesLike = Uint8Array | ArrayBuffer | ArrayBufferView;
 
@@ -30,6 +35,8 @@ export interface PxpipeOptions
   > {
   /** Test/debug-only bypass. Product hosts should prefer their dashboard setting. */
   readonly compress?: boolean;
+  /** Semantic compression policy. Unset preserves the existing upstream policy. */
+  readonly profile?: CompressionProfileName;
 }
 
 export interface PxpipeTransformInput {
@@ -98,26 +105,33 @@ function classifyReason(info: TransformInfo): PxpipeReason {
 }
 
 /**
- * Library wrapper for the Anthropic Messages transformer: model gate, machine-readable
- * reasons, and cache_control ownership flag (prevents hosts stacking a second injector).
+ * Library wrapper for the Anthropic Messages transformer: profile-local model gate,
+ * machine-readable reasons and cache-control ownership metadata.
  */
 export async function transformAnthropicMessages(
   input: PxpipeTransformInput,
 ): Promise<PxpipeTransformResult> {
   const original = toUint8Array(input.body);
-  if (!isPxpipeSupportedModel(input.model)) {
-    return {
-      body: original,
-      applied: false,
-      reason: 'unsupported_model',
-      detail: input.model ?? undefined,
-      info: emptyInfo('unsupported_model'),
-      cache: { ownsCacheControl: false, markerCount: countCacheControlMarkers(original) },
-    };
-  }
 
   try {
-    const { body, info } = await transformRequest(original, { ...input.options, model: input.model ?? undefined });
+    const { profile: requestedProfile, ...overrides } = input.options ?? {};
+    const profile = resolveCompressionProfile(requestedProfile);
+    if (!isPxpipeSupportedModelForScope(input.model, profile.name)) {
+      return {
+        body: original,
+        applied: false,
+        reason: 'unsupported_model',
+        detail: input.model ?? undefined,
+        info: emptyInfo('unsupported_model'),
+        cache: { ownsCacheControl: false, markerCount: countCacheControlMarkers(original) },
+      };
+    }
+
+    const options = mergeCompressionProfileOptions(profile, overrides);
+    const { body, info } = await transformRequest(original, {
+      ...options,
+      model: input.model ?? undefined,
+    });
     const reason = classifyReason(info);
     const markerCount = countCacheControlMarkers(body);
     return {
@@ -155,9 +169,7 @@ export interface RenderTextToImagesOptions {
   /** Shrink the canvas to the widest actual line (default true). `false` keeps the
    *  full `cols` width — the proxy's eval-backed full-canvas behavior. */
   readonly shrink?: boolean;
-  /** Reflow the text before rendering (minify + join hard newlines with the ↵ sentinel so
-   *  short lines pack into full-width rows). This is the proxy's dense history format and is
-   *  what `pxpipe export` uses. Default false (raw one-line-per-row). */
+  /** Reflow the text before rendering. Default false. */
   readonly reflow?: boolean;
   /** Max source chars per page. Default DENSE_CONTENT_CHARS_PER_IMAGE. */
   readonly maxCharsPerImage?: number;
@@ -181,13 +193,7 @@ export interface RenderTextToImagesResult {
   readonly pixels: number;
 }
 
-/**
- * Render arbitrary text to dense PNG pages — the public, documented entry for the
- * renderer the proxy uses internally. Sizes a narrow canvas to the content (`shrink`).
- * Returns raw PNG bytes + pixel dimensions, ready to write to disk or wrap in
- * image blocks. This is the surface SDK consumers should use instead of reaching into
- * the internal leaf renderers in `render.ts`.
- */
+/** Render arbitrary text to PNG pages using the same internal renderer as the proxy. */
 export async function renderTextToImages(
   text: string,
   opts: RenderTextToImagesOptions = {},
@@ -197,19 +203,7 @@ export async function renderTextToImages(
   const style = opts.style ?? profile?.style ?? DENSE_RENDER_STYLE;
   const maxHeightPx = opts.maxHeightPx ?? profile?.maxHeightPx ?? MAX_HEIGHT_PX;
   const maxChars = opts.maxCharsPerImage ?? DENSE_CONTENT_CHARS_PER_IMAGE;
-
-  // Reflow (the proxy's dense default; opt-in here): minify trailing whitespace + collapse
-  // blank-line runs, then join hard newlines with the ↵ sentinel so short lines PACK into
-  // full-width rows instead of one-line-per-row with a ragged right margin. Indentation is
-  // preserved (minifyForRender only touches trailing ws), so code stays readable and the ↵
-  // marks every real newline so the text is fully reconstructable. This is exactly what the
-  // proxy's history path does before rendering — without it, a 384-col canvas holding ~25-col
-  // code lines wastes ~75% of every row, which is why raw exports looked sparse. reflow()
-  // bails (→ raw text) only if the source already contains ↵, which is vanishingly rare.
   const source = opts.reflow ? reflow(text) ?? text : text;
-
-  // Measure the content width. Reflowed source is one joined full-width line, so this is
-  // byte-identical to the proxy's history render.
   const cols = opts.shrink === false ? maxCols : measureContentCols(source, maxCols);
   const imgs = await renderTextToPngsWithCharLimit(source, cols, maxChars, style, maxHeightPx);
 

--- a/src/core/safety-policy.ts
+++ b/src/core/safety-policy.ts
@@ -1,0 +1,189 @@
+import type { GptHistoryOptions } from './openai-history.js';
+import type { KeepSharpBlock, TransformOptions } from './transform.js';
+
+export type CompressionProfileName =
+  | 'coding-safe'
+  | 'balanced'
+  | 'aggressive'
+  | 'passthrough';
+
+export interface CompressionProfile {
+  readonly name: CompressionProfileName;
+  readonly description: string;
+  readonly transform: Readonly<TransformOptions>;
+}
+
+const CODE_FENCE = /```(?:[A-Za-z0-9_+-]+)?\s*[\s\S]*?```/;
+const DIFF = /(?:^|\n)(?:diff --git |@@\s+-\d|\+\+\+\s+\S|---\s+\S)/m;
+const STACK = /(?:^|\n)\s*(?:at\s+\S+\s*\(|Traceback \(most recent call last\)|Caused by:|panic:)/m;
+const COMPILER = /(?:^|\n).*(?:error TS\d+|warning TS\d+|error\[[A-Z]\d+\]|fatal error:|undefined reference|SyntaxError:|TypeError:|AssertionError:)/m;
+const TEST_OUTPUT = /(?:^|\n).*(?:FAIL(?:ED)?\b|PASS\b|Tests?:\s+\d+|test result:|\d+\s+failed|\d+\s+passed)/mi;
+const PATH_WITH_LINE = /(?:^|\s)(?:\.?\.?\/|\/)[^\s:]+:\d+(?::\d+)?\b/;
+const SOURCE_SHAPE = /(?:^|\n)\s*(?:import\s|export\s|const\s|let\s|var\s|function\s|class\s|interface\s|type\s|def\s|async\s+def\s|fn\s|package\s|#include\s|public\s+|private\s+|protected\s+)/m;
+const STRUCTURED_STATE = /^\s*[\[{][\s\S]*[\]}]\s*$/;
+const EXACT_MACHINE_TOKEN = /(?:\b[0-9a-f]{7,40}\b|\b[A-Z][A-Z0-9_]{2,}\b|--[A-Za-z][\w-]*|\b[A-Za-z_][A-Za-z0-9_]*\([^\n]{0,120}\))/;
+
+/**
+ * Conservative classifier for live coding-agent output. A false positive only
+ * leaves more text native; a false negative can turn exact code/state into a
+ * lossy modality.
+ */
+export function shouldKeepToolResultSharp(block: KeepSharpBlock): boolean {
+  const text = block.text;
+  if (!text) return false;
+  const sample = text.length > 96_000
+    ? `${text.slice(0, 64_000)}\n${text.slice(-32_000)}`
+    : text;
+  return CODE_FENCE.test(sample)
+    || DIFF.test(sample)
+    || STACK.test(sample)
+    || COMPILER.test(sample)
+    || TEST_OUTPUT.test(sample)
+    || PATH_WITH_LINE.test(sample)
+    || SOURCE_SHAPE.test(sample)
+    || STRUCTURED_STATE.test(sample.trim())
+    || EXACT_MACHINE_TOKEN.test(sample);
+}
+
+const HISTORY_ONLY_STATIC_FLOOR = Number.MAX_SAFE_INTEGER;
+
+const PROFILES: Record<CompressionProfileName, CompressionProfile> = {
+  'coding-safe': {
+    name: 'coding-safe',
+    description: 'keep authority and live tool state native; collapse only old closed history',
+    transform: {
+      compress: true,
+      compressTools: false,
+      compressToolResults: false,
+      minCompressChars: HISTORY_ONLY_STATIC_FLOOR,
+      collapseHistory: true,
+      historyAmortizationHorizon: 4,
+      reflow: true,
+      gptHistory: {
+        keepTail: 12,
+        keepRecentPairs: 12,
+        minCollapsePrefix: 16,
+        minCollapseTokens: 4_000,
+      },
+      keepSharp: shouldKeepToolResultSharp,
+    },
+  },
+  balanced: {
+    name: 'balanced',
+    description: 'same live-state boundary with a shorter protected history tail',
+    transform: {
+      compress: true,
+      compressTools: false,
+      compressToolResults: false,
+      minCompressChars: HISTORY_ONLY_STATIC_FLOOR,
+      collapseHistory: true,
+      historyAmortizationHorizon: 3,
+      reflow: true,
+      gptHistory: {
+        keepTail: 8,
+        keepRecentPairs: 8,
+        minCollapsePrefix: 12,
+        minCollapseTokens: 3_000,
+      },
+      keepSharp: shouldKeepToolResultSharp,
+    },
+  },
+  // Preserve upstream's current behavior unless a profile is explicitly chosen.
+  aggressive: {
+    name: 'aggressive',
+    description: 'existing transform policy',
+    transform: {},
+  },
+  passthrough: {
+    name: 'passthrough',
+    description: 'route only; disable context transforms',
+    transform: { compress: false },
+  },
+};
+
+export function resolveCompressionProfile(raw?: string): CompressionProfile {
+  const value = (raw ?? '').trim().toLowerCase();
+  if (!value || value === 'aggressive' || value === 'legacy') return PROFILES.aggressive;
+  if (value === 'safe' || value === 'coding' || value === 'coding-safe') return PROFILES['coding-safe'];
+  if (value === 'balanced') return PROFILES.balanced;
+  if (value === 'off' || value === 'disabled' || value === 'passthrough') return PROFILES.passthrough;
+  throw new Error(`invalid PXPIPE_PROFILE '${raw}'; expected coding-safe, balanced, aggressive or passthrough`);
+}
+
+function maxDefined(base: number | undefined, caller: number | undefined): number | undefined {
+  if (base === undefined) return caller;
+  if (caller === undefined) return base;
+  return Math.max(base, caller);
+}
+
+function tightenHistoryOptions(
+  base: Partial<GptHistoryOptions> | undefined,
+  caller: Partial<GptHistoryOptions> | undefined,
+): Partial<GptHistoryOptions> | undefined {
+  if (!base && !caller) return undefined;
+  const merged: Partial<GptHistoryOptions> = { ...base, ...caller };
+  const keepTail = maxDefined(base?.keepTail, caller?.keepTail);
+  const keepRecentPairs = maxDefined(base?.keepRecentPairs, caller?.keepRecentPairs);
+  const minCollapsePrefix = maxDefined(base?.minCollapsePrefix, caller?.minCollapsePrefix);
+  const minCollapseTokens = maxDefined(base?.minCollapseTokens, caller?.minCollapseTokens);
+  if (keepTail !== undefined) merged.keepTail = keepTail;
+  if (keepRecentPairs !== undefined) merged.keepRecentPairs = keepRecentPairs;
+  if (minCollapsePrefix !== undefined) merged.minCollapsePrefix = minCollapsePrefix;
+  if (minCollapseTokens !== undefined) merged.minCollapseTokens = minCollapseTokens;
+  return merged;
+}
+
+/**
+ * Caller overrides may tighten a profile, but safe profiles retain their semantic
+ * boundary: static authority/tool schemas and live tool results cannot be turned
+ * back on for imaging, protected-history floors cannot be lowered, and the
+ * built-in keep-sharp classifier cannot be disabled.
+ */
+export function mergeCompressionProfileOptions(
+  profile: CompressionProfile,
+  overrides: TransformOptions = {},
+): TransformOptions {
+  const baseKeep = profile.transform.keepSharp;
+  const callerKeep = overrides.keepSharp;
+  const keepSharp = baseKeep && callerKeep
+    ? (block: KeepSharpBlock) => {
+        let base = false;
+        let caller = false;
+        try { base = baseKeep(block) === true; } catch { /* defensive */ }
+        try { caller = callerKeep(block) === true; } catch { /* defensive */ }
+        return base || caller;
+      }
+    : callerKeep ?? baseKeep;
+
+  const merged: TransformOptions = {
+    ...profile.transform,
+    ...overrides,
+    ...(keepSharp ? { keepSharp } : {}),
+  };
+
+  if (profile.name === 'passthrough') {
+    return { ...merged, compress: false };
+  }
+  if (profile.name === 'aggressive') return merged;
+
+  const minCompressChars = maxDefined(
+    profile.transform.minCompressChars,
+    overrides.minCompressChars,
+  );
+  const historyAmortizationHorizon = maxDefined(
+    profile.transform.historyAmortizationHorizon,
+    overrides.historyAmortizationHorizon,
+  );
+  const gptHistory = tightenHistoryOptions(profile.transform.gptHistory, overrides.gptHistory);
+
+  return {
+    ...merged,
+    compress: overrides.compress === false ? false : profile.transform.compress,
+    compressTools: false,
+    compressToolResults: false,
+    ...(minCompressChars !== undefined ? { minCompressChars } : {}),
+    collapseHistory: overrides.collapseHistory === false ? false : profile.transform.collapseHistory,
+    ...(historyAmortizationHorizon !== undefined ? { historyAmortizationHorizon } : {}),
+    ...(gptHistory ? { gptHistory } : {}),
+  };
+}

--- a/src/node.ts
+++ b/src/node.ts
@@ -15,6 +15,7 @@ import * as os from 'node:os';
 import { isIP } from 'node:net';
 import { spawnSync } from 'node:child_process';
 import { createProxy, parseGatewayHeaders, resolveUpstreams, type ProxyConfig } from './core/proxy.js';
+import { mergeCompressionProfileOptions, resolveCompressionProfile } from './core/safety-policy.js';
 import {
   chatCompletionsUrl,
 } from './core/messages-chat-bridge.js';
@@ -1164,20 +1165,10 @@ async function main(): Promise<void> {
       imageDumpDir = undefined;
     }
   }
-  // Transform options pass through empty — the proxy uses the DEFAULTS
-  // baked into transform.ts. There are no behavior toggles: system slab,
-  // reminders, tool_results, and history compression all run
-  // unconditionally; the per-block break-even gate decides per-call
-  // whether to actually image each piece. The function-form `transform`
-  // below is ONLY a kill switch (PXPIPE_DISABLE / dashboard toggle →
-  // compress:false); on the active path it returns {}, so the gate always
-  // runs on static DEFAULTS — charsPerToken=4, priorWarm*=0 — which leaves
-  // the warm-baseline and anti-flapping burn terms inert. That is
-  // deliberate, NOT an oversight: there is no live-α feedback loop from
-  // the dashboard. Telemetry (2026-06, 897 sessions / 21,347 measured
-  // rows) showed 5 mode flips ever and losses at 0.8% of wins — all
-  // one-time cache-create amortization — so closing the loop would not
-  // change decisions. Re-run that reconciliation before wiring one in.
+  // The default profile preserves the existing transform behavior. An explicit
+  // PXPIPE_PROFILE can instead constrain the transform to archival history or
+  // disable it entirely; the per-block profitability gates still make the final
+  // image/text decision within the selected policy.
   const tracker: Tracker = new FileTracker(opts.eventsFile);
 
   // Sidecar dir for oversized 4xx request-body samples. Lives next to the
@@ -1200,6 +1191,11 @@ async function main(): Promise<void> {
   // Seed the "recent requests" table from the JSONL log so a process restart
   // doesn't reset what you can see in the UI. Best-effort; ignored on error.
   await dashboard.replay(opts.eventsFile).catch(() => {});
+
+  const compressionProfile = resolveCompressionProfile(process.env.PXPIPE_PROFILE);
+  if (compressionProfile.name !== 'aggressive') {
+    console.log(`[pxpipe] compression profile: ${compressionProfile.name}`);
+  }
 
   const config: ProxyConfig = {
     authToken: anthropicAuthToken,
@@ -1227,8 +1223,8 @@ async function main(): Promise<void> {
       // still logging real usage + count_tokens baselines to its own PXPIPE_LOG.
       // (The dashboard kill switch does the same thing at runtime.)
       if (forcePassthrough || !dashboard.getCompressionEnabled()) return { compress: false };
-      // Active path: use DEFAULTS in transform.ts for break-even gating.
-      return {};
+      // Explicit profiles constrain what may leave native coding state.
+      return mergeCompressionProfileOptions(compressionProfile);
     },
     onRequest: async (e) => {
       // Feed the dashboard BEFORE tracker.emit — toTrackEvent strips

--- a/tests/google-safety-profile.test.ts
+++ b/tests/google-safety-profile.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformGoogleGenerateContent } from '../src/core/google.js';
+import {
+  mergeCompressionProfileOptions,
+  resolveCompressionProfile,
+} from '../src/core/safety-policy.js';
+
+const encode = (value: unknown): Uint8Array =>
+  new TextEncoder().encode(JSON.stringify(value));
+
+describe('Google coding-safe enforcement', () => {
+  it('keeps Gemini system authority native under coding-safe', async () => {
+    const request = {
+      systemInstruction: {
+        parts: [{
+          text:
+            'AUTHORITATIVE CODING INSTRUCTIONS\n'
+            + 'Never alter exact source state.\n'.repeat(4_000),
+        }],
+      },
+      contents: [{
+        role: 'user',
+        parts: [{ text: 'Inspect the repository.' }],
+      }],
+    };
+
+    const original = encode(request);
+    const options = mergeCompressionProfileOptions(
+      resolveCompressionProfile('coding-safe'),
+    );
+
+    const result = await transformGoogleGenerateContent(
+      original,
+      'gemini-3.6-flash',
+      options,
+    );
+
+    expect(result.info.compressed).toBe(false);
+    expect(result.info.reason).toMatch(/^below_min_chars/);
+    expect(result.body).toEqual(original);
+  });
+
+  it('tightens Gemini history thresholds under coding-safe', async () => {
+    // Ordinary Gemini history policy can collapse this transcript.
+    //
+    // coding-safe raises:
+    //   keepTail          6  -> 12
+    //   minCollapsePrefix 10 -> 16
+    //   minCollapseTokens 2000 -> 4000
+    //
+    // The same request must therefore remain native in coding-safe mode.
+    const contents = Array.from({ length: 20 }, (_, index) => ({
+      role: index % 2 === 0 ? 'user' : 'model',
+      parts: [{
+        text:
+          `turn-${index}\n`
+          + 'payload_0123456789 '.repeat(250),
+      }],
+    }));
+
+    const request = { contents };
+    const original = encode(request);
+
+    const ordinary = await transformGoogleGenerateContent(
+      original,
+      'gemini-3.6-flash',
+      {
+        compressTools: false,
+        compressToolResults: false,
+      },
+    );
+
+    expect(ordinary.info.compressed).toBe(true);
+    expect(ordinary.body).not.toEqual(original);
+
+    const safeOptions = mergeCompressionProfileOptions(
+      resolveCompressionProfile('coding-safe'),
+    );
+
+    const safe = await transformGoogleGenerateContent(
+      original,
+      'gemini-3.6-flash',
+      safeOptions,
+    );
+
+    expect(safe.info.compressed).toBe(false);
+    expect(safe.body).toEqual(original);
+  });
+});

--- a/tests/provider-neutral-contracts.test.ts
+++ b/tests/provider-neutral-contracts.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { transformOpenAIChatCompletions, transformOpenAIResponses } from '../src/core/openai.js';
+import { transformRequest } from '../src/core/transform.js';
+import { createProxy } from '../src/core/proxy.js';
+
+const encode = (value: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(value));
+const decode = (value: Uint8Array): any => JSON.parse(new TextDecoder().decode(value));
+const dense = (size: number): string => Array.from(
+  { length: Math.ceil(size / 24) },
+  (_, index) => `module_${index}=value_${index * 7919}`,
+).join('\n').slice(0, size);
+const force = { charsPerToken: 1, minCompressChars: 1 } as const;
+
+let previousModels: string | undefined;
+beforeEach(() => {
+  previousModels = process.env.PXPIPE_MODELS;
+  process.env.PXPIPE_MODELS = 'claude-fable-5,gpt-5.6-sol';
+});
+afterEach(() => {
+  if (previousModels === undefined) delete process.env.PXPIPE_MODELS;
+  else process.env.PXPIPE_MODELS = previousModels;
+  vi.unstubAllGlobals();
+});
+
+describe('provider-neutral request semantics', () => {
+  it('keeps Anthropic tool schemas machine-readable and semantically exact', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['create', 'update'] },
+        payload: {
+          type: 'object',
+          properties: { id: { type: 'string', pattern: '^[a-z0-9-]+$' } },
+          required: ['id'],
+          additionalProperties: false,
+        },
+      },
+      required: ['action', 'payload'],
+      additionalProperties: false,
+    };
+    const result = await transformRequest(encode({
+      model: 'claude-fable-5',
+      max_tokens: 32,
+      system: dense(70_000),
+      tools: [{ name: 'mutate_record', description: dense(12_000), input_schema: schema }],
+      messages: [{ role: 'user', content: 'Create one record.' }],
+    }), force);
+    const output = decode(result.body);
+
+    expect(result.info.compressed).toBe(true);
+    expect(output.tools[0].name).toBe('mutate_record');
+    expect(output.tools[0].input_schema).toEqual(schema);
+    expect(JSON.stringify(output.messages)).toContain('Create one record.');
+  });
+
+  it('keeps OpenAI response-format JSON Schema unchanged', async () => {
+    const responseFormat = {
+      type: 'json_schema',
+      json_schema: {
+        name: 'result',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: {
+            status: { type: 'string', enum: ['ok', 'error'] },
+            identifiers: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['status', 'identifiers'],
+          additionalProperties: false,
+        },
+      },
+    };
+    const result = await transformOpenAIChatCompletions(encode({
+      model: 'gpt-5.6-sol',
+      messages: [
+        { role: 'system', content: dense(70_000) },
+        { role: 'user', content: 'Return the requested JSON.' },
+      ],
+      response_format: responseFormat,
+    }), force);
+    const output = decode(result.body);
+
+    expect(result.info.compressed).toBe(true);
+    expect(output.response_format).toEqual(responseFormat);
+    expect(JSON.stringify(output.messages)).toContain('Return the requested JSON.');
+  });
+
+  it('preserves Responses function-call/output ordering and exact call ids', async () => {
+    const result = await transformOpenAIResponses(encode({
+      model: 'gpt-5.6-sol',
+      input: [
+        { role: 'system', content: dense(60_000) },
+        { type: 'function_call', call_id: 'call_exact_123', name: 'lookup', arguments: '{"id":"abc-123"}' },
+        { type: 'function_call_output', call_id: 'call_exact_123', output: '{"value":7}' },
+        { role: 'user', content: 'Use the tool result and answer.' },
+      ],
+    }), force);
+    const output = decode(result.body);
+    const callIndex = output.input.findIndex((item: any) => item.type === 'function_call');
+    const outputIndex = output.input.findIndex((item: any) => item.type === 'function_call_output');
+
+    expect(callIndex).toBeGreaterThanOrEqual(0);
+    expect(outputIndex).toBe(callIndex + 1);
+    expect(output.input[callIndex].call_id).toBe('call_exact_123');
+    expect(output.input[outputIndex].call_id).toBe('call_exact_123');
+    expect(output.input[outputIndex].output).toBe('{"value":7}');
+    expect(JSON.stringify(output.input)).toContain('Use the tool result and answer.');
+  });
+
+  it('never recursively recompresses an existing native image', async () => {
+    const nativeImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    const result = await transformOpenAIChatCompletions(encode({
+      model: 'gpt-5.6-sol',
+      messages: [
+        { role: 'system', content: dense(60_000) },
+        {
+          role: 'user',
+          content: [
+            { type: 'image_url', image_url: { url: nativeImage, detail: 'low' } },
+            { type: 'text', text: 'Inspect the supplied image.' },
+          ],
+        },
+      ],
+    }), force);
+    const output = decode(result.body);
+    const serialized = JSON.stringify(output);
+
+    expect(serialized.match(new RegExp(nativeImage.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))).toHaveLength(1);
+    expect(serialized).toContain('Inspect the supplied image.');
+  });
+});
+
+describe('provider-neutral response transparency', () => {
+  it('does not rewrite an OpenAI-compatible model response or provider headers', async () => {
+    const exactResponse = '{\n  "id":"resp-1",\n  "provider_field":{"keep":true},\n  "choices":[{"message":{"role":"assistant","content":"OK"}}]\n}';
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(exactResponse, {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'x-provider-field': 'preserved',
+        'retry-after': '17',
+      },
+    })));
+
+    const proxy = createProxy({
+      openAIUpstream: 'https://api.openai.test',
+      openAIApiKey: 'test-key',
+      openAIModels: ['gpt-5.6-sol'],
+      transform: force,
+    });
+    const response = await proxy(new Request('http://localhost/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer test-key' },
+      body: JSON.stringify({
+        model: 'gpt-5.6-sol',
+        messages: [
+          { role: 'system', content: dense(60_000) },
+          { role: 'user', content: 'Reply with OK.' },
+        ],
+      }),
+    }));
+
+    expect(await response.text()).toBe(exactResponse);
+    expect(response.headers.get('x-provider-field')).toBe('preserved');
+    expect(response.headers.get('retry-after')).toBe('17');
+  });
+});

--- a/tests/safety-profile.test.ts
+++ b/tests/safety-profile.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  isPxpipeSupportedModelForScope,
+} from '../src/core/applicability.js';
+import {
+  mergeCompressionProfileOptions,
+  resolveCompressionProfile,
+  shouldKeepToolResultSharp,
+} from '../src/core/safety-policy.js';
+
+const previousModels = process.env.PXPIPE_MODELS;
+afterEach(() => {
+  if (previousModels === undefined) delete process.env.PXPIPE_MODELS;
+  else process.env.PXPIPE_MODELS = previousModels;
+});
+
+describe('coding-safe profile', () => {
+  it('keeps authority and live tool-result imaging disabled', () => {
+    const options = mergeCompressionProfileOptions(resolveCompressionProfile('coding-safe'));
+    expect(options.compress).toBe(true);
+    expect(options.compressTools).toBe(false);
+    expect(options.compressToolResults).toBe(false);
+    expect(options.minCompressChars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(options.collapseHistory).toBe(true);
+    expect(options.gptHistory?.keepTail).toBe(12);
+  });
+
+  it('preserves upstream behavior when the profile is unset', () => {
+    expect(resolveCompressionProfile(undefined).name).toBe('aggressive');
+    expect(mergeCompressionProfileOptions(resolveCompressionProfile(undefined))).toEqual({});
+  });
+
+  it('does not let caller overrides weaken the built-in semantic boundary', () => {
+    const options = mergeCompressionProfileOptions(
+      resolveCompressionProfile('coding-safe'),
+      {
+        compressTools: true,
+        compressToolResults: true,
+        minCompressChars: 1,
+        historyAmortizationHorizon: 1,
+        gptHistory: {
+          keepTail: 0,
+          keepRecentPairs: 0,
+          minCollapsePrefix: 1,
+          minCollapseTokens: 1,
+        },
+        keepSharp: () => false,
+      },
+    );
+    expect(options.compressTools).toBe(false);
+    expect(options.compressToolResults).toBe(false);
+    expect(options.minCompressChars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(options.historyAmortizationHorizon).toBe(4);
+    expect(options.gptHistory?.keepTail).toBe(12);
+    expect(options.gptHistory?.keepRecentPairs).toBe(12);
+    expect(options.gptHistory?.minCollapsePrefix).toBe(16);
+    expect(options.gptHistory?.minCollapseTokens).toBe(4_000);
+    expect(options.keepSharp?.({
+      text: 'src/index.ts:42:7 error TS2322: Type mismatch',
+      kind: 'tool_result',
+    })).toBe(true);
+  });
+
+  it('allows caller overrides to tighten safe profiles', () => {
+    const options = mergeCompressionProfileOptions(
+      resolveCompressionProfile('balanced'),
+      {
+        compress: false,
+        collapseHistory: false,
+        historyAmortizationHorizon: 6,
+        gptHistory: {
+          keepTail: 14,
+          keepRecentPairs: 14,
+          minCollapsePrefix: 20,
+          minCollapseTokens: 5_000,
+        },
+      },
+    );
+    expect(options.compress).toBe(false);
+    expect(options.collapseHistory).toBe(false);
+    expect(options.historyAmortizationHorizon).toBe(6);
+    expect(options.gptHistory?.keepTail).toBe(14);
+    expect(options.gptHistory?.keepRecentPairs).toBe(14);
+    expect(options.gptHistory?.minCollapsePrefix).toBe(20);
+    expect(options.gptHistory?.minCollapseTokens).toBe(5_000);
+  });
+
+  it('cannot turn passthrough back into a transform', () => {
+    const options = mergeCompressionProfileOptions(
+      resolveCompressionProfile('passthrough'),
+      { compress: true, compressToolResults: true },
+    );
+    expect(options.compress).toBe(false);
+  });
+
+  it('recognizes coding-state shapes conservatively', () => {
+    expect(shouldKeepToolResultSharp({ text: 'diff --git a/a.ts b/a.ts\n@@ -1 +1 @@', kind: 'tool_result' })).toBe(true);
+    expect(shouldKeepToolResultSharp({ text: '{"commit":"a1b2c3d4","ok":true}', kind: 'tool_result' })).toBe(true);
+    expect(shouldKeepToolResultSharp({ text: 'ordinary prose without machine state', kind: 'tool_result' })).toBe(false);
+  });
+
+  it('safe scopes cannot promote experimental models through PXPIPE_MODELS', () => {
+    process.env.PXPIPE_MODELS = 'claude-fable-5,gemini-3.6-flash,gpt-5.6-sol,claude-opus-5';
+    expect(isPxpipeSupportedModelForScope('claude-fable-5', 'coding-safe')).toBe(true);
+    expect(isPxpipeSupportedModelForScope('gemini-3.6-flash', 'coding-safe')).toBe(true);
+    expect(isPxpipeSupportedModelForScope('gpt-5.6-sol', 'coding-safe')).toBe(false);
+    expect(isPxpipeSupportedModelForScope('claude-opus-5', 'balanced')).toBe(false);
+    expect(isPxpipeSupportedModelForScope('gpt-5.6-sol', 'aggressive')).toBe(true);
+  });
+
+  it('passthrough admits no model for transformation', () => {
+    expect(isPxpipeSupportedModelForScope('claude-fable-5', 'passthrough')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

For coding agents, reducing every eligible block is not the same as preserving exact working state. Authority text, tool schemas, live source/tool output, diffs, diagnostics, paths, and identifiers are materially riskier to change modality than old closed conversation history.

## Changes

- add explicit `coding-safe`, `balanced`, `aggressive`, and `passthrough` profiles;
- preserve the existing upstream behavior when `PXPIPE_PROFILE` is unset;
- keep tools and live tool results native in safe profiles;
- limit safe compression to sufficiently old, closed history;
- add a conservative keep-sharp classifier for code, diffs, diagnostics, stack traces, structured state, paths, and machine identifiers;
- prevent caller overrides from weakening that guard;
- keep safe-profile model admission limited to upstream's existing evidence-backed default models;
- expose profile-local library/applicability APIs;
- wire profile selection into the Node host;
- add provider-neutral regression contracts for schemas, Responses call/output ordering, native images, response bytes, and provider headers.

## Scope

No AGY aliases, Codex routing, provider router, dashboard redesign, model promotion, or cache optimizer.

The unset-profile behavior is intentionally unchanged.

## Validation

Validated from a branch based directly on current upstream `0.13.1`:

- production dependency audit;
- TypeScript typecheck;
- focused safety/contracts tests;
- full test suite;
- build;
- Worker dry-run;
- `git diff --check`.

No raw prompts, credentials, session files, machine identifiers, or temporary validation machinery are included.
