### PR TITLE
feat(router): add explicit provider router core

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -36,6 +36,16 @@ export {
 export { transformOpenAIChatCompletions, transformOpenAIResponses, resolveVisionCost, openAIVisionTokens } from './openai.js';
 export { createProxy, type ProxyConfig, type ProxyEvent } from './proxy.js';
 export {
+  createProviderRouter,
+  parseProviderRoute,
+  assertProviderId,
+  type ProviderProtocol,
+  type ProviderRouteDefinition,
+  type ProviderRouterConfig,
+  type ProviderRouterInspection,
+  type ParsedProviderRoute,
+} from './provider-router.js';
+export {
   computeActualInputEff,
   computeBaselineInputEff,
   CACHE_CREATE_RATE,

--- a/src/core/provider-router.ts
+++ b/src/core/provider-router.ts
@@ -1,0 +1,166 @@
+import { createProxy, type ProxyConfig, type ProxyEvent } from './proxy.js';
+
+export type ProviderProtocol = 'anthropic' | 'openai' | 'google';
+
+export interface ProviderRouteDefinition {
+  /** Stable route id used in `/providers/<id>/...`. */
+  id: string;
+  /** Wire protocol accepted by the configured upstream. */
+  protocol: ProviderProtocol;
+  /** Existing proxy configuration for this provider. Kept in memory only. */
+  proxy: ProxyConfig;
+}
+
+export interface ProviderRouterConfig {
+  /** Handles legacy unprefixed routes such as `/v1/messages`. */
+  defaultProxy: ProxyConfig;
+  /** Explicitly addressable providers. */
+  providers: readonly ProviderRouteDefinition[];
+  /** Optional observer invoked after the provider-specific observer. */
+  onRequest?: (providerId: string, event: ProxyEvent) => void | Promise<void>;
+}
+
+export interface ParsedProviderRoute {
+  providerId: string;
+  upstreamPath: string;
+}
+
+export interface ProviderRouterInspection {
+  defaultRoute: 'legacy';
+  providers: Array<{
+    id: string;
+    protocol: ProviderProtocol;
+    prefix: string;
+  }>;
+}
+
+const PROVIDER_ID = /^[a-z][a-z0-9-]{0,62}$/;
+const PREFIX = '/providers/';
+
+export function assertProviderId(id: string): void {
+  if (!PROVIDER_ID.test(id)) {
+    throw new Error(
+      `invalid provider id ${JSON.stringify(id)}; expected lowercase letters, digits and dashes`,
+    );
+  }
+}
+
+/**
+ * Parse an explicit provider-prefixed request path.
+ *
+ * The provider id is never accepted from a header, query string or body. This
+ * keeps routing metadata outside the model payload and prevents an untrusted
+ * client from overriding upstream selection through a forwarded header.
+ */
+export function parseProviderRoute(pathname: string): ParsedProviderRoute | null {
+  if (!pathname.startsWith(PREFIX)) return null;
+  const remainder = pathname.slice(PREFIX.length);
+  const slash = remainder.indexOf('/');
+  if (slash <= 0) return null;
+
+  const providerId = remainder.slice(0, slash);
+  if (!PROVIDER_ID.test(providerId)) return null;
+
+  const upstreamPath = remainder.slice(slash);
+  if (!upstreamPath.startsWith('/') || upstreamPath.startsWith('//')) return null;
+  return { providerId, upstreamPath };
+}
+
+function wrapProviderObserver(
+  definition: ProviderRouteDefinition,
+  routerObserver: ProviderRouterConfig['onRequest'],
+): ProxyConfig {
+  const providerObserver = definition.proxy.onRequest;
+  return {
+    ...definition.proxy,
+    onRequest: async (event) => {
+      // Keep provider identity explicit even for generic OpenAI-compatible
+      // providers whose core handler would otherwise leave it unset.
+      event.provider ??= definition.id;
+      await providerObserver?.(event);
+      await routerObserver?.(definition.id, event);
+    },
+  };
+}
+
+function rewriteProviderRequest(request: Request, route: ParsedProviderRoute): Request {
+  const sourceUrl = new URL(request.url);
+  sourceUrl.pathname = route.upstreamPath;
+
+  const bodyAllowed = request.method !== 'GET' && request.method !== 'HEAD';
+  const init: RequestInit & { duplex?: 'half' } = {
+    method: request.method,
+    headers: new Headers(request.headers),
+    body: bodyAllowed ? request.body : undefined,
+    redirect: request.redirect,
+    signal: request.signal,
+  };
+  if (request.body) init.duplex = 'half';
+
+  // The body stream is forwarded without decoding or re-encoding it. Tool
+  // schemas, prompts, binary parts and structured-output contracts remain
+  // untouched until the selected provider's normal transform pipeline runs.
+  return new Request(sourceUrl, init);
+}
+
+/**
+ * Create one request handler that multiplexes several provider-specific
+ * `createProxy` instances behind one Web-standard request handler.
+ *
+ * Legacy paths continue through `defaultProxy`. Explicit provider paths use:
+ *
+ *   /providers/<provider-id>/<upstream-path>
+ */
+export function createProviderRouter(
+  config: ProviderRouterConfig,
+): ((request: Request) => Promise<Response>) & { inspect(): ProviderRouterInspection } {
+  const defaultHandler = createProxy(config.defaultProxy);
+  const handlers = new Map<string, ReturnType<typeof createProxy>>();
+  const definitions = new Map<string, ProviderRouteDefinition>();
+
+  for (const definition of config.providers) {
+    assertProviderId(definition.id);
+    if (definitions.has(definition.id)) {
+      throw new Error(`duplicate provider id: ${definition.id}`);
+    }
+    definitions.set(definition.id, definition);
+    handlers.set(
+      definition.id,
+      createProxy(wrapProviderObserver(definition, config.onRequest)),
+    );
+  }
+
+  const route = async (request: Request): Promise<Response> => {
+    const parsed = parseProviderRoute(new URL(request.url).pathname);
+    if (!parsed) return defaultHandler(request);
+
+    const handler = handlers.get(parsed.providerId);
+    if (!handler) {
+      return new Response(
+        JSON.stringify({
+          error: 'unknown_provider',
+          provider: parsed.providerId,
+        }),
+        {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    }
+
+    return handler(rewriteProviderRequest(request, parsed));
+  };
+
+  return Object.assign(route, {
+    inspect(): ProviderRouterInspection {
+      return {
+        defaultRoute: 'legacy',
+        providers: [...definitions.values()].map((definition) => ({
+          id: definition.id,
+          protocol: definition.protocol,
+          prefix: `${PREFIX}${definition.id}`,
+        })),
+      };
+    },
+  });
+}

--- a/src/core/provider-router.ts
+++ b/src/core/provider-router.ts
@@ -100,6 +100,16 @@ function rewriteProviderRequest(request: Request, route: ParsedProviderRoute): R
   return new Request(sourceUrl, init);
 }
 
+function invalidProviderRoute(): Response {
+  return new Response(
+    JSON.stringify({ error: 'invalid_provider_route' }),
+    {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
 /**
  * Create one request handler that multiplexes several provider-specific
  * `createProxy` instances behind one Web-standard request handler.
@@ -128,8 +138,11 @@ export function createProviderRouter(
   }
 
   const route = async (request: Request): Promise<Response> => {
-    const parsed = parseProviderRoute(new URL(request.url).pathname);
-    if (!parsed) return defaultHandler(request);
+    const pathname = new URL(request.url).pathname;
+    const parsed = parseProviderRoute(pathname);
+    // `/providers/` is a reserved internal namespace. Malformed explicit routes
+    // must never fall through to the legacy/default upstream.
+    if (!parsed) return pathname.startsWith(PREFIX) ? invalidProviderRoute() : defaultHandler(request);
 
     const handler = handlers.get(parsed.providerId);
     if (!handler) {

--- a/src/core/provider-router.ts
+++ b/src/core/provider-router.ts
@@ -35,7 +35,8 @@ export interface ProviderRouterInspection {
 }
 
 const PROVIDER_ID = /^[a-z][a-z0-9-]{0,62}$/;
-const PREFIX = '/providers/';
+const PROVIDER_ROOT = '/providers';
+const PREFIX = `${PROVIDER_ROOT}/`;
 
 export function assertProviderId(id: string): void {
   if (!PROVIDER_ID.test(id)) {
@@ -64,6 +65,10 @@ export function parseProviderRoute(pathname: string): ParsedProviderRoute | null
   const upstreamPath = remainder.slice(slash);
   if (!upstreamPath.startsWith('/') || upstreamPath.startsWith('//')) return null;
   return { providerId, upstreamPath };
+}
+
+function isProviderNamespace(pathname: string): boolean {
+  return pathname === PROVIDER_ROOT || pathname.startsWith(PREFIX);
 }
 
 function wrapProviderObserver(
@@ -140,9 +145,9 @@ export function createProviderRouter(
   const route = async (request: Request): Promise<Response> => {
     const pathname = new URL(request.url).pathname;
     const parsed = parseProviderRoute(pathname);
-    // `/providers/` is a reserved internal namespace. Malformed explicit routes
+    // `/providers` is a reserved internal namespace. Malformed explicit routes
     // must never fall through to the legacy/default upstream.
-    if (!parsed) return pathname.startsWith(PREFIX) ? invalidProviderRoute() : defaultHandler(request);
+    if (!parsed) return isProviderNamespace(pathname) ? invalidProviderRoute() : defaultHandler(request);
 
     const handler = handlers.get(parsed.providerId);
     if (!handler) {

--- a/src/core/provider-router.ts
+++ b/src/core/provider-router.ts
@@ -74,9 +74,6 @@ function wrapProviderObserver(
   return {
     ...definition.proxy,
     onRequest: async (event) => {
-      // Keep provider identity explicit even for generic OpenAI-compatible
-      // providers whose core handler would otherwise leave it unset.
-      event.provider ??= definition.id;
       await providerObserver?.(event);
       await routerObserver?.(definition.id, event);
     },

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -56,6 +56,7 @@ describe('provider route parsing', () => {
 
   it('does not treat incomplete or malformed paths as valid provider routes', () => {
     expect(parseProviderRoute('/v1/messages')).toBeNull();
+    expect(parseProviderRoute('/providers')).toBeNull();
     expect(parseProviderRoute('/providers/')).toBeNull();
     expect(parseProviderRoute('/providers/OpenAI/v1/chat/completions')).toBeNull();
     expect(parseProviderRoute('/providers/openai-alt')).toBeNull();
@@ -159,6 +160,7 @@ describe('provider router', () => {
   });
 
   it.each([
+    '/providers',
     '/providers/',
     '/providers/OpenAI/v1/chat/completions',
     '/providers/openai-alt',

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -186,7 +186,7 @@ describe('provider router', () => {
     ));
     expect(response.status).toBe(200);
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe('https://legacy.example/v1/messages');
+    expect(calls[0]!.url).toBe('https://legacy.example/v1/messages?provider=openai-alt');
   });
 
   it('exposes only credential-free provider metadata', () => {

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -54,7 +54,7 @@ describe('provider route parsing', () => {
     });
   });
 
-  it('does not treat incomplete or malformed paths as explicit provider routes', () => {
+  it('does not treat incomplete or malformed paths as valid provider routes', () => {
     expect(parseProviderRoute('/v1/messages')).toBeNull();
     expect(parseProviderRoute('/providers/')).toBeNull();
     expect(parseProviderRoute('/providers/OpenAI/v1/chat/completions')).toBeNull();
@@ -155,6 +155,33 @@ describe('provider router', () => {
       error: 'unknown_provider',
       provider: 'not-configured',
     });
+    expect(calls).toHaveLength(0);
+  });
+
+  it.each([
+    '/providers/',
+    '/providers/OpenAI/v1/chat/completions',
+    '/providers/openai-alt',
+    '/providers/openai-alt//v1/chat/completions',
+  ])('fails malformed reserved provider route %s closed', async (pathname) => {
+    const calls: FetchCall[] = [];
+    installEchoFetch(calls);
+    const router = createProviderRouter({
+      defaultProxy: { upstream: 'https://legacy.example' },
+      providers: [{
+        id: 'openai-alt',
+        protocol: 'openai',
+        proxy: { openAIUpstream: 'https://api.openai-alt.example' },
+      }],
+    });
+
+    const response = await router(new Request(`http://127.0.0.1:47821${pathname}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    }));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'invalid_provider_route' });
     expect(calls).toHaveLength(0);
   });
 

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  assertProviderId,
+  createProviderRouter,
+  parseProviderRoute,
+} from '../src/core/provider-router.js';
+
+function echoFetch(calls: Array<{ url: string; body: string; authorization: string | null }>): typeof fetch {
+  return vi.fn<typeof fetch>(async (input, init) => {
+    const request = input instanceof Request
+      ? input
+      : new Request(String(input), {
+          ...init,
+          ...(init?.body ? { duplex: 'half' as const } : {}),
+        });
+    const body = request.method === 'GET' || request.method === 'HEAD'
+      ? ''
+      : await request.text();
+    calls.push({
+      url: request.url,
+      body,
+      authorization: request.headers.get('authorization'),
+    });
+    return new Response(JSON.stringify({ url: request.url, body }), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'x-upstream': new URL(request.url).hostname,
+      },
+    });
+  });
+}
+
+describe('provider route parsing', () => {
+  it('accepts explicit provider paths and strips only the internal prefix', () => {
+    expect(parseProviderRoute('/providers/featherless/v1/chat/completions')).toEqual({
+      providerId: 'featherless',
+      upstreamPath: '/v1/chat/completions',
+    });
+    expect(parseProviderRoute('/providers/anthropic/v1/messages')).toEqual({
+      providerId: 'anthropic',
+      upstreamPath: '/v1/messages',
+    });
+  });
+
+  it('does not treat incomplete or malformed paths as explicit provider routes', () => {
+    expect(parseProviderRoute('/v1/messages')).toBeNull();
+    expect(parseProviderRoute('/providers/')).toBeNull();
+    expect(parseProviderRoute('/providers/Featherless/v1/chat/completions')).toBeNull();
+    expect(parseProviderRoute('/providers/featherless')).toBeNull();
+    expect(parseProviderRoute('/providers/featherless//v1/chat/completions')).toBeNull();
+  });
+
+  it('validates provider identifiers', () => {
+    expect(() => assertProviderId('featherless')).not.toThrow();
+    expect(() => assertProviderId('openai-compatible')).not.toThrow();
+    expect(() => assertProviderId('Bad_Id')).toThrow(/invalid provider id/);
+    expect(() => assertProviderId('')).toThrow(/invalid provider id/);
+  });
+});
+
+describe('provider router', () => {
+  it('routes explicit providers while preserving query, body and response headers', async () => {
+    const defaultCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const featherlessCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const observed: string[] = [];
+
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy.example',
+        customFetch: echoFetch(defaultCalls),
+      },
+      providers: [{
+        id: 'featherless',
+        protocol: 'openai',
+        proxy: {
+          provider: 'featherless',
+          openAIUpstream: 'https://api.featherless.example',
+          featherlessTransformMode: 'off',
+          customFetch: echoFetch(featherlessCalls),
+          onRequest: (event) => observed.push(`provider:${event.provider}`),
+        },
+      }],
+      onRequest: (providerId, event) => {
+        observed.push(`router:${providerId}:${event.provider}`);
+      },
+    });
+
+    const raw = '{"model":"moonshotai/Kimi-K3","messages":[],"spacing":"  preserved  "}';
+    const response = await router(new Request(
+      'http://127.0.0.1:47821/providers/featherless/v1/chat/completions?trace=one',
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer incoming-token',
+          'content-type': 'application/json',
+        },
+        body: raw,
+      },
+    ));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-upstream')).toBe('api.featherless.example');
+    expect(featherlessCalls).toHaveLength(1);
+    expect(featherlessCalls[0]!.url).toBe('https://api.featherless.example/v1/chat/completions?trace=one');
+    expect(featherlessCalls[0]!.authorization).toBe('Bearer incoming-token');
+    expect(featherlessCalls[0]!.body).toBe(raw);
+    await response.text();
+
+    await vi.waitFor(() => {
+      expect(observed).toEqual([
+        'provider:featherless',
+        'router:featherless:featherless',
+      ]);
+    });
+  });
+
+  it('keeps legacy unprefixed routes on the default proxy', async () => {
+    const calls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy-anthropic.example',
+        customFetch: echoFetch(calls),
+      },
+      providers: [],
+    });
+
+    const response = await router(new Request('http://127.0.0.1:47821/v1/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'unsupported-test-model',
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    }));
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://legacy-anthropic.example/v1/messages');
+  });
+
+  it('fails unknown explicit providers closed without contacting any upstream', async () => {
+    const calls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy.example',
+        customFetch: echoFetch(calls),
+      },
+      providers: [],
+    });
+
+    const response = await router(new Request(
+      'http://127.0.0.1:47821/providers/not-configured/v1/messages',
+      { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' },
+    ));
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: 'unknown_provider',
+      provider: 'not-configured',
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('does not let query/header/body provider hints change the selected route', async () => {
+    const defaultCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const explicitCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy.example',
+        customFetch: echoFetch(defaultCalls),
+      },
+      providers: [{
+        id: 'featherless',
+        protocol: 'openai',
+        proxy: {
+          provider: 'featherless',
+          openAIUpstream: 'https://api.featherless.example',
+          featherlessTransformMode: 'off',
+          customFetch: echoFetch(explicitCalls),
+        },
+      }],
+    });
+
+    const response = await router(new Request(
+      'http://127.0.0.1:47821/v1/messages?provider=featherless',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-pxpipe-provider': 'featherless',
+        },
+        body: JSON.stringify({ provider: 'featherless', messages: [] }),
+      },
+    ));
+    expect(response.status).toBe(200);
+    expect(defaultCalls).toHaveLength(1);
+    expect(explicitCalls).toHaveLength(0);
+  });
+
+  it('exposes only credential-free provider metadata', () => {
+    const router = createProviderRouter({
+      defaultProxy: { upstream: 'https://legacy.example', apiKey: 'default-secret' },
+      providers: [{
+        id: 'featherless',
+        protocol: 'openai',
+        proxy: {
+          provider: 'featherless',
+          openAIUpstream: 'https://api.featherless.example',
+          openAIApiKey: 'provider-secret',
+        },
+      }],
+    });
+    expect(router.inspect()).toEqual({
+      defaultRoute: 'legacy',
+      providers: [{
+        id: 'featherless',
+        protocol: 'openai',
+        prefix: '/providers/featherless',
+      }],
+    });
+    expect(JSON.stringify(router.inspect())).not.toContain('secret');
+  });
+
+  it('rejects duplicate provider ids', () => {
+    expect(() => createProviderRouter({
+      defaultProxy: { upstream: 'https://legacy.example' },
+      providers: [
+        { id: 'same', protocol: 'anthropic', proxy: { upstream: 'https://a.example' } },
+        { id: 'same', protocol: 'openai', proxy: { openAIUpstream: 'https://b.example' } },
+      ],
+    })).toThrow(/duplicate provider id/);
+  });
+});

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   assertProviderId,
@@ -6,8 +6,14 @@ import {
   parseProviderRoute,
 } from '../src/core/provider-router.js';
 
-function echoFetch(calls: Array<{ url: string; body: string; authorization: string | null }>): typeof fetch {
-  return vi.fn<typeof fetch>(async (input, init) => {
+interface FetchCall {
+  url: string;
+  body: string;
+  authorization: string | null;
+}
+
+function installEchoFetch(calls: FetchCall[]): void {
+  vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (input, init) => {
     const request = input instanceof Request
       ? input
       : new Request(String(input), {
@@ -29,13 +35,17 @@ function echoFetch(calls: Array<{ url: string; body: string; authorization: stri
         'x-upstream': new URL(request.url).hostname,
       },
     });
-  });
+  }));
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('provider route parsing', () => {
   it('accepts explicit provider paths and strips only the internal prefix', () => {
-    expect(parseProviderRoute('/providers/featherless/v1/chat/completions')).toEqual({
-      providerId: 'featherless',
+    expect(parseProviderRoute('/providers/openai-alt/v1/chat/completions')).toEqual({
+      providerId: 'openai-alt',
       upstreamPath: '/v1/chat/completions',
     });
     expect(parseProviderRoute('/providers/anthropic/v1/messages')).toEqual({
@@ -47,13 +57,13 @@ describe('provider route parsing', () => {
   it('does not treat incomplete or malformed paths as explicit provider routes', () => {
     expect(parseProviderRoute('/v1/messages')).toBeNull();
     expect(parseProviderRoute('/providers/')).toBeNull();
-    expect(parseProviderRoute('/providers/Featherless/v1/chat/completions')).toBeNull();
-    expect(parseProviderRoute('/providers/featherless')).toBeNull();
-    expect(parseProviderRoute('/providers/featherless//v1/chat/completions')).toBeNull();
+    expect(parseProviderRoute('/providers/OpenAI/v1/chat/completions')).toBeNull();
+    expect(parseProviderRoute('/providers/openai-alt')).toBeNull();
+    expect(parseProviderRoute('/providers/openai-alt//v1/chat/completions')).toBeNull();
   });
 
   it('validates provider identifiers', () => {
-    expect(() => assertProviderId('featherless')).not.toThrow();
+    expect(() => assertProviderId('anthropic')).not.toThrow();
     expect(() => assertProviderId('openai-compatible')).not.toThrow();
     expect(() => assertProviderId('Bad_Id')).toThrow(/invalid provider id/);
     expect(() => assertProviderId('')).toThrow(/invalid provider id/);
@@ -61,35 +71,28 @@ describe('provider route parsing', () => {
 });
 
 describe('provider router', () => {
-  it('routes explicit providers while preserving query, body and response headers', async () => {
-    const defaultCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
-    const featherlessCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+  it('routes an explicit OpenAI provider while preserving query, body and auth', async () => {
+    const calls: FetchCall[] = [];
     const observed: string[] = [];
+    installEchoFetch(calls);
 
     const router = createProviderRouter({
-      defaultProxy: {
-        upstream: 'https://legacy.example',
-        customFetch: echoFetch(defaultCalls),
-      },
+      defaultProxy: { upstream: 'https://legacy.example' },
       providers: [{
-        id: 'featherless',
+        id: 'openai-alt',
         protocol: 'openai',
         proxy: {
-          provider: 'featherless',
-          openAIUpstream: 'https://api.featherless.example',
-          featherlessTransformMode: 'off',
-          customFetch: echoFetch(featherlessCalls),
-          onRequest: (event) => observed.push(`provider:${event.provider}`),
+          openAIUpstream: 'https://api.openai-alt.example',
+          openAIModels: ['gpt-test'],
+          onRequest: () => observed.push('provider-observer'),
         },
       }],
-      onRequest: (providerId, event) => {
-        observed.push(`router:${providerId}:${event.provider}`);
-      },
+      onRequest: (providerId) => observed.push(`router:${providerId}`),
     });
 
-    const raw = '{"model":"moonshotai/Kimi-K3","messages":[],"spacing":"  preserved  "}';
+    const raw = '{"model":"gpt-test","messages":[],"spacing":"  preserved  "}';
     const response = await router(new Request(
-      'http://127.0.0.1:47821/providers/featherless/v1/chat/completions?trace=one',
+      'http://127.0.0.1:47821/providers/openai-alt/v1/chat/completions?trace=one',
       {
         method: 'POST',
         headers: {
@@ -101,28 +104,23 @@ describe('provider router', () => {
     ));
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('x-upstream')).toBe('api.featherless.example');
-    expect(featherlessCalls).toHaveLength(1);
-    expect(featherlessCalls[0]!.url).toBe('https://api.featherless.example/v1/chat/completions?trace=one');
-    expect(featherlessCalls[0]!.authorization).toBe('Bearer incoming-token');
-    expect(featherlessCalls[0]!.body).toBe(raw);
+    expect(response.headers.get('x-upstream')).toBe('api.openai-alt.example');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://api.openai-alt.example/v1/chat/completions?trace=one');
+    expect(calls[0]!.authorization).toBe('Bearer incoming-token');
+    expect(calls[0]!.body).toBe(raw);
     await response.text();
 
     await vi.waitFor(() => {
-      expect(observed).toEqual([
-        'provider:featherless',
-        'router:featherless:featherless',
-      ]);
+      expect(observed).toEqual(['provider-observer', 'router:openai-alt']);
     });
   });
 
   it('keeps legacy unprefixed routes on the default proxy', async () => {
-    const calls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const calls: FetchCall[] = [];
+    installEchoFetch(calls);
     const router = createProviderRouter({
-      defaultProxy: {
-        upstream: 'https://legacy-anthropic.example',
-        customFetch: echoFetch(calls),
-      },
+      defaultProxy: { upstream: 'https://legacy-anthropic.example' },
       providers: [],
     });
 
@@ -140,13 +138,11 @@ describe('provider router', () => {
     expect(calls[0]!.url).toBe('https://legacy-anthropic.example/v1/messages');
   });
 
-  it('fails unknown explicit providers closed without contacting any upstream', async () => {
-    const calls: Array<{ url: string; body: string; authorization: string | null }> = [];
+  it('fails unknown explicit providers closed without contacting an upstream', async () => {
+    const calls: FetchCall[] = [];
+    installEchoFetch(calls);
     const router = createProviderRouter({
-      defaultProxy: {
-        upstream: 'https://legacy.example',
-        customFetch: echoFetch(calls),
-      },
+      defaultProxy: { upstream: 'https://legacy.example' },
       providers: [],
     });
 
@@ -162,51 +158,45 @@ describe('provider router', () => {
     expect(calls).toHaveLength(0);
   });
 
-  it('does not let query/header/body provider hints change the selected route', async () => {
-    const defaultCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
-    const explicitCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+  it('does not let query/header/body hints select an explicit provider', async () => {
+    const calls: FetchCall[] = [];
+    installEchoFetch(calls);
     const router = createProviderRouter({
-      defaultProxy: {
-        upstream: 'https://legacy.example',
-        customFetch: echoFetch(defaultCalls),
-      },
+      defaultProxy: { upstream: 'https://legacy.example' },
       providers: [{
-        id: 'featherless',
+        id: 'openai-alt',
         protocol: 'openai',
         proxy: {
-          provider: 'featherless',
-          openAIUpstream: 'https://api.featherless.example',
-          featherlessTransformMode: 'off',
-          customFetch: echoFetch(explicitCalls),
+          openAIUpstream: 'https://api.openai-alt.example',
+          openAIModels: ['gpt-test'],
         },
       }],
     });
 
     const response = await router(new Request(
-      'http://127.0.0.1:47821/v1/messages?provider=featherless',
+      'http://127.0.0.1:47821/v1/messages?provider=openai-alt',
       {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
-          'x-pxpipe-provider': 'featherless',
+          'x-pxpipe-provider': 'openai-alt',
         },
-        body: JSON.stringify({ provider: 'featherless', messages: [] }),
+        body: JSON.stringify({ provider: 'openai-alt', messages: [] }),
       },
     ));
     expect(response.status).toBe(200);
-    expect(defaultCalls).toHaveLength(1);
-    expect(explicitCalls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://legacy.example/v1/messages');
   });
 
   it('exposes only credential-free provider metadata', () => {
     const router = createProviderRouter({
       defaultProxy: { upstream: 'https://legacy.example', apiKey: 'default-secret' },
       providers: [{
-        id: 'featherless',
+        id: 'openai-alt',
         protocol: 'openai',
         proxy: {
-          provider: 'featherless',
-          openAIUpstream: 'https://api.featherless.example',
+          openAIUpstream: 'https://api.openai-alt.example',
           openAIApiKey: 'provider-secret',
         },
       }],
@@ -214,9 +204,9 @@ describe('provider router', () => {
     expect(router.inspect()).toEqual({
       defaultRoute: 'legacy',
       providers: [{
-        id: 'featherless',
+        id: 'openai-alt',
         protocol: 'openai',
-        prefix: '/providers/featherless',
+        prefix: '/providers/openai-alt',
       }],
     });
     expect(JSON.stringify(router.inspect())).not.toContain('secret');


### PR DESCRIPTION
## Problem

A single PXPipe listener needs a way to select isolated provider configurations without trusting routing hints embedded in model payloads, headers, or query parameters.

## Changes

- add explicit `/providers/<id>/<upstream-path>` routing;
- select providers from the URL path only;
- preserve request body streams, query strings, headers, and legacy unprefixed routes;
- keep each provider on its own existing `ProxyConfig`;
- fail unknown explicit providers closed before contacting an upstream;
- validate provider identifiers and duplicates;
- expose credential-free route inspection;
- compose provider-specific and router-level request observers;
- export the router through the core package;
- add routing/isolation regression tests.

## Scope

No Node-host migration, AGY integration, Codex launcher, dashboard work, or provider discovery is included.

## Validation

Validated from a branch based directly on current upstream `0.13.1`:

- production dependency audit;
- TypeScript typecheck;
- focused router tests;
- full test suite;
- build.

No raw prompts, credentials, session files, or machine identifiers are included.
