### PR TITLE
feat(accounting): normalize provider evidence and savings

### DIFF
--- a/docs/ACCOUNTING_MODEL.md
+++ b/docs/ACCOUNTING_MODEL.md
@@ -1,0 +1,42 @@
+# Provider-neutral accounting model
+
+PXPipe must not describe character reduction as token savings. Accounting is
+split into independent evidence classes.
+
+## Evidence priority
+
+1. **Provider-reported** — an original-request baseline from the provider and
+   actual provider usage for the transformed request.
+2. **Estimated** — provider/model-specific token estimates for both request
+   shapes.
+3. **Bytes-only** — original and transformed serialized request sizes.
+4. **Unavailable** — insufficient evidence; no savings number is emitted.
+
+Provider-reported evidence always wins when both reported and estimated values
+exist. Estimates remain available for diagnostics but do not replace the
+reported result.
+
+## Provider input semantics
+
+Anthropic reports uncached input, cache creation and cache reads as disjoint
+buckets. Physical input tokens are their sum.
+
+OpenAI-compatible providers, Featherless and Google report cached tokens as a
+subset of input tokens. The cached bucket must not be added to input again.
+
+## Normalized fields
+
+- original/transformed bytes and compression ratio;
+- provider-reported original and actual input tokens;
+- provider-reported token reduction and ratio;
+- estimated original/actual input tokens and reduction;
+- cache-read and cache-write buckets;
+- image tokens;
+- output and total tokens;
+- PXPipe-added latency and model latency as separate inputs;
+- fallback count;
+- bypass reason;
+- provider and model labels.
+
+The normalization API does not infer latency components from wall-clock values
+or invent an original token baseline. Callers must supply measured evidence.

--- a/docs/ACCOUNTING_MODEL.md
+++ b/docs/ACCOUNTING_MODEL.md
@@ -24,6 +24,30 @@ buckets. Physical input tokens are their sum.
 OpenAI-compatible providers, Featherless and Google report cached tokens as a
 subset of input tokens. The cached bucket must not be added to input again.
 
+For an unknown provider, PXPipe does not guess whether cache buckets are
+disjoint or subsets. Provider-reported input normalization therefore fails
+closed when cache buckets are supplied for an unknown provider.
+
+A missing Anthropic cache bucket means zero. A bucket that is present but is
+negative, non-integral, non-finite or outside JavaScript's safe-integer range
+invalidates that provider-reported total instead of being silently treated as
+zero.
+
+## Measurement validity
+
+Token counts, byte counts, image-token counts and event counters are discrete
+quantities. They must be non-negative safe integers.
+
+Latency values are continuous measurements and may be finite non-negative
+fractional milliseconds.
+
+A negative **reduction** is valid evidence: it means the transformed request
+expanded relative to the baseline. PXPipe preserves that result instead of
+clamping it to zero.
+
+If provider-reported evidence is invalid or incomplete, normalization falls
+back to the next complete evidence class rather than manufacturing a result.
+
 ## Normalized fields
 
 - original/transformed bytes and compression ratio;
@@ -38,5 +62,6 @@ subset of input tokens. The cached bucket must not be added to input again.
 - bypass reason;
 - provider and model labels.
 
-The normalization API does not infer latency components from wall-clock values
-or invent an original token baseline. Callers must supply measured evidence.
+The normalization API does not infer latency components from wall-clock values,
+invent an original token baseline, or guess unknown provider cache semantics.
+Callers must supply measured evidence.

--- a/src/core/accounting.ts
+++ b/src/core/accounting.ts
@@ -55,8 +55,29 @@ export interface NormalizedAccounting {
   bypassReason?: string;
 }
 
-function nonNegative(value: number | undefined): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+/**
+ * Token counts, byte counts and event counters come from discrete quantities.
+ * Reject fractions, unsafe integers and non-finite values instead of coercing
+ * malformed telemetry into apparently precise accounting.
+ */
+function nonNegativeCount(value: number | undefined): number | undefined {
+  return typeof value === 'number'
+    && Number.isSafeInteger(value)
+    && value >= 0
+    ? value
+    : undefined;
+}
+
+/**
+ * Latency is a continuous measurement and may legitimately contain fractional
+ * milliseconds, so it only requires a finite non-negative number.
+ */
+function nonNegativeMeasure(value: number | undefined): number | undefined {
+  return typeof value === 'number'
+    && Number.isFinite(value)
+    && value >= 0
+    ? value
+    : undefined;
 }
 
 function difference(before: number | undefined, after: number | undefined): number | undefined {
@@ -69,40 +90,93 @@ function ratio(reduced: number | undefined, baseline: number | undefined): numbe
   return reduced / baseline;
 }
 
+function safeSum(values: readonly number[]): number | undefined {
+  let total = 0;
+  for (const value of values) {
+    total += value;
+    if (!Number.isSafeInteger(total) || total < 0) return undefined;
+  }
+  return total;
+}
+
+function suppliedInvalidCount(value: number | undefined): boolean {
+  return value !== undefined && nonNegativeCount(value) === undefined;
+}
+
 /**
+ * Normalize the provider's reported input usage into physical input tokens.
+ *
  * Provider usage buckets are not shaped identically:
  *
  * - Anthropic reports uncached input, cache creation and cache reads as
- *   disjoint buckets. Total physical input is their sum.
- * - OpenAI-compatible and Google usage report cached tokens as a subset of the
- *   input count. Adding the cache bucket would double-count it.
- * - Featherless is OpenAI-compatible, so it follows OpenAI semantics.
+ *   disjoint buckets. Physical input is their sum.
+ * - OpenAI-compatible providers and Google report cached tokens as a subset of
+ *   the input count. Adding the cache bucket would double-count it.
+ * - Featherless follows its OpenAI-compatible usage shape.
+ * - An unknown provider is accepted only when no cache bucket semantics need
+ *   to be inferred. If cache buckets are supplied, normalization fails closed.
+ *
+ * Missing Anthropic cache buckets mean zero. A PRESENT but malformed bucket is
+ * different: it invalidates the provider-reported total instead of silently
+ * turning corrupted telemetry into savings evidence.
  */
 export function providerActualInputTokens(input: AccountingInput): number | undefined {
-  const reported = nonNegative(input.providerInputTokens);
+  const reported = nonNegativeCount(input.providerInputTokens);
   if (reported === undefined) return undefined;
-  if (input.provider !== 'anthropic') return reported;
-  return reported
-    + (nonNegative(input.cacheReadTokens) ?? 0)
-    + (nonNegative(input.cacheWriteTokens) ?? 0);
+
+  const cacheRead = nonNegativeCount(input.cacheReadTokens);
+  const cacheWrite = nonNegativeCount(input.cacheWriteTokens);
+
+  if (input.provider === 'anthropic') {
+    if (
+      suppliedInvalidCount(input.cacheReadTokens)
+      || suppliedInvalidCount(input.cacheWriteTokens)
+    ) {
+      return undefined;
+    }
+
+    return safeSum([
+      reported,
+      cacheRead ?? 0,
+      cacheWrite ?? 0,
+    ]);
+  }
+
+  if (input.provider === 'unknown') {
+    // No provider-specific cache semantics are known. If cache telemetry is
+    // present, guessing subset-vs-disjoint would manufacture precision.
+    if (
+      input.cacheReadTokens !== undefined
+      || input.cacheWriteTokens !== undefined
+    ) {
+      return undefined;
+    }
+
+    return reported;
+  }
+
+  // OpenAI, Google and Featherless input totals already include their cache
+  // subsets. Cache buckets remain diagnostic fields only.
+  return reported;
 }
 
 export function normalizeAccounting(input: AccountingInput): NormalizedAccounting {
-  const originalBytes = nonNegative(input.originalBytes);
-  const transformedBytes = nonNegative(input.transformedBytes);
+  const originalBytes = nonNegativeCount(input.originalBytes);
+  const transformedBytes = nonNegativeCount(input.transformedBytes);
   const bytesReduced = difference(originalBytes, transformedBytes);
 
-  const providerOriginal = nonNegative(input.providerBaselineInputTokens);
+  const providerOriginal = nonNegativeCount(input.providerBaselineInputTokens);
   const providerActual = providerActualInputTokens(input);
   const providerReduced = difference(providerOriginal, providerActual);
 
-  const estimatedOriginal = nonNegative(input.estimatedOriginalInputTokens);
-  const estimatedActual = nonNegative(input.estimatedTransformedInputTokens);
+  const estimatedOriginal = nonNegativeCount(input.estimatedOriginalInputTokens);
+  const estimatedActual = nonNegativeCount(input.estimatedTransformedInputTokens);
   const estimatedReduced = difference(estimatedOriginal, estimatedActual);
 
   let evidence: SavingsEvidence = 'unavailable';
   let inputTokensReduced: number | undefined;
   let inputReductionRatio: number | undefined;
+
   if (providerReduced !== undefined) {
     evidence = 'provider-reported';
     inputTokensReduced = providerReduced;
@@ -115,45 +189,78 @@ export function normalizeAccounting(input: AccountingInput): NormalizedAccountin
     evidence = 'bytes-only';
   }
 
-  const output = nonNegative(input.providerOutputTokens);
+  const cacheRead = nonNegativeCount(input.cacheReadTokens);
+  const cacheWrite = nonNegativeCount(input.cacheWriteTokens);
+  const image = nonNegativeCount(input.imageTokens);
+  const output = nonNegativeCount(input.providerOutputTokens);
+
   const total = providerActual !== undefined && output !== undefined
-    ? providerActual + output
+    ? safeSum([providerActual, output])
     : undefined;
+
+  const proxyAddedMs = nonNegativeMeasure(input.proxyAddedLatencyMs);
+  const modelMs = nonNegativeMeasure(input.modelLatencyMs);
 
   return {
     provider: input.provider,
     ...(input.model ? { model: input.model } : {}),
+
     bytes: {
       ...(originalBytes !== undefined ? { original: originalBytes } : {}),
       ...(transformedBytes !== undefined ? { transformed: transformedBytes } : {}),
       ...(bytesReduced !== undefined ? { reduced: bytesReduced } : {}),
-      ...(originalBytes !== undefined && originalBytes > 0 && transformedBytes !== undefined
-        ? { compressionRatio: transformedBytes / originalBytes }
-        : {}),
+      ...(
+        originalBytes !== undefined
+        && originalBytes > 0
+        && transformedBytes !== undefined
+          ? { compressionRatio: transformedBytes / originalBytes }
+          : {}
+      ),
     },
+
     tokens: {
-      ...(providerOriginal !== undefined ? { providerReportedOriginalInput: providerOriginal } : {}),
-      ...(providerActual !== undefined ? { providerReportedActualInput: providerActual } : {}),
-      ...(providerReduced !== undefined ? { providerReportedReduced: providerReduced } : {}),
-      ...(estimatedOriginal !== undefined ? { estimatedOriginalInput: estimatedOriginal } : {}),
-      ...(estimatedActual !== undefined ? { estimatedActualInput: estimatedActual } : {}),
-      ...(estimatedReduced !== undefined ? { estimatedReduced } : {}),
-      ...(nonNegative(input.cacheReadTokens) !== undefined ? { cacheRead: input.cacheReadTokens } : {}),
-      ...(nonNegative(input.cacheWriteTokens) !== undefined ? { cacheWrite: input.cacheWriteTokens } : {}),
-      ...(nonNegative(input.imageTokens) !== undefined ? { image: input.imageTokens } : {}),
+      ...(providerOriginal !== undefined
+        ? { providerReportedOriginalInput: providerOriginal }
+        : {}),
+      ...(providerActual !== undefined
+        ? { providerReportedActualInput: providerActual }
+        : {}),
+      ...(providerReduced !== undefined
+        ? { providerReportedReduced: providerReduced }
+        : {}),
+      ...(estimatedOriginal !== undefined
+        ? { estimatedOriginalInput: estimatedOriginal }
+        : {}),
+      ...(estimatedActual !== undefined
+        ? { estimatedActualInput: estimatedActual }
+        : {}),
+      ...(estimatedReduced !== undefined
+        ? { estimatedReduced }
+        : {}),
+      ...(cacheRead !== undefined ? { cacheRead } : {}),
+      ...(cacheWrite !== undefined ? { cacheWrite } : {}),
+      ...(image !== undefined ? { image } : {}),
       ...(output !== undefined ? { output } : {}),
       ...(total !== undefined ? { total } : {}),
     },
+
     savings: {
       evidence,
-      ...(inputTokensReduced !== undefined ? { inputTokensReduced } : {}),
-      ...(inputReductionRatio !== undefined ? { inputReductionRatio } : {}),
+      ...(inputTokensReduced !== undefined
+        ? { inputTokensReduced }
+        : {}),
+      ...(inputReductionRatio !== undefined
+        ? { inputReductionRatio }
+        : {}),
     },
+
     latency: {
-      ...(nonNegative(input.proxyAddedLatencyMs) !== undefined ? { proxyAddedMs: input.proxyAddedLatencyMs } : {}),
-      ...(nonNegative(input.modelLatencyMs) !== undefined ? { modelMs: input.modelLatencyMs } : {}),
+      ...(proxyAddedMs !== undefined ? { proxyAddedMs } : {}),
+      ...(modelMs !== undefined ? { modelMs } : {}),
     },
-    fallbackCount: nonNegative(input.fallbackCount) ?? 0,
+
+    fallbackCount: nonNegativeCount(input.fallbackCount) ?? 0,
+
     ...(input.bypassReason ? { bypassReason: input.bypassReason } : {}),
   };
 }

--- a/src/core/accounting.ts
+++ b/src/core/accounting.ts
@@ -1,0 +1,159 @@
+export type AccountingProvider = 'anthropic' | 'openai' | 'google' | 'featherless' | 'unknown';
+export type SavingsEvidence = 'provider-reported' | 'estimated' | 'bytes-only' | 'unavailable';
+
+export interface AccountingInput {
+  provider: AccountingProvider;
+  model?: string;
+  originalBytes?: number;
+  transformedBytes?: number;
+  estimatedOriginalInputTokens?: number;
+  estimatedTransformedInputTokens?: number;
+  providerBaselineInputTokens?: number;
+  providerInputTokens?: number;
+  providerOutputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  imageTokens?: number;
+  proxyAddedLatencyMs?: number;
+  modelLatencyMs?: number;
+  fallbackCount?: number;
+  bypassReason?: string;
+}
+
+export interface NormalizedAccounting {
+  provider: AccountingProvider;
+  model?: string;
+  bytes: {
+    original?: number;
+    transformed?: number;
+    reduced?: number;
+    compressionRatio?: number;
+  };
+  tokens: {
+    providerReportedOriginalInput?: number;
+    providerReportedActualInput?: number;
+    providerReportedReduced?: number;
+    estimatedOriginalInput?: number;
+    estimatedActualInput?: number;
+    estimatedReduced?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    image?: number;
+    output?: number;
+    total?: number;
+  };
+  savings: {
+    evidence: SavingsEvidence;
+    inputTokensReduced?: number;
+    inputReductionRatio?: number;
+  };
+  latency: {
+    proxyAddedMs?: number;
+    modelMs?: number;
+  };
+  fallbackCount: number;
+  bypassReason?: string;
+}
+
+function nonNegative(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function difference(before: number | undefined, after: number | undefined): number | undefined {
+  if (before === undefined || after === undefined) return undefined;
+  return before - after;
+}
+
+function ratio(reduced: number | undefined, baseline: number | undefined): number | undefined {
+  if (reduced === undefined || baseline === undefined || baseline <= 0) return undefined;
+  return reduced / baseline;
+}
+
+/**
+ * Provider usage buckets are not shaped identically:
+ *
+ * - Anthropic reports uncached input, cache creation and cache reads as
+ *   disjoint buckets. Total physical input is their sum.
+ * - OpenAI-compatible and Google usage report cached tokens as a subset of the
+ *   input count. Adding the cache bucket would double-count it.
+ * - Featherless is OpenAI-compatible, so it follows OpenAI semantics.
+ */
+export function providerActualInputTokens(input: AccountingInput): number | undefined {
+  const reported = nonNegative(input.providerInputTokens);
+  if (reported === undefined) return undefined;
+  if (input.provider !== 'anthropic') return reported;
+  return reported
+    + (nonNegative(input.cacheReadTokens) ?? 0)
+    + (nonNegative(input.cacheWriteTokens) ?? 0);
+}
+
+export function normalizeAccounting(input: AccountingInput): NormalizedAccounting {
+  const originalBytes = nonNegative(input.originalBytes);
+  const transformedBytes = nonNegative(input.transformedBytes);
+  const bytesReduced = difference(originalBytes, transformedBytes);
+
+  const providerOriginal = nonNegative(input.providerBaselineInputTokens);
+  const providerActual = providerActualInputTokens(input);
+  const providerReduced = difference(providerOriginal, providerActual);
+
+  const estimatedOriginal = nonNegative(input.estimatedOriginalInputTokens);
+  const estimatedActual = nonNegative(input.estimatedTransformedInputTokens);
+  const estimatedReduced = difference(estimatedOriginal, estimatedActual);
+
+  let evidence: SavingsEvidence = 'unavailable';
+  let inputTokensReduced: number | undefined;
+  let inputReductionRatio: number | undefined;
+  if (providerReduced !== undefined) {
+    evidence = 'provider-reported';
+    inputTokensReduced = providerReduced;
+    inputReductionRatio = ratio(providerReduced, providerOriginal);
+  } else if (estimatedReduced !== undefined) {
+    evidence = 'estimated';
+    inputTokensReduced = estimatedReduced;
+    inputReductionRatio = ratio(estimatedReduced, estimatedOriginal);
+  } else if (bytesReduced !== undefined) {
+    evidence = 'bytes-only';
+  }
+
+  const output = nonNegative(input.providerOutputTokens);
+  const total = providerActual !== undefined && output !== undefined
+    ? providerActual + output
+    : undefined;
+
+  return {
+    provider: input.provider,
+    ...(input.model ? { model: input.model } : {}),
+    bytes: {
+      ...(originalBytes !== undefined ? { original: originalBytes } : {}),
+      ...(transformedBytes !== undefined ? { transformed: transformedBytes } : {}),
+      ...(bytesReduced !== undefined ? { reduced: bytesReduced } : {}),
+      ...(originalBytes !== undefined && originalBytes > 0 && transformedBytes !== undefined
+        ? { compressionRatio: transformedBytes / originalBytes }
+        : {}),
+    },
+    tokens: {
+      ...(providerOriginal !== undefined ? { providerReportedOriginalInput: providerOriginal } : {}),
+      ...(providerActual !== undefined ? { providerReportedActualInput: providerActual } : {}),
+      ...(providerReduced !== undefined ? { providerReportedReduced: providerReduced } : {}),
+      ...(estimatedOriginal !== undefined ? { estimatedOriginalInput: estimatedOriginal } : {}),
+      ...(estimatedActual !== undefined ? { estimatedActualInput: estimatedActual } : {}),
+      ...(estimatedReduced !== undefined ? { estimatedReduced } : {}),
+      ...(nonNegative(input.cacheReadTokens) !== undefined ? { cacheRead: input.cacheReadTokens } : {}),
+      ...(nonNegative(input.cacheWriteTokens) !== undefined ? { cacheWrite: input.cacheWriteTokens } : {}),
+      ...(nonNegative(input.imageTokens) !== undefined ? { image: input.imageTokens } : {}),
+      ...(output !== undefined ? { output } : {}),
+      ...(total !== undefined ? { total } : {}),
+    },
+    savings: {
+      evidence,
+      ...(inputTokensReduced !== undefined ? { inputTokensReduced } : {}),
+      ...(inputReductionRatio !== undefined ? { inputReductionRatio } : {}),
+    },
+    latency: {
+      ...(nonNegative(input.proxyAddedLatencyMs) !== undefined ? { proxyAddedMs: input.proxyAddedLatencyMs } : {}),
+      ...(nonNegative(input.modelLatencyMs) !== undefined ? { modelMs: input.modelLatencyMs } : {}),
+    },
+    fallbackCount: nonNegative(input.fallbackCount) ?? 0,
+    ...(input.bypassReason ? { bypassReason: input.bypassReason } : {}),
+  };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -41,3 +41,11 @@ export {
   CACHE_CREATE_RATE,
   CACHE_READ_RATE,
 } from './baseline.js';
+export {
+  normalizeAccounting,
+  providerActualInputTokens,
+  type AccountingInput,
+  type AccountingProvider,
+  type NormalizedAccounting,
+  type SavingsEvidence,
+} from './accounting.js';

--- a/tests/accounting-normalization.test.ts
+++ b/tests/accounting-normalization.test.ts
@@ -25,6 +25,59 @@ describe('provider input normalization', () => {
       })).toBe(1_000);
     },
   );
+
+  it.each([
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['fractional', 1.5],
+    ['unsafe', Number.MAX_SAFE_INTEGER + 1],
+  ] as const)(
+    'fails closed on a %s Anthropic cache-read counter',
+    (_label, malformed) => {
+      expect(providerActualInputTokens({
+        provider: 'anthropic',
+        providerInputTokens: 1_000,
+        cacheReadTokens: malformed,
+      })).toBeUndefined();
+    },
+  );
+
+  it.each([
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['fractional', 1.5],
+    ['unsafe', Number.MAX_SAFE_INTEGER + 1],
+  ] as const)(
+    'fails closed on a %s Anthropic cache-write counter',
+    (_label, malformed) => {
+      expect(providerActualInputTokens({
+        provider: 'anthropic',
+        providerInputTokens: 1_000,
+        cacheWriteTokens: malformed,
+      })).toBeUndefined();
+    },
+  );
+
+  it('fails closed when Anthropic bucket summation exceeds safe integer precision', () => {
+    expect(providerActualInputTokens({
+      provider: 'anthropic',
+      providerInputTokens: Number.MAX_SAFE_INTEGER,
+      cacheReadTokens: 1,
+    })).toBeUndefined();
+  });
+
+  it('does not guess cache semantics for an unknown provider', () => {
+    expect(providerActualInputTokens({
+      provider: 'unknown',
+      providerInputTokens: 1_000,
+      cacheReadTokens: 700,
+    })).toBeUndefined();
+
+    expect(providerActualInputTokens({
+      provider: 'unknown',
+      providerInputTokens: 1_000,
+    })).toBe(1_000);
+  });
 });
 
 describe('normalized accounting evidence', () => {
@@ -52,9 +105,11 @@ describe('normalized accounting evidence', () => {
       inputTokensReduced: 16_500,
       inputReductionRatio: 0.825,
     });
+
     expect(result.tokens.providerReportedActualInput).toBe(3_500);
     expect(result.tokens.total).toBe(3_800);
     expect(result.tokens.estimatedReduced).toBe(21_000);
+
     expect(result.bytes).toEqual({
       original: 100_000,
       transformed: 25_000,
@@ -69,10 +124,49 @@ describe('normalized accounting evidence', () => {
       estimatedOriginalInputTokens: 10_000,
       estimatedTransformedInputTokens: 4_000,
     });
+
     expect(result.savings).toEqual({
       evidence: 'estimated',
       inputTokensReduced: 6_000,
       inputReductionRatio: 0.6,
+    });
+  });
+
+  it('falls back to estimates when Anthropic usage buckets are malformed', () => {
+    const result = normalizeAccounting({
+      provider: 'anthropic',
+      providerBaselineInputTokens: 10_000,
+      providerInputTokens: 2_000,
+      cacheReadTokens: -1,
+      estimatedOriginalInputTokens: 10_000,
+      estimatedTransformedInputTokens: 4_000,
+    });
+
+    expect(result.tokens.providerReportedActualInput).toBeUndefined();
+    expect(result.tokens.providerReportedReduced).toBeUndefined();
+
+    expect(result.savings).toEqual({
+      evidence: 'estimated',
+      inputTokensReduced: 6_000,
+      inputReductionRatio: 0.6,
+    });
+  });
+
+  it('does not claim provider-reported savings when unknown cache semantics are present', () => {
+    const result = normalizeAccounting({
+      provider: 'unknown',
+      providerBaselineInputTokens: 10_000,
+      providerInputTokens: 2_000,
+      cacheReadTokens: 1_000,
+      originalBytes: 10_000,
+      transformedBytes: 4_000,
+    });
+
+    expect(result.tokens.providerReportedActualInput).toBeUndefined();
+    expect(result.tokens.providerReportedReduced).toBeUndefined();
+
+    expect(result.savings).toEqual({
+      evidence: 'bytes-only',
     });
   });
 
@@ -83,24 +177,70 @@ describe('normalized accounting evidence', () => {
       transformedBytes: 400,
       bypassReason: 'provider_usage_unavailable',
     });
+
     expect(result.savings.evidence).toBe('bytes-only');
     expect(result.savings.inputTokensReduced).toBeUndefined();
     expect(result.tokens.providerReportedReduced).toBeUndefined();
     expect(result.bypassReason).toBe('provider_usage_unavailable');
   });
 
-  it('never converts invalid negative counters into savings', () => {
+  it('never converts malformed discrete counters into savings', () => {
     const result = normalizeAccounting({
       provider: 'openai',
       providerBaselineInputTokens: -1,
-      providerInputTokens: -10,
-      originalBytes: -100,
+      providerInputTokens: 10.5,
+      estimatedOriginalInputTokens: Number.NaN,
+      estimatedTransformedInputTokens: 20,
+      originalBytes: 100.5,
       transformedBytes: 20,
-      fallbackCount: -3,
+      fallbackCount: 1.5,
     });
+
     expect(result.savings.evidence).toBe('unavailable');
     expect(result.bytes.original).toBeUndefined();
     expect(result.tokens.providerReportedActualInput).toBeUndefined();
+    expect(result.tokens.estimatedOriginalInput).toBeUndefined();
     expect(result.fallbackCount).toBe(0);
+  });
+
+  it('allows fractional latency measurements while rejecting negative latency', () => {
+    const result = normalizeAccounting({
+      provider: 'openai',
+      proxyAddedLatencyMs: 12.75,
+      modelLatencyMs: -1,
+    });
+
+    expect(result.latency).toEqual({
+      proxyAddedMs: 12.75,
+    });
+  });
+
+  it('preserves measured expansion as a negative reduction instead of hiding it', () => {
+    const result = normalizeAccounting({
+      provider: 'openai',
+      providerBaselineInputTokens: 1_000,
+      providerInputTokens: 1_250,
+    });
+
+    expect(result.savings).toEqual({
+      evidence: 'provider-reported',
+      inputTokensReduced: -250,
+      inputReductionRatio: -0.25,
+    });
+
+    expect(result.tokens.providerReportedReduced).toBe(-250);
+  });
+
+  it('does not emit an unsafe total-token sum', () => {
+    const result = normalizeAccounting({
+      provider: 'openai',
+      providerInputTokens: Number.MAX_SAFE_INTEGER,
+      providerOutputTokens: 1,
+    });
+
+    expect(result.tokens.providerReportedActualInput)
+      .toBe(Number.MAX_SAFE_INTEGER);
+
+    expect(result.tokens.total).toBeUndefined();
   });
 });

--- a/tests/accounting-normalization.test.ts
+++ b/tests/accounting-normalization.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeAccounting,
+  providerActualInputTokens,
+} from '../src/core/accounting.js';
+
+describe('provider input normalization', () => {
+  it('sums Anthropic disjoint cache buckets', () => {
+    expect(providerActualInputTokens({
+      provider: 'anthropic',
+      providerInputTokens: 100,
+      cacheReadTokens: 700,
+      cacheWriteTokens: 200,
+    })).toBe(1_000);
+  });
+
+  it.each(['openai', 'google', 'featherless'] as const)(
+    'does not double-count cached input for %s',
+    (provider) => {
+      expect(providerActualInputTokens({
+        provider,
+        providerInputTokens: 1_000,
+        cacheReadTokens: 700,
+      })).toBe(1_000);
+    },
+  );
+});
+
+describe('normalized accounting evidence', () => {
+  it('prefers provider-reported token reduction over estimates', () => {
+    const result = normalizeAccounting({
+      provider: 'anthropic',
+      model: 'claude-opus-5',
+      originalBytes: 100_000,
+      transformedBytes: 25_000,
+      providerBaselineInputTokens: 20_000,
+      providerInputTokens: 1_000,
+      cacheReadTokens: 2_000,
+      cacheWriteTokens: 500,
+      providerOutputTokens: 300,
+      estimatedOriginalInputTokens: 25_000,
+      estimatedTransformedInputTokens: 4_000,
+      imageTokens: 1_200,
+      proxyAddedLatencyMs: 85,
+      modelLatencyMs: 2_400,
+      fallbackCount: 1,
+    });
+
+    expect(result.savings).toEqual({
+      evidence: 'provider-reported',
+      inputTokensReduced: 16_500,
+      inputReductionRatio: 0.825,
+    });
+    expect(result.tokens.providerReportedActualInput).toBe(3_500);
+    expect(result.tokens.total).toBe(3_800);
+    expect(result.tokens.estimatedReduced).toBe(21_000);
+    expect(result.bytes).toEqual({
+      original: 100_000,
+      transformed: 25_000,
+      reduced: 75_000,
+      compressionRatio: 0.25,
+    });
+  });
+
+  it('labels token savings estimated when no provider baseline exists', () => {
+    const result = normalizeAccounting({
+      provider: 'openai',
+      estimatedOriginalInputTokens: 10_000,
+      estimatedTransformedInputTokens: 4_000,
+    });
+    expect(result.savings).toEqual({
+      evidence: 'estimated',
+      inputTokensReduced: 6_000,
+      inputReductionRatio: 0.6,
+    });
+  });
+
+  it('reports bytes-only evidence without inventing token savings', () => {
+    const result = normalizeAccounting({
+      provider: 'unknown',
+      originalBytes: 1_000,
+      transformedBytes: 400,
+      bypassReason: 'provider_usage_unavailable',
+    });
+    expect(result.savings.evidence).toBe('bytes-only');
+    expect(result.savings.inputTokensReduced).toBeUndefined();
+    expect(result.tokens.providerReportedReduced).toBeUndefined();
+    expect(result.bypassReason).toBe('provider_usage_unavailable');
+  });
+
+  it('never converts invalid negative counters into savings', () => {
+    const result = normalizeAccounting({
+      provider: 'openai',
+      providerBaselineInputTokens: -1,
+      providerInputTokens: -10,
+      originalBytes: -100,
+      transformedBytes: 20,
+      fallbackCount: -3,
+    });
+    expect(result.savings.evidence).toBe('unavailable');
+    expect(result.bytes.original).toBeUndefined();
+    expect(result.tokens.providerReportedActualInput).toBeUndefined();
+    expect(result.fallbackCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

Provider-reported usage, local estimates, and serialized-byte reduction are different evidence classes, and cache-token buckets do not have identical semantics across providers.

## Changes

Add a small provider-neutral accounting API that:

- distinguishes `provider-reported`, `estimated`, `bytes-only`, and `unavailable` evidence;
- treats Anthropic cache read/write buckets as disjoint from uncached input;
- treats OpenAI-compatible, Featherless, and Google cached tokens as subsets of input;
- prefers provider-reported baselines over estimates;
- never turns invalid or negative counters into savings;
- keeps PXPipe-added and model latency as separately supplied measurements;
- exports the normalization primitives from the core package.

## Scope

No dashboard or tracker rewiring is included.

This PR defines and tests the accounting contract only; it does not introduce a new savings claim.

## Validation

Validated from a branch based directly on current upstream `0.13.1`:

- production dependency audit;
- TypeScript typecheck;
- focused accounting tests;
- full test suite;
- build.

No raw prompts, credentials, session files, or machine identifiers are included.
