### PR TITLE
feat(codex): preserve prompt cache during history optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,38 @@ normally — pxpipe compresses the *request* only, never the model's output.
 Recent turns stay text; the system prompt, tool docs, and older bulk history
 are imaged.
 
+### `pxpipe codex`
+
+Codex has a dedicated native Responses integration. Start the persistent PXPipe
+listener normally, then launch Codex through it:
+
+```bash
+pxpipe codex
+pxpipe codex --binary codex-ar
+```
+
+The launcher preserves Codex-owned ChatGPT authentication and `CODEX_HOME`,
+routes `/backend-api/codex/responses` through PXPipe, and leaves native
+`/responses/compact` traffic untouched. If the listener is unavailable it
+falls back to a direct Codex launch without rewriting the caller environment.
+
+Use `pxpipe codex --direct` to request the direct path explicitly.
+
+See [docs/CODEX_INTEGRATION.md](docs/CODEX_INTEGRATION.md) for the routing and
+authentication contract.
+
 ### `pxpipe warp`
 
 ```bash
-pxpipe warp -- claude          # also: cursor-agent, codex, or a shell alias
+pxpipe warp -- claude          # also: cursor-agent or a shell alias
 ```
 
 Same thing without `ANTHROPIC_BASE_URL`, so `/remote-control`, claude.ai
 connectors, and first-party gates keep working. Full instructions in the
 dashboard.
+
+For Codex, prefer the dedicated `pxpipe codex` launcher above rather than the
+Anthropic-oriented Warp path.
 
 `api.anthropic.com/v1/messages` is routed by default. Agents that reach their
 provider over some other base URL need a rule for it, and a rule that names a

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
-// Tiny shim: just runs the bundled Node entry. Real CLI logic lives in src/node.ts.
-import('../dist/node.js').catch((err) => {
+// Tiny shim: dispatch the dedicated Codex launcher before the bundled server
+// entry. All other CLI logic remains in src/node.ts.
+const entry = process.argv[2] === 'codex' ? '../dist/codex-entry.js' : '../dist/node.js';
+import(entry).catch((err) => {
   console.error('[pxpipe] failed to start:', err);
   console.error('[pxpipe] did you forget to `npm run build`?');
   process.exit(1);

--- a/docs/CODEX_INTEGRATION.md
+++ b/docs/CODEX_INTEGRATION.md
@@ -43,3 +43,47 @@ Model selection is read-only. Explicit Codex model arguments win, then the
 selected profile model, then top-level `config.toml`. When no persistent model
 can be resolved, PXPipe leaves model selection to the installed Codex CLI
 instead of injecting a reference model.
+
+## Cache-first history optimization
+
+The dedicated Codex route can apply a stricter Responses-history admission
+policy than generic OpenAI-compatible traffic. The purpose is not to transform
+more often; it is to avoid replacing a valuable warm prompt prefix for a small
+raw text/image win.
+
+The optimizer follows these rules:
+
+1. Completed `function_call` and `custom_tool_call` rounds are paired with their
+   matching outputs by `call_id`. Open, orphaned, malformed and referenced
+   protocol state remains native and acts as a boundary.
+2. Eligible cold history is divided into deterministic sealed sections. The
+   newest incomplete section stays native so appending one more turn does not
+   rewrite all previously emitted images.
+3. A complete history plan must clear absolute, relative and per-image net
+   saving floors after image cost and PXPipe's native framing/fact-sheet text.
+4. After process start, the first eligible turn stays native so provider usage
+   can establish whether the existing Codex prefix is already warm.
+5. A warm native prefix is preserved. A cold/low-cache prefix may transition to
+   images when the materiality gate passes.
+6. Once a compressed prefix is warm, later transforms may only append sections
+   when every previously emitted synthetic Responses segment remains an exact
+   hash prefix. A mutation falls back to native history for that turn.
+7. Provider-reported `input_tokens` and `cached_tokens` are the cache signal.
+   Both counters must be explicitly present and internally valid before they can
+   change adaptive state; missing or malformed cache telemetry is treated as
+   unknown rather than as a cold-cache observation. Cache state is scoped by a
+   short SHA-256 fingerprint of Codex's `thread-id`; the raw thread identifier is
+   not retained. This is intentionally narrower than Codex's provider prompt-cache
+   namespace: root and subagent requests may share a session-level cache lineage
+   while still owning different history trajectories. The in-memory observer
+   therefore never transfers adaptive admission state between distinct threads.
+   It stores only bounded token counts and short hashes of synthetic segments; it
+   stores no prompt, tool input or tool output text.
+8. Native `/responses/compact` is never transformed by this policy. A successful
+   native compaction invalidates the previous per-thread cache observation because
+   Codex keeps the thread identity while replacing its history. The next eligible
+   regular request therefore performs a fresh native observation before creating
+   another image epoch.
+
+The cache-first policy is enabled only on the dedicated `codex` provider route.
+Generic OpenAI-compatible callers retain their existing history behavior.

--- a/docs/CODEX_INTEGRATION.md
+++ b/docs/CODEX_INTEGRATION.md
@@ -1,0 +1,45 @@
+# Codex integration
+
+PXPipe can launch Codex through the existing persistent loopback listener without
+rewriting Codex authentication files or replacing the native Responses API.
+
+```bash
+pxpipe codex
+pxpipe codex --binary codex-ar
+```
+
+The launcher installs temporary Codex provider overrides for the child process:
+
+- provider id: `pxpipe`;
+- provider display name: `OpenAI`;
+- wire API: `responses`;
+- auth: Codex/OpenAI auth remains owned by the caller;
+- base URL: `http://127.0.0.1:<PORT>/providers/codex/backend-api/codex`.
+
+`CODEX_HOME` is not changed, so alternate wrappers/accounts keep their own
+configuration and authentication state. While routing through PXPipe,
+`OPENAI_BASE_URL` and inherited loopback proxy variables are removed from the
+child because provider routing is expressed through Codex's model-provider
+configuration instead. Explicit `--direct` mode and the automatic fallback used
+when no persistent listener is available preserve the caller environment
+unchanged.
+
+The persistent Node listener owns an isolated `codex` provider route whose
+Anthropic/default and OpenAI upstream bases both point to `https://chatgpt.com`.
+The route does not inherit alternate gateway routing, gateway headers, API keys,
+or Cloudflare provider credentials from the default listener. That lets normal
+`/backend-api/codex/responses` requests use PXPipe's existing Responses
+transform/accounting path while native endpoints such as `/responses/compact`
+remain pass-through requests on the same authenticated origin.
+
+PXPipe does not claim WebSocket Responses support here; the provider override
+sets `supports_websockets=false`. Use the dedicated `pxpipe codex` launcher,
+not the Anthropic-oriented Warp path.
+
+If the persistent listener is unavailable, the launcher prints a warning and
+starts Codex directly. `--direct` requests that behavior explicitly.
+
+Model selection is read-only. Explicit Codex model arguments win, then the
+selected profile model, then top-level `config.toml`. When no persistent model
+can be resolved, PXPipe leaves model selection to the installed Codex CLI
+instead of injecting a reference model.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "assets/*LICENSE.txt",
     "README.md",
     "SECURITY.md",
+    "docs/CODEX_INTEGRATION.md",
     "docs/SECURITY_MODEL.md",
     "LICENSE"
   ],

--- a/src/codex-entry.ts
+++ b/src/codex-entry.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  buildCodexCommandArgs,
+  buildCodexEnvironment,
+  parseCodexInvocation,
+  resolveCodexPersistentProxy,
+} from './core/codex.js';
+import { resolveCodexModelSelection } from './core/codex-model.js';
+
+const REFERENCE_MODEL = 'gpt-5.6-sol';
+
+function readCodexConfig(env: NodeJS.ProcessEnv): string | undefined {
+  const root = env.CODEX_HOME?.trim() || join(homedir(), '.codex');
+  try { return readFileSync(join(root, 'config.toml'), 'utf8'); }
+  catch { return undefined; }
+}
+
+function launch(binary: string, args: string[], env: NodeJS.ProcessEnv): void {
+  const child = spawn(binary, args, { stdio: 'inherit', env });
+  const handlers = new Map<NodeJS.Signals, () => void>();
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'] as const) {
+    const handler = (): void => { child.kill(signal); };
+    handlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+  const cleanup = (): void => {
+    for (const [signal, handler] of handlers) process.off(signal, handler);
+  };
+  child.on('error', (error) => {
+    cleanup();
+    console.error(`[pxpipe] codex: cannot run ${binary}: ${error.message}`);
+    process.exitCode = 127;
+  });
+  child.on('exit', (code, signal) => {
+    cleanup();
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exitCode = code ?? 0;
+  });
+}
+
+async function main(): Promise<void> {
+  let invocation;
+  try {
+    invocation = parseCodexInvocation(process.argv.slice(2));
+  } catch (error) {
+    console.error(`[pxpipe] codex: ${(error as Error).message}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const directEnv = buildCodexEnvironment(process.env, 'direct');
+  if (invocation.direct) {
+    launch(invocation.binary, invocation.args, directEnv);
+    return;
+  }
+
+  const proxy = await resolveCodexPersistentProxy(process.env);
+  if (!proxy) {
+    console.warn('[pxpipe] codex: persistent listener unavailable; launching Codex direct');
+    launch(invocation.binary, invocation.args, directEnv);
+    return;
+  }
+
+  const childEnv = buildCodexEnvironment(process.env, 'proxied');
+
+  const selection = resolveCodexModelSelection(
+    invocation.args,
+    readCodexConfig(process.env),
+    REFERENCE_MODEL,
+  );
+  // Do not inject the diagnostic reference fallback into Codex. If no user
+  // model can be resolved, leave model selection to the installed Codex CLI.
+  const resolvedModel = selection.source === 'reference' ? undefined : selection.model;
+  const args = buildCodexCommandArgs(proxy.baseUrl, invocation.args, resolvedModel);
+  console.error(`[pxpipe] codex → 127.0.0.1:${proxy.port} (native Responses route)`);
+  launch(invocation.binary, args, childEnv);
+}
+
+void main();

--- a/src/core/codex-cache-state.ts
+++ b/src/core/codex-cache-state.ts
@@ -1,0 +1,137 @@
+/**
+ * Small in-memory cache observation store for the dedicated Codex route.
+ *
+ * OpenAI prompt caching is automatic and prefix-based. A history transform that
+ * rewrites an already-warm prefix can cost far more than the raw text→image
+ * delta saves. The transform path therefore needs one fact from the PREVIOUS
+ * accepted request in the same Codex trajectory: was that request already warm,
+ * and which frozen history wire segments did it send?
+ *
+ * No prompt/tool text is retained here. Keys are opaque per-thread SHA-256
+ * fingerprints supplied by the proxy, and segment values are sha8 digests of
+ * exact synthetic Responses items.
+ */
+
+const MAX_SESSIONS = 512;
+
+export interface CodexCacheHint {
+  readonly inputTokens: number;
+  readonly cachedTokens: number;
+  readonly cacheShare: number;
+  readonly compressed: boolean;
+  readonly historySegmentShas: readonly string[];
+  readonly lastSeenMs: number;
+}
+
+export interface CodexCacheOutcome {
+  inputTokens?: number;
+  cachedTokens?: number;
+  compressed: boolean;
+  historySegmentShas?: readonly string[];
+}
+
+interface RecordState {
+  inputTokens: number;
+  cachedTokens: number;
+  compressed: boolean;
+  historySegmentShas: string[];
+  lastSeenMs: number;
+}
+
+const sessions = new Map<string, RecordState>();
+
+function nonNegativeSafeInteger(value: number | undefined): number | undefined {
+  return typeof value === 'number'
+    && Number.isSafeInteger(value)
+    && value >= 0
+    ? value
+    : undefined;
+}
+
+function touch(key: string, value: RecordState): void {
+  sessions.delete(key);
+  sessions.set(key, value);
+
+  while (sessions.size > MAX_SESSIONS) {
+    const oldest = sessions.keys().next().value;
+    if (oldest === undefined) break;
+    sessions.delete(oldest);
+  }
+}
+
+export function getCodexCacheHint(
+  sessionKey: string | undefined,
+): CodexCacheHint | undefined {
+  if (!sessionKey) return undefined;
+
+  const state = sessions.get(sessionKey);
+  if (!state) return undefined;
+
+  touch(sessionKey, state);
+
+  return {
+    inputTokens: state.inputTokens,
+    cachedTokens: state.cachedTokens,
+    cacheShare: state.cachedTokens / state.inputTokens,
+    compressed: state.compressed,
+    historySegmentShas: [...state.historySegmentShas],
+    lastSeenMs: state.lastSeenMs,
+  };
+}
+
+/**
+ * Record only complete, provider-grounded cache telemetry.
+ *
+ * `cachedTokens` is intentionally required. Missing cache details mean cache
+ * status is unknown, not zero. Malformed counters and an impossible cached
+ * subset larger than total input also fail closed and leave the last trustworthy
+ * observation untouched.
+ */
+export function noteCodexCacheOutcome(
+  sessionKey: string | undefined,
+  outcome: CodexCacheOutcome,
+  nowMs: number = Date.now(),
+): void {
+  if (!sessionKey) return;
+
+  const inputTokens = nonNegativeSafeInteger(outcome.inputTokens);
+  const cachedTokens = nonNegativeSafeInteger(outcome.cachedTokens);
+
+  if (
+    inputTokens === undefined
+    || inputTokens <= 0
+    || cachedTokens === undefined
+    || cachedTokens > inputTokens
+  ) {
+    return;
+  }
+
+  touch(sessionKey, {
+    inputTokens,
+    cachedTokens,
+    compressed: outcome.compressed,
+    historySegmentShas: outcome.compressed
+      ? [...(outcome.historySegmentShas ?? [])]
+      : [],
+    lastSeenMs: nowMs,
+  });
+}
+
+/**
+ * Drop one trajectory's adaptive observation.
+ *
+ * A successful native Codex compaction replaces the request history while
+ * retaining the thread identity. The previous token/cache measurement therefore
+ * no longer describes the new trajectory and must not authorize a transition.
+ */
+export function invalidateCodexCacheState(
+  sessionKey: string | undefined,
+): void {
+  if (!sessionKey) return;
+  sessions.delete(sessionKey);
+}
+
+/** Tests only. */
+export function clearCodexCacheState(): void {
+  sessions.clear();
+}

--- a/src/core/codex-model.ts
+++ b/src/core/codex-model.ts
@@ -1,0 +1,155 @@
+/** Narrow, read-only Codex model-selection helpers. */
+
+export type CodexModelSource = 'cli' | 'profile' | 'config' | 'reference';
+
+export interface CodexModelSelection {
+  model: string;
+  source: CodexModelSource;
+  profile?: string;
+}
+
+interface ParsedCodexConfig {
+  model?: string;
+  profile?: string;
+  profileModels: Map<string, string>;
+}
+
+function stripTomlComment(raw: string): string {
+  let quote: 'single' | 'double' | null = null;
+  let escaped = false;
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i]!;
+    if (quote === 'double') {
+      if (escaped) { escaped = false; continue; }
+      if (ch === '\\') { escaped = true; continue; }
+      if (ch === '"') quote = null;
+      continue;
+    }
+    if (quote === 'single') {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (ch === '"') quote = 'double';
+    else if (ch === "'") quote = 'single';
+    else if (ch === '#') return raw.slice(0, i);
+  }
+  return raw;
+}
+
+function unquoteTomlScalar(raw: string): string | undefined {
+  const value = stripTomlComment(raw).trim();
+  if (!value) return undefined;
+  if (value.startsWith('"')) {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return typeof parsed === 'string' && parsed.trim() ? parsed.trim() : undefined;
+    } catch { return undefined; }
+  }
+  if (value.startsWith("'")) {
+    const end = value.indexOf("'", 1);
+    if (end < 0) return undefined;
+    return value.slice(1, end).trim() || undefined;
+  }
+  return value.split(/\s+/)[0]?.trim() || undefined;
+}
+
+function assignmentValue(raw: string, key: string): string | undefined {
+  const eq = raw.indexOf('=');
+  if (eq < 0 || raw.slice(0, eq).trim() !== key) return undefined;
+  return unquoteTomlScalar(raw.slice(eq + 1));
+}
+
+function configOverride(args: readonly string[], key: string): string | undefined {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === '-c' || arg === '--config') {
+      const next = args[i + 1];
+      if (next !== undefined) {
+        const value = assignmentValue(next, key);
+        if (value !== undefined) return value;
+        i += 1;
+      }
+    } else if (arg.startsWith('-c=')) {
+      const value = assignmentValue(arg.slice(3), key);
+      if (value !== undefined) return value;
+    } else if (arg.startsWith('--config=')) {
+      const value = assignmentValue(arg.slice('--config='.length), key);
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+export function codexModelFromArgs(args: readonly string[]): string | undefined {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === '-m' || arg === '--model') {
+      const next = args[i + 1]?.trim();
+      if (next) return next;
+    } else if (arg.startsWith('--model=')) {
+      const value = arg.slice('--model='.length).trim();
+      if (value) return value;
+    }
+  }
+  return configOverride(args, 'model');
+}
+
+export function codexProfileFromArgs(args: readonly string[]): string | undefined {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === '-p' || arg === '--profile') {
+      const next = args[i + 1]?.trim();
+      if (next) return next;
+    } else if (arg.startsWith('--profile=')) {
+      const value = arg.slice('--profile='.length).trim();
+      if (value) return value;
+    }
+  }
+  return configOverride(args, 'profile');
+}
+
+function parseCodexConfig(text: string | undefined): ParsedCodexConfig {
+  const parsed: ParsedCodexConfig = { profileModels: new Map() };
+  if (!text) return parsed;
+  let profileSection: string | null = null;
+  let inOtherSection = false;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = stripTomlComment(rawLine).trim();
+    if (!line) continue;
+    const section = /^\[([^\]]+)\]$/.exec(line);
+    if (section) {
+      const profile = /^profiles\.([A-Za-z0-9_.-]+)$/.exec(section[1]!.trim());
+      profileSection = profile?.[1] ?? null;
+      inOtherSection = profileSection === null;
+      continue;
+    }
+    const model = assignmentValue(line, 'model');
+    if (model !== undefined) {
+      if (profileSection !== null) parsed.profileModels.set(profileSection, model);
+      else if (!inOtherSection) parsed.model = model;
+      continue;
+    }
+    if (!inOtherSection && profileSection === null) {
+      const profile = assignmentValue(line, 'profile');
+      if (profile !== undefined) parsed.profile = profile;
+    }
+  }
+  return parsed;
+}
+
+export function resolveCodexModelSelection(
+  args: readonly string[],
+  configText: string | undefined,
+  referenceModel: string,
+): CodexModelSelection {
+  const explicit = codexModelFromArgs(args);
+  if (explicit) return { model: explicit, source: 'cli' };
+  const config = parseCodexConfig(configText);
+  const profile = codexProfileFromArgs(args) ?? config.profile;
+  if (profile) {
+    const model = config.profileModels.get(profile);
+    if (model) return { model, source: 'profile', profile };
+  }
+  if (config.model) return { model: config.model, source: 'config' };
+  return { model: referenceModel, source: 'reference', ...(profile ? { profile } : {}) };
+}

--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -39,6 +39,10 @@ export function buildCodexProxyConfig(base: ProxyConfig): ProxyConfig {
 
     openAIModels: [],
     cloudflareModels: [],
+
+    // Cache/materiality-aware Responses history admission is deliberately
+    // enabled only on this isolated Codex route.
+    codexOptimization: true,
   };
 }
 

--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -1,0 +1,185 @@
+/** First-class Codex CLI routing through the persistent PXPipe listener. */
+
+import type { ProxyConfig } from './proxy.js';
+
+export const CODEX_PROVIDER_ID = 'codex';
+export const CODEX_MODEL_PROVIDER_ID = 'pxpipe';
+export const CODEX_NATIVE_PROVIDER_NAME = 'OpenAI';
+export const DEFAULT_CODEX_PORT = 47821;
+export const DEFAULT_CODEX_CHATGPT_BASE = 'https://chatgpt.com';
+
+/**
+ * Derive the dedicated Codex route from the main listener configuration.
+ *
+ * Operational settings such as transform policy, observers, size limits and
+ * timeouts are inherited. Provider/gateway routing and credentials are not:
+ * Codex must always forward the caller's own ChatGPT authentication directly
+ * to the ChatGPT Codex origin.
+ */
+export function buildCodexProxyConfig(base: ProxyConfig): ProxyConfig {
+  return {
+    ...base,
+
+    // Never inherit an alternate provider/gateway from the default listener.
+    provider: undefined,
+    gatewayBaseUrl: undefined,
+    gatewayHeaders: undefined,
+
+    upstream: DEFAULT_CODEX_CHATGPT_BASE,
+    apiKey: undefined,
+    authToken: undefined,
+
+    openAIUpstream: DEFAULT_CODEX_CHATGPT_BASE,
+    openAIApiKey: undefined,
+
+    // A provider-specific Cloudflare route or credential must not bleed into
+    // the ChatGPT OAuth path either.
+    cloudflareUpstream: undefined,
+    cloudflareApiKey: undefined,
+
+    openAIModels: [],
+    cloudflareModels: [],
+  };
+}
+
+/**
+ * Codex appends `/responses`, `/responses/compact`, and `/models` to this base.
+ * The provider router removes `/providers/codex`; the remaining ChatGPT path is
+ * forwarded by the isolated Codex proxy configuration.
+ */
+export function codexProviderBaseUrl(port: number): string {
+  return `http://127.0.0.1:${port}/providers/${CODEX_PROVIDER_ID}/backend-api/codex`;
+}
+
+/** Temporary Codex config overrides. No Codex files are modified. */
+export function buildCodexConfigArgs(baseUrl: string): string[] {
+  const provider = `model_providers.${CODEX_MODEL_PROVIDER_ID}`;
+  return [
+    '-c', `${provider}.name=${CODEX_NATIVE_PROVIDER_NAME}`,
+    '-c', `${provider}.base_url=${baseUrl}`,
+    '-c', `${provider}.wire_api=responses`,
+    '-c', `${provider}.requires_openai_auth=true`,
+    '-c', `${provider}.supports_websockets=false`,
+    '-c', `model_provider=${CODEX_MODEL_PROVIDER_ID}`,
+  ];
+}
+
+function isLoopbackProxyUrl(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const { hostname } = new URL(value.includes('://') ? value : `http://${value}`);
+    return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1';
+  } catch {
+    return false;
+  }
+}
+
+function appendNoProxy(existing: string | undefined): string {
+  const wanted = ['127.0.0.1', 'localhost', '::1'];
+  const have = (existing ?? '').split(',').map((item) => item.trim()).filter(Boolean);
+  for (const entry of wanted) if (!have.includes(entry)) have.push(entry);
+  return have.join(',');
+}
+
+/**
+ * Build a child environment without disturbing CODEX_HOME/auth state.
+ *
+ * Endpoint overrides from other wrappers are removed because this launcher uses
+ * Codex's model-provider config layer. Loopback Warp proxies are removed so the
+ * plain HTTP hop to the persistent listener cannot be intercepted recursively.
+ */
+export type CodexEnvironmentMode = 'proxied' | 'direct';
+
+export function buildCodexEnvironment(
+  source: NodeJS.ProcessEnv,
+  mode: CodexEnvironmentMode = 'proxied',
+): NodeJS.ProcessEnv {
+  const env = { ...source };
+
+  // A direct launch must be observationally equivalent to invoking Codex
+  // without PXPipe: preserve caller endpoint/proxy configuration untouched.
+  if (mode === 'direct') return env;
+
+  delete env.OPENAI_BASE_URL;
+  for (const key of ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy'] as const) {
+    if (isLoopbackProxyUrl(env[key])) delete env[key];
+  }
+  env.NO_PROXY = appendNoProxy(env.NO_PROXY);
+  env.no_proxy = appendNoProxy(env.no_proxy);
+  return env;
+}
+
+export interface CodexInvocation {
+  binary: string;
+  direct: boolean;
+  args: string[];
+}
+
+/** `pxpipe codex [--binary NAME] [--direct] [--] [codex args...]` */
+export function parseCodexInvocation(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): CodexInvocation {
+  const rest = argv[0] === 'codex' ? argv.slice(1) : [...argv];
+  let binary = env.PXPIPE_CODEX_BINARY?.trim() || 'codex';
+  let direct = false;
+  let index = 0;
+  for (; index < rest.length; index += 1) {
+    const arg = rest[index]!;
+    if (arg === '--') {
+      index += 1;
+      break;
+    }
+    if (arg === '--binary') {
+      const value = rest[index + 1];
+      if (value === undefined || value.startsWith('-')) {
+        throw new Error('--binary requires an executable name or path');
+      }
+      binary = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--binary=')) {
+      binary = arg.slice('--binary='.length);
+      if (!binary) throw new Error('--binary requires an executable name or path');
+      continue;
+    }
+    if (arg === '--direct') {
+      direct = true;
+      continue;
+    }
+    break;
+  }
+  return { binary, direct, args: rest.slice(index) };
+}
+
+export function buildCodexCommandArgs(
+  baseUrl: string,
+  args: readonly string[],
+  resolvedModel?: string,
+): string[] {
+  const modelArgs = resolvedModel?.trim() ? ['-c', `model=${resolvedModel.trim()}`] : [];
+  return [...buildCodexConfigArgs(baseUrl), ...modelArgs, ...args];
+}
+
+export function resolveCodexPort(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number(env.PORT ?? DEFAULT_CODEX_PORT);
+  return Number.isSafeInteger(raw) && raw > 0 && raw <= 65535 ? raw : DEFAULT_CODEX_PORT;
+}
+
+/** Health-check the already-running PXPipe listener; never binds another port. */
+export async function resolveCodexPersistentProxy(
+  env: NodeJS.ProcessEnv = process.env,
+  fetchFn: typeof fetch = fetch,
+): Promise<{ baseUrl: string; port: number } | null> {
+  const port = resolveCodexPort(env);
+  try {
+    const response = await fetchFn(`http://127.0.0.1:${port}/proxy-stats`, {
+      signal: AbortSignal.timeout(1_000),
+    });
+    if (!response.ok) return null;
+  } catch {
+    return null;
+  }
+  return { baseUrl: codexProviderBaseUrl(port), port };
+}

--- a/src/core/gpt-model-profiles.ts
+++ b/src/core/gpt-model-profiles.ts
@@ -84,6 +84,21 @@ export interface GptHistoryProfile {
   framing: 'full' | 'compact';
   /** Fact-sheet placement for discontiguous Responses history groups. */
   factSheetScope: 'per-segment' | 'combined';
+  /** Token target for one immutable Responses history section. Once a section
+   *  seals, later turns append new sections rather than re-rendering old pages. */
+  responsesSectionTokens?: number;
+  /** Minimum whole-plan net raw saving after image + PXPipe framing/ledger. */
+  minNetSavingsTokens?: number;
+  /** Minimum whole-plan net raw saving / original represented text. */
+  minNetSavingsRatio?: number;
+  /** Minimum whole-plan net raw saving per physical PNG. */
+  minNetSavingsPerImage?: number;
+  /** Prior provider cache share at/above which changing an existing warm native
+   *  or compressed prefix is refused unless context pressure overrides it. */
+  warmCacheShareBlock?: number;
+  /** Provider-input token level where context preservation may override the
+   *  warm-cache transition guard. Deliberately below the model hard limit. */
+  contextPressureTokens?: number;
 }
 
 export interface GptModelProfile {
@@ -207,7 +222,25 @@ const GPT56_SOL_PROFILE: GptModelProfile = {
     minCollapseTokens: 1000,
     responsesMode: 'mixed',
     framing: 'compact',
-    factSheetScope: 'combined',
+    // Each immutable Codex section owns its own exact-token sheet. A combined
+    // sheet would move/grow whenever a new section sealed and would therefore
+    // invalidate otherwise-stable old segment bytes.
+    factSheetScope: 'per-segment',
+    // Codex already gets very strong automatic prompt caching. Seal substantially
+    // larger immutable history sections so one newly-cold message cannot make an
+    // old image pack churn on every request.
+    responsesSectionTokens: 6_000,
+    // Telemetry from real Codex sessions showed the legacy >0-token gate happily
+    // spending 3-7 PNGs for ~400 raw tokens (~40 cache-weighted tokens). A Codex
+    // transform now has to be materially useful before changing modality.
+    minNetSavingsTokens: 1_024,
+    minNetSavingsRatio: 0.15,
+    minNetSavingsPerImage: 128,
+    // A warm native prefix is usually cheaper than introducing images. Only a
+    // cold/low-cache transition (or genuine context pressure) may establish the
+    // first compressed epoch; once established, later epochs must be append-only.
+    warmCacheShareBlock: 0.50,
+    contextPressureTokens: 800_000,
   },
   style: {
     ...BASE_STYLE,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -36,6 +36,16 @@ export {
 export { transformOpenAIChatCompletions, transformOpenAIResponses, resolveVisionCost, openAIVisionTokens } from './openai.js';
 export { createProxy, type ProxyConfig, type ProxyEvent } from './proxy.js';
 export {
+  createProviderRouter,
+  parseProviderRoute,
+  assertProviderId,
+  type ProviderProtocol,
+  type ProviderRouteDefinition,
+  type ProviderRouterConfig,
+  type ProviderRouterInspection,
+  type ParsedProviderRoute,
+} from './provider-router.js';
+export {
   computeActualInputEff,
   computeBaselineInputEff,
   CACHE_CREATE_RATE,

--- a/src/core/openai-history.ts
+++ b/src/core/openai-history.ts
@@ -91,6 +91,9 @@ export interface GptHistoryOptions {
    *  each section renders to roughly one ≤6000px image, well under gpt-5.x's
    *  10,000-patch `detail:original` budget. Turn size, not turn count, drives this. */
   sectionTokens: number;
+  /** Responses mixed-mode immutable section target. 0 preserves the historical
+   *  per-run planner; Codex/Sol opts into larger append-only sections. */
+  responsesSectionTokens: number;
   /** Max rendered image height in px (per-model; from the GPT profile). Threaded
    *  into renderTextToPngs so history pages split at the same height the gate prices. */
   maxHeightPx: number;
@@ -115,6 +118,7 @@ export const GPT_HISTORY_DEFAULTS: GptHistoryOptions = {
   collapseChunk: 10,
   freezeChunk: 10,
   sectionTokens: 2000,
+  responsesSectionTokens: 0,
   // GPT path: OpenAI's resize bounds (2048-bbox / 768 short side) permit the tall
   // strip — do NOT re-link to render.ts MAX_HEIGHT_PX (Anthropic's 1568/1.15 MP clamp).
   maxHeightPx: GPT_MAX_HEIGHT_PX,
@@ -141,7 +145,7 @@ export interface HistoryTurn {
 }
 
 export interface ResponsesPairState {
-  /** Strict adjacent call/output pairs found in the original request. */
+  /** All supported completed call/output pairs (function + Codex custom tools). */
   completedPairs: number;
   /** Newest completed pairs deliberately retained as native Responses items. */
   recentCompletedPairs: number;
@@ -153,13 +157,33 @@ export interface ResponsesPairState {
   orphanOutputs: number;
   /** Duplicate, reversed, or non-adjacent shapes that cannot be paired safely. */
   malformedItems: number;
+  /** Function-tool subset retained for backwards-compatible telemetry. */
+  completedFunctionPairs: number;
+  recentFunctionPairs: number;
+  oldFunctionPairs: number;
+  openFunctionCalls: number;
+  orphanFunctionOutputs: number;
+  malformedFunctionItems: number;
+  /** Codex custom-tool subset. */
+  completedCustomToolPairs: number;
+  recentCustomToolPairs: number;
+  oldCustomToolPairs: number;
+  openCustomToolCalls: number;
+  orphanCustomToolOutputs: number;
+  malformedCustomToolItems: number;
   /** Original-request o200k bucket share belonging to eligible old pairs. */
   imageableFunctionCallTokens: number;
   imageableFunctionOutputTokens: number;
+  imageableCustomToolCallTokens: number;
+  imageableCustomToolOutputTokens: number;
   /** Eligible pairs actually removed from native input and represented by images. */
   collapsedPairs: number;
+  collapsedFunctionPairs: number;
   collapsedFunctionCallTokens: number;
   collapsedFunctionOutputTokens: number;
+  collapsedCustomToolPairs: number;
+  collapsedCustomToolCallTokens: number;
+  collapsedCustomToolOutputTokens: number;
 }
 
 export interface ResponsesPairCollapseSegment {
@@ -522,9 +546,8 @@ function gptCountTokens(text: string): number {
 
 function responseCallText(item: Record<string, unknown>): string {
   const name = typeof item.name === 'string' ? item.name : 'tool';
-  const args = typeof item.arguments === 'string'
-    ? item.arguments
-    : safeJson(item.arguments);
+  const payload = item.arguments !== undefined ? item.arguments : item.input;
+  const args = typeof payload === 'string' ? payload : safeJson(payload);
   return `[tool_use ${name}]\n${args}`;
 }
 
@@ -533,9 +556,40 @@ function responseOutputText(item: Record<string, unknown>): string {
   return `[tool_result]\n${output}`;
 }
 
+function responsePairKindForCallType(type: string): ResponsesPairKind | null {
+  if (type === 'function_call') return 'function';
+  if (type === 'custom_tool_call') return 'custom';
+  return null;
+}
+
+function responseExpectedOutputType(type: string): string | null {
+  if (type === 'function_call') return 'function_call_output';
+  if (type === 'custom_tool_call') return 'custom_tool_call_output';
+  return null;
+}
+
+function responsePairKindForOutputType(type: string): ResponsesPairKind | null {
+  if (type === 'function_call_output') return 'function';
+  if (type === 'custom_tool_call_output') return 'custom';
+  return null;
+}
+
+function isSupportedResponseCallType(type: string): boolean {
+  return responsePairKindForCallType(type) !== null;
+}
+
+function isSupportedResponseOutputType(type: string): boolean {
+  return responsePairKindForOutputType(type) !== null;
+}
+
+type ResponsesPairKind = 'function' | 'custom';
+
 interface ResponsesCompletedPair {
+  kind: ResponsesPairKind;
   callIndex: number;
   outputIndex: number;
+  callType: string;
+  outputType: string;
   text: string;
   callTokens: number;
   outputTokens: number;
@@ -659,102 +713,138 @@ function classifyResponsesPairs(
   items: unknown[],
   keepRecentPairs: number,
 ): { old: ResponsesCompletedRound[]; state: ResponsesPairState } {
+  type KindCounts = Record<ResponsesPairKind, number>;
+  const zeroKinds = (): KindCounts => ({ function: 0, custom: 0 });
   const calls = new Map<string, number[]>();
   const outputs = new Map<string, number[]>();
-  let missingIdItems = 0;
+  const keyKind = new Map<string, ResponsesPairKind>();
+  const keyFor = (kind: ResponsesPairKind, id: string): string => `${kind}\u0000${id}`;
+  const missingId = zeroKinds();
+
   for (let i = 0; i < items.length; i++) {
     const type = responseItemType(items[i]);
-    if (type !== 'function_call' && type !== 'function_call_output') continue;
+    const callKind = responsePairKindForCallType(type);
+    const outputKind = responsePairKindForOutputType(type);
+    const kind = callKind ?? outputKind;
+    if (!kind) continue;
     const id = responseCallId(items[i]);
-    if (!id) { missingIdItems++; continue; }
-    const map = type === 'function_call' ? calls : outputs;
-    const at = map.get(id) ?? [];
+    if (!id) {
+      missingId[kind] += 1;
+      continue;
+    }
+    const key = keyFor(kind, id);
+    keyKind.set(key, kind);
+    const map = callKind ? calls : outputs;
+    const at = map.get(key) ?? [];
     at.push(i);
-    map.set(id, at);
+    map.set(key, at);
   }
 
   const pairByCallIndex = new Map<number, ResponsesCompletedPair>();
-  let openCalls = 0;
-  let orphanOutputs = 0;
-  let malformedItems = missingIdItems;
-  const ids = new Set([...calls.keys(), ...outputs.keys()]);
-  for (const id of ids) {
-    const cs = calls.get(id) ?? [];
-    const os = outputs.get(id) ?? [];
+  const openByKind = zeroKinds();
+  const orphanByKind = zeroKinds();
+  const malformedByKind = { ...missingId };
+  const keys = new Set([...calls.keys(), ...outputs.keys()]);
+  for (const key of keys) {
+    const kind = keyKind.get(key)!;
+    const cs = calls.get(key) ?? [];
+    const os = outputs.get(key) ?? [];
     if (cs.length === 1 && os.length === 1 && cs[0]! < os[0]!) {
       const callIndex = cs[0]!;
       const outputIndex = os[0]!;
       const call = items[callIndex] as Record<string, unknown>;
       const output = items[outputIndex] as Record<string, unknown>;
+      const callType = responseItemType(call);
+      const outputType = responseItemType(output);
+      if (responseExpectedOutputType(callType) !== outputType) {
+        malformedByKind[kind] += 2;
+        continue;
+      }
       pairByCallIndex.set(callIndex, {
+        kind,
         callIndex,
         outputIndex,
+        callType,
+        outputType,
         text: `${responseCallText(call)}\n${responseOutputText(output)}`,
-        // Match measureResponsesComposition exactly so the share is comparable
-        // to its functionCalls/functionOutputs buckets.
+        // Call JSON is model-visible in full. For the output side preserve the
+        // historical conservative baseline: count only the payload, not wrapper
+        // fields, so savings are never credited for protocol metadata.
         callTokens: gptCountTokens(JSON.stringify(call)),
         outputTokens: gptCountTokens(
           typeof output.output === 'string' ? output.output : safeJson(output.output),
         ),
       });
-    } else if (cs.length > 0 && os.length === 0) openCalls += cs.length;
-    else if (os.length > 0 && cs.length === 0) orphanOutputs += os.length;
-    else malformedItems += cs.length + os.length;
+    } else if (cs.length > 0 && os.length === 0) {
+      openByKind[kind] += cs.length;
+    } else if (os.length > 0 && cs.length === 0) {
+      orphanByKind[kind] += os.length;
+    } else {
+      malformedByKind[kind] += cs.length + os.length;
+    }
   }
 
-  // Discover contiguous calls* + outputs* rounds. A candidate unique pair that
-  // does not fit one of these rounds is non-adjacent protocol state and remains
-  // native. This is the shape OpenCode uses for parallel tool calls.
+  // Discover protocol-atomic calls* + outputs* rounds. This accepts function
+  // calls and Codex custom-tool calls, including a mixed parallel round, but
+  // never crosses an unknown/intervening item and never selects only one side.
   const completed: ResponsesCompletedRound[] = [];
   const acceptedCallIndices = new Set<number>();
   for (let i = 0; i < items.length;) {
-    if (responseItemType(items[i]) !== 'function_call' || !pairByCallIndex.has(i)) {
+    const firstType = responseItemType(items[i]);
+    if (!isSupportedResponseCallType(firstType) || !pairByCallIndex.has(i)) {
       i++;
       continue;
     }
-    const calls: ResponsesCompletedPair[] = [];
+    const roundCalls: ResponsesCompletedPair[] = [];
     let j = i;
-    while (responseItemType(items[j]) === 'function_call' && pairByCallIndex.has(j)) {
-      calls.push(pairByCallIndex.get(j)!);
+    while (
+      j < items.length
+      && isSupportedResponseCallType(responseItemType(items[j]))
+      && pairByCallIndex.has(j)
+    ) {
+      roundCalls.push(pairByCallIndex.get(j)!);
       j++;
     }
-    const roundOutputIndices = new Set(calls.map((pair) => pair.outputIndex));
-    const outputs: number[] = [];
-    // Do not absorb an output belonging to orphan/other state into this round.
+    const roundOutputIndices = new Set(roundCalls.map((pair) => pair.outputIndex));
+    const roundOutputs: number[] = [];
     while (
-      responseItemType(items[j]) === 'function_call_output'
+      j < items.length
+      && isSupportedResponseOutputType(responseItemType(items[j]))
       && roundOutputIndices.has(j)
     ) {
-      outputs.push(j);
+      roundOutputs.push(j);
       j++;
     }
-    const outputSet = new Set(outputs);
-    const valid = calls.length > 0
-      && outputs.length === calls.length
-      && calls.every((pair) => outputSet.has(pair.outputIndex));
+    const outputSet = new Set(roundOutputs);
+    const valid = roundCalls.length > 0
+      && roundOutputs.length === roundCalls.length
+      && roundCalls.every((pair) => outputSet.has(pair.outputIndex));
     if (!valid) {
       i++;
       continue;
     }
-    const byOutput = [...calls].sort((a, b) => a.outputIndex - b.outputIndex);
+    const byOutput = [...roundCalls].sort((a, b) => a.outputIndex - b.outputIndex);
     const indices = [
-      ...calls.map((pair) => pair.callIndex),
+      ...roundCalls.map((pair) => pair.callIndex),
       ...byOutput.map((pair) => pair.outputIndex),
     ];
     completed.push({
-      pairs: calls,
+      pairs: roundCalls,
       indices,
       startIndex: i,
       endIndex: j - 1,
       text: byOutput.map((pair) => pair.text).join('\n\n'),
-      callTokens: calls.reduce((sum, pair) => sum + pair.callTokens, 0),
-      outputTokens: calls.reduce((sum, pair) => sum + pair.outputTokens, 0),
+      callTokens: roundCalls.reduce((sum, pair) => sum + pair.callTokens, 0),
+      outputTokens: roundCalls.reduce((sum, pair) => sum + pair.outputTokens, 0),
     });
-    for (const pair of calls) acceptedCallIndices.add(pair.callIndex);
+    for (const pair of roundCalls) acceptedCallIndices.add(pair.callIndex);
     i = j;
   }
+
+  // A unique call/output that could not form one contiguous protocol round is
+  // still malformed for collapse purposes. Keep it byte-exact and count it.
   for (const pair of pairByCallIndex.values()) {
-    if (!acceptedCallIndices.has(pair.callIndex)) malformedItems += 2;
+    if (!acceptedCallIndices.has(pair.callIndex)) malformedByKind[pair.kind] += 2;
   }
 
   const keep = Math.max(0, Math.floor(keepRecentPairs));
@@ -765,24 +855,48 @@ function classifyResponsesPairs(
     recentPairs += completed[recentStart]!.pairs.length;
   }
   const old = completed.slice(0, recentStart);
-  const completedPairs = completed.reduce((n, round) => n + round.pairs.length, 0);
-  const oldPairs = old.reduce((n, round) => n + round.pairs.length, 0);
-  const imageableFunctionCallTokens = old.reduce((n, round) => n + round.callTokens, 0);
-  const imageableFunctionOutputTokens = old.reduce((n, round) => n + round.outputTokens, 0);
+  const recent = completed.slice(recentStart);
+
+  const pairsOf = (rounds: ResponsesCompletedRound[], kind?: ResponsesPairKind): ResponsesCompletedPair[] =>
+    rounds.flatMap((round) => kind ? round.pairs.filter((pair) => pair.kind === kind) : round.pairs);
+  const completedAll = pairsOf(completed);
+  const recentAll = pairsOf(recent);
+  const oldAll = pairsOf(old);
+  const oldFunction = pairsOf(old, 'function');
+  const oldCustom = pairsOf(old, 'custom');
+
   return {
     old,
     state: {
-      completedPairs,
-      recentCompletedPairs: completedPairs - oldPairs,
-      oldCompletedPairs: oldPairs,
-      openCalls,
-      orphanOutputs,
-      malformedItems,
-      imageableFunctionCallTokens,
-      imageableFunctionOutputTokens,
+      completedPairs: completedAll.length,
+      recentCompletedPairs: recentAll.length,
+      oldCompletedPairs: oldAll.length,
+      openCalls: openByKind.function + openByKind.custom,
+      orphanOutputs: orphanByKind.function + orphanByKind.custom,
+      malformedItems: malformedByKind.function + malformedByKind.custom,
+      completedFunctionPairs: pairsOf(completed, 'function').length,
+      recentFunctionPairs: pairsOf(recent, 'function').length,
+      oldFunctionPairs: oldFunction.length,
+      openFunctionCalls: openByKind.function,
+      orphanFunctionOutputs: orphanByKind.function,
+      malformedFunctionItems: malformedByKind.function,
+      completedCustomToolPairs: pairsOf(completed, 'custom').length,
+      recentCustomToolPairs: pairsOf(recent, 'custom').length,
+      oldCustomToolPairs: oldCustom.length,
+      openCustomToolCalls: openByKind.custom,
+      orphanCustomToolOutputs: orphanByKind.custom,
+      malformedCustomToolItems: malformedByKind.custom,
+      imageableFunctionCallTokens: oldFunction.reduce((sum, pair) => sum + pair.callTokens, 0),
+      imageableFunctionOutputTokens: oldFunction.reduce((sum, pair) => sum + pair.outputTokens, 0),
+      imageableCustomToolCallTokens: oldCustom.reduce((sum, pair) => sum + pair.callTokens, 0),
+      imageableCustomToolOutputTokens: oldCustom.reduce((sum, pair) => sum + pair.outputTokens, 0),
       collapsedPairs: 0,
+      collapsedFunctionPairs: 0,
       collapsedFunctionCallTokens: 0,
       collapsedFunctionOutputTokens: 0,
+      collapsedCustomToolPairs: 0,
+      collapsedCustomToolCallTokens: 0,
+      collapsedCustomToolOutputTokens: 0,
     },
   };
 }
@@ -905,43 +1019,101 @@ async function planResponsesMixedCollapse(
     const source = units.map((unit) => unit.text).join('\n\n');
     const safe = neutralizeSentinel(source);
     const renderedText = o.reflow ? reflow(safe) ?? safe : safe;
-    const images = await renderTextToPngs(renderedText, o.cols, o.style ?? DEFAULT_GPT_PROFILE.style, o.maxHeightPx);
+    const images = await renderTextToPngs(
+      renderedText,
+      o.cols,
+      o.style ?? DEFAULT_GPT_PROFILE.style,
+      o.maxHeightPx,
+    );
     return { source, renderedText, images };
   };
 
   const segments: ResponsesPairCollapseSegment[] = [];
   let remainingImages = maxImages;
   let hitImageCap = false;
-  for (const run of runs) {
-    if (remainingImages === 0) { hitImageCap = true; break; }
-    let low = 0;
-    let high = run.length + 1;
-    let best: Awaited<ReturnType<typeof renderUnits>> | undefined;
-    while (low + 1 < high) {
-      const count = Math.floor((low + high) / 2);
-      const rendered = await renderUnits(run.slice(0, count));
-      if (rendered.images.length > 0 && rendered.images.length <= remainingImages) {
-        low = count;
-        best = rendered;
-      } else {
-        high = count;
+
+  if (o.responsesSectionTokens > 0) {
+    // Codex cache-stable mode: seal each contiguous run into deterministic
+    // token-sized sections. The trailing partial section stays native until it
+    // fills. Once sealed, its source range never changes as future items append,
+    // so the old PNG bytes remain a stable prompt-cache prefix.
+    const target = Math.max(1, Math.floor(o.responsesSectionTokens));
+    outer: for (const run of runs) {
+      let sectionStart = 0;
+      let sectionTokens = 0;
+      for (let i = 0; i < run.length; i++) {
+        sectionTokens += run[i]!.baselineTokens;
+        if (sectionTokens < target) continue;
+        const selected = run.slice(sectionStart, i + 1);
+        const rendered = await renderUnits(selected);
+        if (rendered.images.length === 0) {
+          sectionStart = i + 1;
+          sectionTokens = 0;
+          continue;
+        }
+        if (rendered.images.length > remainingImages) {
+          hitImageCap = true;
+          break outer;
+        }
+        const selectedBaselineTokens = selected.reduce((sum, unit) => sum + unit.baselineTokens, 0);
+        if (!isProfitable(rendered.renderedText, o.cols, selectedBaselineTokens)) {
+          // Reaching the token target does not make an under-filled image worth
+          // sending. Keep accumulating this same deterministic section until its
+          // raw image cost beats native text; the first profitable boundary is
+          // then stable for every future append of this trajectory.
+          continue;
+        }
+        const selectedIndices = selected.flatMap((unit) => unit.indices).sort((a, b) => a - b);
+        segments.push({
+          insertAt: selectedIndices[0]!,
+          selectedIndices,
+          images: rendered.images,
+          imageSources: rendered.images.map(() => rendered.source),
+          text: rendered.source,
+          baselineTokens: selectedBaselineTokens,
+        });
+        remainingImages -= rendered.images.length;
+        // Seal only a physically/economically viable section. A tiny trailing
+        // island therefore stays native instead of becoming a cache-hostile PNG.
+        sectionStart = i + 1;
+        sectionTokens = 0;
       }
+      // [sectionStart..end) is intentionally left native until it reaches target.
     }
-    if (!best || low === 0) { hitImageCap = true; break; }
-    const selected = run.slice(0, low);
-    const selectedBaselineTokens = selected.reduce((sum, unit) => sum + unit.baselineTokens, 0);
-    if (!isProfitable(best.renderedText, o.cols, selectedBaselineTokens)) continue;
-    const selectedIndices = selected.flatMap((unit) => unit.indices).sort((a, b) => a - b);
-    segments.push({
-      insertAt: selectedIndices[0]!,
-      selectedIndices,
-      images: best.images,
-      imageSources: best.images.map(() => best.source),
-      text: best.source,
-      baselineTokens: selectedBaselineTokens,
-    });
-    remainingImages -= best.images.length;
-    if (low < run.length) { hitImageCap = true; break; }
+  } else {
+    // Historical generic Responses planner: pack as much of each run as the
+    // physical image budget permits. Kept for non-Codex OpenAI-compatible users.
+    for (const run of runs) {
+      if (remainingImages === 0) { hitImageCap = true; break; }
+      let low = 0;
+      let high = run.length + 1;
+      let best: Awaited<ReturnType<typeof renderUnits>> | undefined;
+      while (low + 1 < high) {
+        const count = Math.floor((low + high) / 2);
+        const rendered = await renderUnits(run.slice(0, count));
+        if (rendered.images.length > 0 && rendered.images.length <= remainingImages) {
+          low = count;
+          best = rendered;
+        } else {
+          high = count;
+        }
+      }
+      if (!best || low === 0) { hitImageCap = true; break; }
+      const selected = run.slice(0, low);
+      const selectedBaselineTokens = selected.reduce((sum, unit) => sum + unit.baselineTokens, 0);
+      if (!isProfitable(best.renderedText, o.cols, selectedBaselineTokens)) continue;
+      const selectedIndices = selected.flatMap((unit) => unit.indices).sort((a, b) => a - b);
+      segments.push({
+        insertAt: selectedIndices[0]!,
+        selectedIndices,
+        images: best.images,
+        imageSources: best.images.map(() => best.source),
+        text: best.source,
+        baselineTokens: selectedBaselineTokens,
+      });
+      remainingImages -= best.images.length;
+      if (low < run.length) { hitImageCap = true; break; }
+    }
   }
 
   if (segments.length === 0) {
@@ -955,9 +1127,16 @@ async function planResponsesMixedCollapse(
   const selectedIndices = segments.flatMap((segment) => segment.selectedIndices).sort((a, b) => a - b);
   const selectedIds = new Set(selectedIndices);
   const selectedRounds = old.filter((round) => round.indices.every((index) => selectedIds.has(index)));
-  state.collapsedPairs = selectedRounds.reduce((n, round) => n + round.pairs.length, 0);
-  state.collapsedFunctionCallTokens = selectedRounds.reduce((n, round) => n + round.callTokens, 0);
-  state.collapsedFunctionOutputTokens = selectedRounds.reduce((n, round) => n + round.outputTokens, 0);
+  const selectedPairs = selectedRounds.flatMap((round) => round.pairs);
+  const selectedFunction = selectedPairs.filter((pair) => pair.kind === 'function');
+  const selectedCustom = selectedPairs.filter((pair) => pair.kind === 'custom');
+  state.collapsedPairs = selectedPairs.length;
+  state.collapsedFunctionPairs = selectedFunction.length;
+  state.collapsedFunctionCallTokens = selectedFunction.reduce((n, pair) => n + pair.callTokens, 0);
+  state.collapsedFunctionOutputTokens = selectedFunction.reduce((n, pair) => n + pair.outputTokens, 0);
+  state.collapsedCustomToolPairs = selectedCustom.length;
+  state.collapsedCustomToolCallTokens = selectedCustom.reduce((n, pair) => n + pair.callTokens, 0);
+  state.collapsedCustomToolOutputTokens = selectedCustom.reduce((n, pair) => n + pair.outputTokens, 0);
   const images = segments.flatMap((segment) => segment.images);
   const imageSources = segments.flatMap((segment) => segment.imageSources);
   const text = segments.map((segment) => segment.text).join('\n\n');
@@ -1085,9 +1264,16 @@ export async function planResponsesPairCollapse(
   const text = segments.map((segment) => segment.text).join('\n\n');
   const selectedIds = new Set(selectedIndices);
   const selectedRounds = old.filter((round) => round.indices.every((index) => selectedIds.has(index)));
-  state.collapsedPairs = selectedRounds.reduce((n, round) => n + round.pairs.length, 0);
-  state.collapsedFunctionCallTokens = selectedRounds.reduce((n, round) => n + round.callTokens, 0);
-  state.collapsedFunctionOutputTokens = selectedRounds.reduce((n, round) => n + round.outputTokens, 0);
+  const selectedPairs = selectedRounds.flatMap((round) => round.pairs);
+  const selectedFunction = selectedPairs.filter((pair) => pair.kind === 'function');
+  const selectedCustom = selectedPairs.filter((pair) => pair.kind === 'custom');
+  state.collapsedPairs = selectedPairs.length;
+  state.collapsedFunctionPairs = selectedFunction.length;
+  state.collapsedFunctionCallTokens = selectedFunction.reduce((n, pair) => n + pair.callTokens, 0);
+  state.collapsedFunctionOutputTokens = selectedFunction.reduce((n, pair) => n + pair.outputTokens, 0);
+  state.collapsedCustomToolPairs = selectedCustom.length;
+  state.collapsedCustomToolCallTokens = selectedCustom.reduce((n, pair) => n + pair.callTokens, 0);
+  state.collapsedCustomToolOutputTokens = selectedCustom.reduce((n, pair) => n + pair.outputTokens, 0);
 
   const droppedCodepoints = new Map<number, number>();
   let droppedChars = 0;

--- a/src/core/openai.ts
+++ b/src/core/openai.ts
@@ -43,6 +43,7 @@ import {
 } from './openai-history.js';
 import { HISTORY_SYNTHETIC_INTRO, HISTORY_SYNTHETIC_OUTRO } from './history.js';
 import { factSheetText } from './factsheet.js';
+import { getCodexCacheHint, type CodexCacheHint } from './codex-cache-state.js';
 import { countTokens as o200kCountTokens } from 'gpt-tokenizer/encoding/o200k_base';
 
 // Per-model GPT rendering + vision-cost profiles (portrait-strip width, image-token
@@ -209,6 +210,8 @@ interface OpenAIResolvedOptions {
   charsPerToken: number;
   reflow: boolean;
   collapseHistory: boolean;
+  codexOptimization: boolean;
+  codexSessionKey?: string;
   gptHistory?: Partial<GptHistoryOptions>;
 }
 
@@ -220,6 +223,7 @@ const DEFAULTS: OpenAIResolvedOptions = {
   charsPerToken: 4, // conservative OpenAI default; override after telemetry
   reflow: true,
   collapseHistory: true,
+  codexOptimization: false,
 };
 
 function resolveOptions(opts: TransformOptions): OpenAIResolvedOptions {
@@ -231,6 +235,8 @@ function resolveOptions(opts: TransformOptions): OpenAIResolvedOptions {
     charsPerToken: opts.charsPerToken ?? DEFAULTS.charsPerToken,
     reflow: opts.reflow ?? DEFAULTS.reflow,
     collapseHistory: opts.collapseHistory ?? DEFAULTS.collapseHistory,
+    codexOptimization: opts.codexOptimization ?? DEFAULTS.codexOptimization,
+    codexSessionKey: opts.codexSessionKey?.trim() || undefined,
     gptHistory: opts.gptHistory,
   };
 }
@@ -265,6 +271,9 @@ function gptHistoryOpts(
     maxHeightPx: o.gptHistory?.maxHeightPx ?? profile.maxHeightPx,
     style: o.gptHistory?.style ?? profile.style,
     maxImages: o.gptHistory?.maxImages ?? configuredHistoryMaxImages(model),
+    responsesSectionTokens: o.gptHistory?.responsesSectionTokens
+      ?? (o.codexOptimization ? profile.history.responsesSectionTokens : undefined)
+      ?? 0,
   };
 }
 
@@ -560,6 +569,11 @@ function measureResponsesComposition(
       c.functionCalls += gptTextTokens(JSON.stringify(o));
     } else if (type === 'function_call_output') {
       c.functionOutputs += gptTextTokens(typeof o.output === 'string' ? o.output : JSON.stringify(o.output ?? ''));
+    } else if (type === 'custom_tool_call') {
+      c.customToolCalls = (c.customToolCalls ?? 0) + gptTextTokens(JSON.stringify(o));
+    } else if (type === 'custom_tool_call_output') {
+      c.customToolOutputs = (c.customToolOutputs ?? 0)
+        + gptTextTokens(typeof o.output === 'string' ? o.output : JSON.stringify(o.output ?? ''));
     } else if (type === 'reasoning') {
       // Includes encrypted_content when present; this is often a large Codex-native bucket.
       c.reasoningEncrypted += gptTextTokens(JSON.stringify(o));
@@ -573,8 +587,8 @@ function measureResponsesComposition(
     }
   }
   c.totalLocal = c.instructions + c.systemDeveloper + c.userAssistant +
-    c.functionCalls + c.functionOutputs + c.reasoningEncrypted +
-    c.compactionOpaque + c.toolsJson + c.other;
+    c.functionCalls + c.functionOutputs + (c.customToolCalls ?? 0) + (c.customToolOutputs ?? 0) +
+    c.reasoningEncrypted + c.compactionOpaque + c.toolsJson + c.other;
   return c;
 }
 
@@ -840,6 +854,121 @@ async function applyChatHistoryCollapse(
   return true;
 }
 
+
+function commonHistorySegmentPrefix(
+  previous: readonly string[],
+  current: readonly string[],
+): number {
+  const n = Math.min(previous.length, current.length);
+  let i = 0;
+  while (i < n && previous[i] === current[i]) i += 1;
+  return i;
+}
+
+function responsesHistorySegmentContent(
+  plan: Awaited<ReturnType<typeof planResponsesPairCollapse>>,
+  profile: GptModelProfile,
+  segmentIndex: number,
+): ResponsesContentPart[] {
+  const compact = profile.history.framing === 'compact';
+  const intro = compact ? COMPACT_HISTORY_TRANSCRIPT_INTRO : HISTORY_TRANSCRIPT_INTRO;
+  const outro = compact ? COMPACT_HISTORY_TRANSCRIPT_OUTRO : HISTORY_TRANSCRIPT_OUTRO;
+  const segment = plan.segments[segmentIndex]!;
+  const combinedSheet = profile.history.factSheetScope === 'combined'
+    ? factSheetText(plan.text, profile.factSheetFormat)
+    : '';
+  const sheet = profile.history.factSheetScope === 'combined'
+    ? (segmentIndex === plan.segments.length - 1 ? combinedSheet : '')
+    : factSheetText(segment.text, profile.factSheetFormat);
+  const content: ResponsesContentPart[] = [
+    { type: 'input_text', text: intro },
+    ...segment.images.map(responsesImagePart),
+  ];
+  if (sheet) content.push({ type: 'input_text', text: sheet });
+  content.push({ type: 'input_text', text: outro });
+  return content;
+}
+
+function responsesHistoryFramingTokens(
+  plan: Awaited<ReturnType<typeof planResponsesPairCollapse>>,
+  profile: GptModelProfile,
+): number {
+  let total = 0;
+  for (let i = 0; i < plan.segments.length; i++) {
+    const content = responsesHistorySegmentContent(plan, profile, i);
+    for (const part of content) {
+      if ((part as { type?: unknown }).type !== 'input_text') continue;
+      const value = (part as { text?: unknown }).text;
+      if (typeof value === 'string') total += gptTextTokens(value);
+    }
+  }
+  return total;
+}
+
+async function responsesHistorySegmentShas(
+  plan: Awaited<ReturnType<typeof planResponsesPairCollapse>>,
+  profile: GptModelProfile,
+): Promise<string[]> {
+  return Promise.all(plan.segments.map(async (_segment, index) => {
+    const content = responsesHistorySegmentContent(plan, profile, index);
+    return sha8(JSON.stringify({ role: 'user', content }));
+  }));
+}
+
+function codexHistoryMateriality(
+  plan: Awaited<ReturnType<typeof planResponsesPairCollapse>>,
+  req: ResponsesRequest,
+  profile: GptModelProfile,
+): { baseline: number; image: number; native: number; rawSaving: number; ratio: number; perImage: number } {
+  const baseline = Math.max(0, plan.baselineTokens ?? gptTextTokens(plan.text));
+  const image = gptImageTokens(req.model, plan.images);
+  const native = responsesHistoryFramingTokens(plan, profile);
+  const rawSaving = baseline - image - native;
+  return {
+    baseline,
+    image,
+    native,
+    rawSaving,
+    ratio: baseline > 0 ? rawSaving / baseline : 0,
+    perImage: plan.images.length > 0 ? rawSaving / plan.images.length : 0,
+  };
+}
+
+function cacheAllowsCodexHistory(
+  hint: CodexCacheHint | undefined,
+  currentSegmentShas: readonly string[],
+  profile: GptModelProfile,
+): { allow: boolean; decision: NonNullable<ResponsesComposition['historyCacheDecision']>; stablePrefix: number } {
+  const warmShare = profile.history.warmCacheShareBlock;
+  if (warmShare === undefined) {
+    return { allow: true, decision: 'not_codex', stablePrefix: 0 };
+  }
+  if (!hint) {
+    return { allow: false, decision: 'no_prior_usage', stablePrefix: 0 };
+  }
+  const stablePrefix = commonHistorySegmentPrefix(hint.historySegmentShas, currentSegmentShas);
+  if (
+    profile.history.contextPressureTokens !== undefined
+    && hint.inputTokens >= profile.history.contextPressureTokens
+  ) {
+    return { allow: true, decision: 'context_pressure_override', stablePrefix };
+  }
+  if (hint.cacheShare < warmShare) {
+    return { allow: true, decision: 'cold_or_low_cache', stablePrefix };
+  }
+  if (!hint.compressed) {
+    return { allow: false, decision: 'warm_native_blocked', stablePrefix };
+  }
+  if (
+    hint.historySegmentShas.length > 0
+    && currentSegmentShas.length >= hint.historySegmentShas.length
+    && stablePrefix === hint.historySegmentShas.length
+  ) {
+    return { allow: true, decision: 'warm_append_only', stablePrefix };
+  }
+  return { allow: false, decision: 'warm_mutation_blocked', stablePrefix };
+}
+
 async function applyResponsesHistoryCollapse(
   req: ResponsesRequest,
   inputItems: Array<ResponsesInputItem | Record<string, unknown>>,
@@ -847,8 +976,8 @@ async function applyResponsesHistoryCollapse(
   o: OpenAIResolvedOptions,
   profile: GptModelProfile,
 ): Promise<boolean> {
-  const profitable = (text: string, cols: number, baselineTextTokens?: number) =>
-    evalOpenAIGate(req.model, text, cols, o.charsPerToken, baselineTextTokens).profitable;
+  const profitable = (historyText: string, cols: number, baselineTextTokens?: number) =>
+    evalOpenAIGate(req.model, historyText, cols, o.charsPerToken, baselineTextTokens).profitable;
   const plan = await planResponsesPairCollapse(
     inputItems,
     profitable,
@@ -856,19 +985,31 @@ async function applyResponsesHistoryCollapse(
   );
   const ps = plan.pairState;
   const rc = info.responsesComposition!;
-  rc.completedFunctionPairs = ps.completedPairs;
-  rc.recentNativeFunctionPairs = ps.recentCompletedPairs;
-  rc.oldFunctionPairs = ps.oldCompletedPairs;
-  rc.openFunctionCalls = ps.openCalls;
-  rc.orphanFunctionOutputs = ps.orphanOutputs;
-  rc.malformedFunctionItems = ps.malformedItems;
+
+  rc.completedFunctionPairs = ps.completedFunctionPairs;
+  rc.recentNativeFunctionPairs = ps.recentFunctionPairs;
+  rc.oldFunctionPairs = ps.oldFunctionPairs;
+  rc.openFunctionCalls = ps.openFunctionCalls;
+  rc.orphanFunctionOutputs = ps.orphanFunctionOutputs;
+  rc.malformedFunctionItems = ps.malformedFunctionItems;
   rc.imageableFunctionCalls = ps.imageableFunctionCallTokens;
   rc.imageableFunctionOutputs = ps.imageableFunctionOutputTokens;
-  rc.collapsedFunctionPairs = ps.collapsedPairs;
+  rc.collapsedFunctionPairs = ps.collapsedFunctionPairs;
   rc.collapsedFunctionCalls = ps.collapsedFunctionCallTokens;
   rc.collapsedFunctionOutputs = ps.collapsedFunctionOutputTokens;
-  // Descending count so the dominant page-breaker is first. Bounded to 8 so a
-  // pathological body cannot bloat the event row.
+
+  rc.completedCustomToolPairs = ps.completedCustomToolPairs;
+  rc.recentNativeCustomToolPairs = ps.recentCustomToolPairs;
+  rc.oldCustomToolPairs = ps.oldCustomToolPairs;
+  rc.openCustomToolCalls = ps.openCustomToolCalls;
+  rc.orphanCustomToolOutputs = ps.orphanCustomToolOutputs;
+  rc.malformedCustomToolItems = ps.malformedCustomToolItems;
+  rc.imageableCustomToolCalls = ps.imageableCustomToolCallTokens;
+  rc.imageableCustomToolOutputs = ps.imageableCustomToolOutputTokens;
+  rc.collapsedCustomToolPairs = ps.collapsedCustomToolPairs;
+  rc.collapsedCustomToolCalls = ps.collapsedCustomToolCallTokens;
+  rc.collapsedCustomToolOutputs = ps.collapsedCustomToolOutputTokens;
+
   if (plan.barrierTypes && plan.barrierTypes.size > 0) {
     rc.barrierTypes = [...plan.barrierTypes.entries()]
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
@@ -876,29 +1017,57 @@ async function applyResponsesHistoryCollapse(
       .map(([type, count]) => `${type}:${count}`);
   }
 
+  if (plan.segments.length === 0 || plan.images.length === 0) {
+    if (plan.reason) info.historyReason = plan.reason;
+    if (plan.collapsedChars > 0) info.historyTextChars = plan.collapsedChars;
+    return false;
+  }
+
+  if (o.codexOptimization) {
+    const materiality = codexHistoryMateriality(plan, req, profile);
+    rc.historyCandidateRawSaving = materiality.rawSaving;
+    rc.historyCandidateRawSavingPct = materiality.ratio * 100;
+    rc.historyCandidateSavingPerImage = materiality.perImage;
+    const minTokens = profile.history.minNetSavingsTokens ?? 0;
+    const minRatio = profile.history.minNetSavingsRatio ?? 0;
+    const minPerImage = profile.history.minNetSavingsPerImage ?? 0;
+    if (
+      materiality.rawSaving < minTokens
+      || materiality.ratio < minRatio
+      || materiality.perImage < minPerImage
+    ) {
+      info.historyReason = 'not_material';
+      info.historyTextChars = plan.collapsedChars;
+      return false;
+    }
+
+    const segmentShas = await responsesHistorySegmentShas(plan, profile);
+    const hint = getCodexCacheHint(o.codexSessionKey);
+    if (hint) rc.priorCacheSharePct = hint.cacheShare * 100;
+    const cache = cacheAllowsCodexHistory(hint, segmentShas, profile);
+    rc.historyStablePrefixSegments = cache.stablePrefix;
+    rc.historyCacheDecision = cache.decision;
+    if (!cache.allow) {
+      info.historyReason = 'cache_preservation';
+      info.historyTextChars = plan.collapsedChars;
+      return false;
+    }
+    info.historySegmentShas = segmentShas;
+  }
+
   foldGptHistory(info, req.model, plan);
-  if (plan.segments.length === 0) return false;
 
   const replacements = new Map<number, ResponsesInputItem>();
-  const compactFraming = profile.history.framing === 'compact';
-  const intro = compactFraming ? COMPACT_HISTORY_TRANSCRIPT_INTRO : HISTORY_TRANSCRIPT_INTRO;
-  const outro = compactFraming ? COMPACT_HISTORY_TRANSCRIPT_OUTRO : HISTORY_TRANSCRIPT_OUTRO;
-  const combinedSheet = profile.history.factSheetScope === 'combined'
-    ? factSheetText(plan.text, profile.factSheetFormat)
-    : '';
   for (let segmentIndex = 0; segmentIndex < plan.segments.length; segmentIndex++) {
     const segment = plan.segments[segmentIndex]!;
-    const content: ResponsesContentPart[] = [
-      { type: 'input_text', text: intro },
-      ...segment.images.map(responsesImagePart),
-    ];
-    const sheet = profile.history.factSheetScope === 'combined'
-      ? (segmentIndex === plan.segments.length - 1 ? combinedSheet : '')
-      : factSheetText(segment.text, profile.factSheetFormat);
-    if (sheet) content.push({ type: 'input_text', text: sheet });
-    content.push({ type: 'input_text', text: outro });
-    info.nativeInjectedTokens = (info.nativeInjectedTokens ?? 0)
-      + gptTextTokens(intro + sheet + outro);
+    const content = responsesHistorySegmentContent(plan, profile, segmentIndex);
+    for (const part of content) {
+      if ((part as { type?: unknown }).type !== 'input_text') continue;
+      const value = (part as { text?: unknown }).text;
+      if (typeof value === 'string') {
+        info.nativeInjectedTokens = (info.nativeInjectedTokens ?? 0) + gptTextTokens(value);
+      }
+    }
     replacements.set(segment.insertAt, { role: 'user', content });
   }
 
@@ -910,9 +1079,7 @@ async function applyResponsesHistoryCollapse(
     if (!removed.has(i)) rewritten.push(inputItems[i]!);
   }
   req.input = rewritten;
-  info.historyImageSha = await sha8(
-    plan.images.map((image) => bytesToBase64(image.png)).join(''),
-  );
+  info.historyImageSha = await sha8(plan.images.map((image) => bytesToBase64(image.png)).join(''));
   return true;
 }
 
@@ -1158,6 +1325,10 @@ export async function transformOpenAIResponses(
   info.responsesComposition = measureResponsesComposition(
     req, inputWasString, originalInputString, inputItems,
   );
+  // Stable trajectory key is needed even when this request only reaches the
+  // history-collapse path and never images static authority/tool context.
+  const firstUser = firstResponsesUserText(inputWasString, originalInputString, inputItems);
+  if (firstUser) info.firstUserSha8 = await sha8(firstUser);
 
   // Collect static context: instructions + system/developer items + flat tools.
   const authorityDocs: string[] = [];
@@ -1220,9 +1391,6 @@ export async function transformOpenAIResponses(
   if (!combinedRaw) {
     return finishHistoryOnly('no_static_context');
   }
-
-  const firstUser = firstResponsesUserText(inputWasString, originalInputString, inputItems);
-  if (firstUser) info.firstUserSha8 = await sha8(firstUser);
 
   const combined = compactSlabWhitespace(combinedRaw).trimEnd();
   const minCompressTokens = profile.minCompressTokens;

--- a/src/core/provider-router.ts
+++ b/src/core/provider-router.ts
@@ -1,0 +1,166 @@
+import { createProxy, type ProxyConfig, type ProxyEvent } from './proxy.js';
+
+export type ProviderProtocol = 'anthropic' | 'openai' | 'google';
+
+export interface ProviderRouteDefinition {
+  /** Stable route id used in `/providers/<id>/...`. */
+  id: string;
+  /** Wire protocol accepted by the configured upstream. */
+  protocol: ProviderProtocol;
+  /** Existing proxy configuration for this provider. Kept in memory only. */
+  proxy: ProxyConfig;
+}
+
+export interface ProviderRouterConfig {
+  /** Handles legacy unprefixed routes such as `/v1/messages`. */
+  defaultProxy: ProxyConfig;
+  /** Explicitly addressable providers. */
+  providers: readonly ProviderRouteDefinition[];
+  /** Optional observer invoked after the provider-specific observer. */
+  onRequest?: (providerId: string, event: ProxyEvent) => void | Promise<void>;
+}
+
+export interface ParsedProviderRoute {
+  providerId: string;
+  upstreamPath: string;
+}
+
+export interface ProviderRouterInspection {
+  defaultRoute: 'legacy';
+  providers: Array<{
+    id: string;
+    protocol: ProviderProtocol;
+    prefix: string;
+  }>;
+}
+
+const PROVIDER_ID = /^[a-z][a-z0-9-]{0,62}$/;
+const PREFIX = '/providers/';
+
+export function assertProviderId(id: string): void {
+  if (!PROVIDER_ID.test(id)) {
+    throw new Error(
+      `invalid provider id ${JSON.stringify(id)}; expected lowercase letters, digits and dashes`,
+    );
+  }
+}
+
+/**
+ * Parse an explicit provider-prefixed request path.
+ *
+ * The provider id is never accepted from a header, query string or body. This
+ * keeps routing metadata outside the model payload and prevents an untrusted
+ * client from overriding upstream selection through a forwarded header.
+ */
+export function parseProviderRoute(pathname: string): ParsedProviderRoute | null {
+  if (!pathname.startsWith(PREFIX)) return null;
+  const remainder = pathname.slice(PREFIX.length);
+  const slash = remainder.indexOf('/');
+  if (slash <= 0) return null;
+
+  const providerId = remainder.slice(0, slash);
+  if (!PROVIDER_ID.test(providerId)) return null;
+
+  const upstreamPath = remainder.slice(slash);
+  if (!upstreamPath.startsWith('/') || upstreamPath.startsWith('//')) return null;
+  return { providerId, upstreamPath };
+}
+
+function wrapProviderObserver(
+  definition: ProviderRouteDefinition,
+  routerObserver: ProviderRouterConfig['onRequest'],
+): ProxyConfig {
+  const providerObserver = definition.proxy.onRequest;
+  return {
+    ...definition.proxy,
+    onRequest: async (event) => {
+      // Keep provider identity explicit even for generic OpenAI-compatible
+      // providers whose core handler would otherwise leave it unset.
+      event.provider ??= definition.id;
+      await providerObserver?.(event);
+      await routerObserver?.(definition.id, event);
+    },
+  };
+}
+
+function rewriteProviderRequest(request: Request, route: ParsedProviderRoute): Request {
+  const sourceUrl = new URL(request.url);
+  sourceUrl.pathname = route.upstreamPath;
+
+  const bodyAllowed = request.method !== 'GET' && request.method !== 'HEAD';
+  const init: RequestInit & { duplex?: 'half' } = {
+    method: request.method,
+    headers: new Headers(request.headers),
+    body: bodyAllowed ? request.body : undefined,
+    redirect: request.redirect,
+    signal: request.signal,
+  };
+  if (request.body) init.duplex = 'half';
+
+  // The body stream is forwarded without decoding or re-encoding it. Tool
+  // schemas, prompts, binary parts and structured-output contracts remain
+  // untouched until the selected provider's normal transform pipeline runs.
+  return new Request(sourceUrl, init);
+}
+
+/**
+ * Create one request handler that multiplexes several provider-specific
+ * `createProxy` instances behind one Web-standard request handler.
+ *
+ * Legacy paths continue through `defaultProxy`. Explicit provider paths use:
+ *
+ *   /providers/<provider-id>/<upstream-path>
+ */
+export function createProviderRouter(
+  config: ProviderRouterConfig,
+): ((request: Request) => Promise<Response>) & { inspect(): ProviderRouterInspection } {
+  const defaultHandler = createProxy(config.defaultProxy);
+  const handlers = new Map<string, ReturnType<typeof createProxy>>();
+  const definitions = new Map<string, ProviderRouteDefinition>();
+
+  for (const definition of config.providers) {
+    assertProviderId(definition.id);
+    if (definitions.has(definition.id)) {
+      throw new Error(`duplicate provider id: ${definition.id}`);
+    }
+    definitions.set(definition.id, definition);
+    handlers.set(
+      definition.id,
+      createProxy(wrapProviderObserver(definition, config.onRequest)),
+    );
+  }
+
+  const route = async (request: Request): Promise<Response> => {
+    const parsed = parseProviderRoute(new URL(request.url).pathname);
+    if (!parsed) return defaultHandler(request);
+
+    const handler = handlers.get(parsed.providerId);
+    if (!handler) {
+      return new Response(
+        JSON.stringify({
+          error: 'unknown_provider',
+          provider: parsed.providerId,
+        }),
+        {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    }
+
+    return handler(rewriteProviderRequest(request, parsed));
+  };
+
+  return Object.assign(route, {
+    inspect(): ProviderRouterInspection {
+      return {
+        defaultRoute: 'legacy',
+        providers: [...definitions.values()].map((definition) => ({
+          id: definition.id,
+          protocol: definition.protocol,
+          prefix: `${PREFIX}${definition.id}`,
+        })),
+      };
+    },
+  });
+}

--- a/src/core/provider-router.ts
+++ b/src/core/provider-router.ts
@@ -100,6 +100,16 @@ function rewriteProviderRequest(request: Request, route: ParsedProviderRoute): R
   return new Request(sourceUrl, init);
 }
 
+function invalidProviderRoute(): Response {
+  return new Response(
+    JSON.stringify({ error: 'invalid_provider_route' }),
+    {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
 /**
  * Create one request handler that multiplexes several provider-specific
  * `createProxy` instances behind one Web-standard request handler.
@@ -128,8 +138,11 @@ export function createProviderRouter(
   }
 
   const route = async (request: Request): Promise<Response> => {
-    const parsed = parseProviderRoute(new URL(request.url).pathname);
-    if (!parsed) return defaultHandler(request);
+    const pathname = new URL(request.url).pathname;
+    const parsed = parseProviderRoute(pathname);
+    // `/providers/` is a reserved internal namespace. Malformed explicit routes
+    // must never fall through to the legacy/default upstream.
+    if (!parsed) return pathname.startsWith(PREFIX) ? invalidProviderRoute() : defaultHandler(request);
 
     const handler = handlers.get(parsed.providerId);
     if (!handler) {

--- a/src/core/provider-router.ts
+++ b/src/core/provider-router.ts
@@ -35,7 +35,8 @@ export interface ProviderRouterInspection {
 }
 
 const PROVIDER_ID = /^[a-z][a-z0-9-]{0,62}$/;
-const PREFIX = '/providers/';
+const PROVIDER_ROOT = '/providers';
+const PREFIX = `${PROVIDER_ROOT}/`;
 
 export function assertProviderId(id: string): void {
   if (!PROVIDER_ID.test(id)) {
@@ -64,6 +65,10 @@ export function parseProviderRoute(pathname: string): ParsedProviderRoute | null
   const upstreamPath = remainder.slice(slash);
   if (!upstreamPath.startsWith('/') || upstreamPath.startsWith('//')) return null;
   return { providerId, upstreamPath };
+}
+
+function isProviderNamespace(pathname: string): boolean {
+  return pathname === PROVIDER_ROOT || pathname.startsWith(PREFIX);
 }
 
 function wrapProviderObserver(
@@ -140,9 +145,9 @@ export function createProviderRouter(
   const route = async (request: Request): Promise<Response> => {
     const pathname = new URL(request.url).pathname;
     const parsed = parseProviderRoute(pathname);
-    // `/providers/` is a reserved internal namespace. Malformed explicit routes
+    // `/providers` is a reserved internal namespace. Malformed explicit routes
     // must never fall through to the legacy/default upstream.
-    if (!parsed) return pathname.startsWith(PREFIX) ? invalidProviderRoute() : defaultHandler(request);
+    if (!parsed) return isProviderNamespace(pathname) ? invalidProviderRoute() : defaultHandler(request);
 
     const handler = handlers.get(parsed.providerId);
     if (!handler) {

--- a/src/core/provider-router.ts
+++ b/src/core/provider-router.ts
@@ -74,9 +74,6 @@ function wrapProviderObserver(
   return {
     ...definition.proxy,
     onRequest: async (event) => {
-      // Keep provider identity explicit even for generic OpenAI-compatible
-      // providers whose core handler would otherwise leave it unset.
-      event.provider ??= definition.id;
       await providerObserver?.(event);
       await routerObserver?.(definition.id, event);
     },

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -4,6 +4,10 @@
  */
 
 import { markCacheDead, noteCacheOutcome, responseLeftNoCache } from './session-state.js';
+import {
+  invalidateCodexCacheState,
+  noteCodexCacheOutcome,
+} from './codex-cache-state.js';
 import { transformRequest, type TransformOptions, type TransformInfo } from './transform.js';
 import { isClaudeModel, transformOpenAIChatCompletions, transformOpenAIResponses } from './openai.js';
 import { isAnthropicMessagesPath, isPxpipeSupportedGptModel, isPxpipeSupportedModel } from './applicability.js';
@@ -54,6 +58,9 @@ export interface ProxyConfig {
    * models retain normal Anthropic routing. */
   openAIModels?: string[];
   cloudflareModels?: string[];
+  /** Enable cache/materiality-aware Responses history admission on the dedicated
+   * Codex route. Generic OpenAI-compatible routes keep their existing policy. */
+  codexOptimization?: boolean;
   /** Pass a function to inject dynamic values per-request (e.g. live charsPerToken);
    *  static object for Workers/tests. */
   transform?: TransformOptions | (() => TransformOptions);
@@ -1384,6 +1391,18 @@ export function createProxy(config: ProxyConfig = {}) {
     const t0 = Date.now();
     const url = new URL(req.url);
     const path = url.pathname + url.search;
+    // Codex exposes a per-thread request identity in a header. Its broader
+    // session/cache lineage may be shared by root and subagent requests, but
+    // adaptive history admission is trajectory-local: fingerprint thread-id so
+    // two threads can never reuse each other's observer state.
+    // Missing thread identity deliberately yields no cache key: the optimizer
+    // then fails closed to a native request instead of guessing a trajectory.
+    const codexThreadId = config.codexOptimization
+      ? req.headers.get('thread-id')?.trim()
+      : undefined;
+    const codexSessionKey = codexThreadId
+      ? (await sha256Text(codexThreadId)).slice(0, 16)
+      : undefined;
 
     // Reversibly disguise the configured upstream id for Claude Code's model
     // picker, matching CLIProxyAPI. The id decodes back to the exact provider
@@ -1648,9 +1667,15 @@ const model = googleModel ?? readModelField(bodyIn);
         if ((bridgedGptMessages || bridgedChatMessages) && effectiveModel) {
           requestModel = effectiveModel;
         }
+        const routeTransformOpts: TransformOptions = {
+          ...transformOpts,
+          ...(config.codexOptimization
+            ? { codexOptimization: true, codexSessionKey }
+            : {}),
+        };
         const effectiveOpts = modelOk
-          ? transformOpts
-          : { ...transformOpts, compress: false };
+          ? routeTransformOpts
+          : { ...routeTransformOpts, compress: false };
         const bridgeBody = bridgedGptMessages
           ? (() => {
               const bridged = JSON.parse(new TextDecoder().decode(
@@ -2014,6 +2039,21 @@ const model = googleModel ?? readModelField(bodyIn);
     responseContentType = upstreamRes.headers.get('content-type') ?? undefined;
     responseContentEncoding = upstreamRes.headers.get('content-encoding') ?? undefined;
 
+    // Native Codex compaction replaces the history while keeping the same
+    // thread-id. A successful compact therefore invalidates the PREVIOUS
+    // trajectory observation before Codex can issue its next regular turn.
+    //
+    // Do this from the HTTP success result rather than waiting for usage:
+    // /responses/compact is deliberately not a Responses-transform/usage-scan
+    // route, and the next request must never see stale pre-compact pressure.
+    if (
+      config.codexOptimization
+      && url.pathname === '/backend-api/codex/responses/compact'
+      && upstreamRes.ok
+    ) {
+      invalidateCodexCacheState(codexSessionKey);
+    }
+
     // Tee: client gets one side; scanner reads the other for usage/measurement/error body.
 let teed: Response;
     let usagePromise: Promise<Usage | undefined>;
@@ -2054,6 +2094,14 @@ let teed: Response;
         usage?.cache_read_input_tokens,
         usage?.cache_creation_input_tokens,
       );
+      if (config.codexOptimization) {
+        noteCodexCacheOutcome(codexSessionKey, {
+          inputTokens: usage?.input_tokens,
+          cachedTokens: usage?.cached_tokens,
+          compressed: Boolean(info?.compressed && (info?.imageCount ?? 0) > 0),
+          historySegmentShas: info?.historySegmentShas,
+        });
+      }
       fire(
         upstreamRes.status,
         info,

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -125,6 +125,15 @@ export interface TransformOptions {
    *  image(s), keeping the recent tail as text. Independent of the static slab.
    *  Default on. See src/core/openai-history.ts. */
   collapseHistory?: boolean;
+  /** Dedicated Codex-route optimization policy. When true, Responses history
+   *  admission is cache-aware and materiality-gated, and only append-stable
+   *  history packs may extend a warm compressed prefix. Generic OpenAI clients
+   *  keep the historical behavior unless their host explicitly opts in. */
+  codexOptimization?: boolean;
+  /** Opaque per-thread cache-state key supplied by the Codex route. The Node
+   *  host fingerprints Codex's `thread-id` before passing it here; raw thread
+   *  identifiers are never retained by the transform/cache observer. */
+  codexSessionKey?: string;
   /** GPT only: history-collapse tuning overrides (keepTail / collapseChunk / …). */
   gptHistory?: Partial<GptHistoryOptions>;
   /** Re-pack image-bound text into a ↵-delimited stream to fill `cols` (~29%→75-80%
@@ -158,6 +167,8 @@ const DEFAULTS: Required<TransformOptions> = {
   maxImageBytes: 18 * 1024 * 1024,
   charsPerToken: 4,
   historyAmortizationHorizon: 1,
+  codexOptimization: false,
+  codexSessionKey: '',
   priorWarmTokens: 0,
   priorWarmImageTokens: 0,
   reflow: true,
@@ -653,6 +664,34 @@ export interface TransformInfo {
     collapsedFunctionPairs?: number;
     collapsedFunctionCalls?: number;
     collapsedFunctionOutputs?: number;
+    /** Custom-tool protocol accounting (Codex uses custom tools heavily). */
+    customToolCalls?: number;
+    customToolOutputs?: number;
+    completedCustomToolPairs?: number;
+    recentNativeCustomToolPairs?: number;
+    oldCustomToolPairs?: number;
+    openCustomToolCalls?: number;
+    orphanCustomToolOutputs?: number;
+    malformedCustomToolItems?: number;
+    imageableCustomToolCalls?: number;
+    imageableCustomToolOutputs?: number;
+    collapsedCustomToolPairs?: number;
+    collapsedCustomToolCalls?: number;
+    collapsedCustomToolOutputs?: number;
+    /** Cache/materiality decision from the dedicated Codex optimizer. */
+    priorCacheSharePct?: number;
+    historyStablePrefixSegments?: number;
+    historyCandidateRawSaving?: number;
+    historyCandidateRawSavingPct?: number;
+    historyCandidateSavingPerImage?: number;
+    historyCacheDecision?:
+      | 'not_codex'
+      | 'no_prior_usage'
+      | 'cold_or_low_cache'
+      | 'warm_native_blocked'
+      | 'warm_append_only'
+      | 'warm_mutation_blocked'
+      | 'context_pressure_override';
     /** Item `type` values that acted as a hard barrier in the Responses
      *  planner, with occurrence counts (`local_shell_call:12`). Every barrier
      *  forces a page break, so a frequent type here is directly responsible
@@ -750,6 +789,10 @@ export interface TransformInfo {
    *  proves Anthropic's prompt cache can `cache_read` (0.1×) instead of `cache_create`.
    *  A changing hash means cache-key drift is back. Only set when collapse produced images. */
   historyImageSha?: string;
+  /** Per-page sha8 digests for cache-stability comparison on the next Codex
+   *  request. Kept in-memory on TransformInfo; tracker persists only bounded
+   *  diagnostics, never PNG bytes or prompt text. */
+  historySegmentShas?: string[];
   /** Freeze-grid step the history collapse actually used, in messages. Rises when the
    *  adaptive packer merges chunks to fit the image budget; must never fall within a
    *  session (a finer re-cut re-keys every chunk). */
@@ -794,6 +837,8 @@ export interface TransformInfo {
     | 'below_min_chars'
     | 'below_min_tokens'
     | 'not_profitable'
+    | 'not_material'
+    | 'cache_preservation'
     | 'too_many_images'
     /** Rendered, then not applied: the collapse group did not fit the decoded
      *  image-byte budget, so the original text stands. Distinct from

--- a/src/node.ts
+++ b/src/node.ts
@@ -14,7 +14,9 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { isIP } from 'node:net';
 import { spawnSync } from 'node:child_process';
-import { createProxy, parseGatewayHeaders, resolveUpstreams, type ProxyConfig } from './core/proxy.js';
+import { parseGatewayHeaders, resolveUpstreams, type ProxyConfig } from './core/proxy.js';
+import { createProviderRouter } from './core/provider-router.js';
+import { buildCodexProxyConfig } from './core/codex.js';
 import {
   chatCompletionsUrl,
 } from './core/messages-chat-bridge.js';
@@ -1329,7 +1331,19 @@ async function main(): Promise<void> {
       tracker.emit(toTrackEvent(e));
     },
   };
-  const handle = createProxy(config);
+  // Codex uses ChatGPT OAuth plus the Responses API. Give it an isolated route
+  // so ordinary OpenAI/API-key traffic keeps its configured upstream while the
+  // caller's own ChatGPT bearer remains untouched. Both bases point at
+  // chatgpt.com: `/backend-api/codex/responses` is transformed by core, while
+  // native `/responses/compact` and `/models` pass through byte-for-byte.
+  const handle = createProviderRouter({
+    defaultProxy: config,
+    providers: [{
+      id: 'codex',
+      protocol: 'openai',
+      proxy: buildCodexProxyConfig(config),
+    }],
+  });
 
   const server = createServer((req, res) => {
     Promise.resolve()

--- a/tests/codex-cache-optimizer.test.ts
+++ b/tests/codex-cache-optimizer.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearCodexCacheState,
+  getCodexCacheHint,
+  noteCodexCacheOutcome,
+} from '../src/core/codex-cache-state.js';
+import { buildCodexProxyConfig } from '../src/core/codex.js';
+import { transformOpenAIResponses } from '../src/core/openai.js';
+import { createProviderRouter } from '../src/core/provider-router.js';
+
+const enc = new TextEncoder();
+const THREAD_A = 'thread-a-fingerprint';
+const THREAD_B = 'thread-b-fingerprint';
+
+async function observerKey(rawThreadId: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    enc.encode(rawThreadId),
+  );
+
+  return Array.from(
+    new Uint8Array(digest),
+    (byte) => byte.toString(16).padStart(2, '0'),
+  ).join('').slice(0, 16);
+}
+
+function build(pairs: number): Uint8Array {
+  const input: Array<Record<string, unknown>> = [
+    { role: 'user', content: 'Audit this repository thoroughly and continue until done.' },
+  ];
+  for (let i = 0; i < pairs; i += 1) {
+    const id = `cc_${i}`;
+    input.push({
+      type: 'custom_tool_call',
+      id: `ct_${id}`,
+      call_id: id,
+      name: 'exec_command',
+      input: `read file ${i}`,
+    });
+    input.push({
+      type: 'custom_tool_call_output',
+      call_id: id,
+      output: Array.from({ length: 120 }, (_, j) =>
+        `file_${i}_${j}.ts symbol_${i}_${j} arg_${j}=value_${i}_${j} ` +
+        `checksum=${(i * 1000 + j).toString(16).padStart(8, '0')} ` +
+        `path=/tmp/repo_${i}/module_${j}/handler_${j}.ts`,
+      ).join('\n'),
+    });
+  }
+  input.push({ role: 'assistant', content: 'Still working on the live task.' });
+  return enc.encode(JSON.stringify({
+    model: 'gpt-5.6-sol',
+    instructions: 'Keep all live tool state exact.',
+    input,
+  }));
+}
+
+beforeEach(() => clearCodexCacheState());
+afterEach(() => vi.unstubAllGlobals());
+
+describe('Codex protocol-aware history', () => {
+  it('accounts completed custom-tool rounds instead of treating every call as a barrier', async () => {
+    const result = await transformOpenAIResponses(build(10), { codexOptimization: false });
+    const c = result.info.responsesComposition!;
+    expect(c.customToolCalls ?? 0).toBeGreaterThan(0);
+    expect(c.customToolOutputs ?? 0).toBeGreaterThan(0);
+    expect(c.completedCustomToolPairs).toBe(10);
+    expect(c.malformedCustomToolItems).toBe(0);
+    const customCallBarriers = c.barrierTypes?.filter((x) => x.startsWith('custom_tool_call:')) ?? [];
+    // The newest protected/live boundary may remain native; closed historical
+    // rounds must not each become their own barrier.
+    expect(customCallBarriers.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('Codex cache-stable admission', () => {
+  it('observes one native request before creating the first image epoch', async () => {
+    const first = await transformOpenAIResponses(build(12), { codexOptimization: true, codexSessionKey: THREAD_A });
+    expect(first.info.firstUserSha8).toMatch(/^[0-9a-f]{8}$/);
+    expect(first.info.historyReason).toBe('cache_preservation');
+    expect(first.info.responsesComposition?.historyCacheDecision).toBe('no_prior_usage');
+    expect(first.info.collapsedImages ?? 0).toBe(0);
+  });
+
+  it('blocks a warm native prefix but permits a material cold transition', async () => {
+    const probe = await transformOpenAIResponses(build(12), { codexOptimization: true, codexSessionKey: THREAD_A });
+    const key = THREAD_A;
+
+    noteCodexCacheOutcome(key, { inputTokens: 120_000, cachedTokens: 110_000, compressed: false });
+    const warm = await transformOpenAIResponses(build(12), { codexOptimization: true, codexSessionKey: THREAD_A });
+    expect(warm.info.historyReason).toBe('cache_preservation');
+    expect(warm.info.responsesComposition?.historyCacheDecision).toBe('warm_native_blocked');
+
+    noteCodexCacheOutcome(key, { inputTokens: 120_000, cachedTokens: 10_000, compressed: false });
+    const cold = await transformOpenAIResponses(build(12), { codexOptimization: true, codexSessionKey: THREAD_A });
+    expect(cold.info.responsesComposition?.historyCacheDecision).toBe('cold_or_low_cache');
+    expect(cold.info.historyReason).toBe('collapsed');
+    expect(cold.info.collapsedImages ?? 0).toBeGreaterThan(0);
+    expect(cold.info.responsesComposition?.historyCandidateRawSaving ?? 0).toBeGreaterThan(1024);
+    expect(cold.info.responsesComposition?.historyCandidateRawSavingPct ?? 0).toBeGreaterThanOrEqual(15);
+  });
+
+  it('does not reuse a same-prompt cache hint across Codex thread keys', async () => {
+    noteCodexCacheOutcome(THREAD_A, {
+      inputTokens: 120_000,
+      cachedTokens: 10_000,
+      compressed: false,
+    });
+    const other = await transformOpenAIResponses(build(12), {
+      codexOptimization: true,
+      codexSessionKey: THREAD_B,
+    });
+    expect(other.info.firstUserSha8).toMatch(/^[0-9a-f]{8}$/);
+    expect(other.info.historyReason).toBe('cache_preservation');
+    expect(other.info.responsesComposition?.historyCacheDecision).toBe('no_prior_usage');
+    expect(other.info.collapsedImages ?? 0).toBe(0);
+  });
+
+  it('invalidates stale pressure after successful native compaction only', async () => {
+    const rawThreadId = 'thread-native-compact';
+    const key = await observerKey(rawThreadId);
+
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://api.anthropic.example',
+      },
+      providers: [{
+        id: 'codex',
+        protocol: 'openai',
+        proxy: buildCodexProxyConfig({}),
+      }],
+    });
+
+    const request = () => new Request(
+      'http://127.0.0.1:47821/providers/codex/backend-api/codex/responses/compact',
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer test-oauth',
+          'content-type': 'application/json',
+          'thread-id': rawThreadId,
+        },
+        body: JSON.stringify({
+          model: 'gpt-5.6-sol',
+          input: [{ type: 'opaque', value: 'native compact payload' }],
+        }),
+      },
+    );
+
+    noteCodexCacheOutcome(key, {
+      inputTokens: 900_000,
+      cachedTokens: 100_000,
+      compressed: false,
+    });
+
+    expect(getCodexCacheHint(key)?.inputTokens).toBe(900_000);
+
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () =>
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ));
+
+    const success = await router(request());
+    expect(success.status).toBe(200);
+    expect(getCodexCacheHint(key)).toBeUndefined();
+
+    // A failed compact did not replace the trajectory, so keep the previous
+    // trustworthy observation rather than forcing a needless cold restart.
+    noteCodexCacheOutcome(key, {
+      inputTokens: 900_000,
+      cachedTokens: 100_000,
+      compressed: false,
+    });
+
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () =>
+      new Response('failed', {
+        status: 500,
+        headers: { 'content-type': 'text/plain' },
+      }),
+    ));
+
+    const failed = await router(request());
+    expect(failed.status).toBe(500);
+    expect(getCodexCacheHint(key)?.inputTokens).toBe(900_000);
+  });
+
+  it('extends a warm compressed epoch only when old synthetic segments stay a prefix', async () => {
+    const probe = await transformOpenAIResponses(build(12), { codexOptimization: true, codexSessionKey: THREAD_A });
+    const key = THREAD_A;
+    noteCodexCacheOutcome(key, { inputTokens: 120_000, cachedTokens: 10_000, compressed: false });
+    const established = await transformOpenAIResponses(build(12), { codexOptimization: true, codexSessionKey: THREAD_A });
+    const segments = established.info.historySegmentShas ?? [];
+    expect(segments.length).toBeGreaterThan(0);
+
+    noteCodexCacheOutcome(key, {
+      inputTokens: 130_000,
+      cachedTokens: 125_000,
+      compressed: true,
+      historySegmentShas: segments,
+    });
+    const extended = await transformOpenAIResponses(build(14), { codexOptimization: true, codexSessionKey: THREAD_A });
+    expect(extended.info.responsesComposition?.historyCacheDecision).toBe('warm_append_only');
+    expect(extended.info.responsesComposition?.historyStablePrefixSegments).toBe(segments.length);
+    expect(extended.info.historyReason).toBe('collapsed');
+  });
+});

--- a/tests/codex-cache-state.test.ts
+++ b/tests/codex-cache-state.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearCodexCacheState,
+  getCodexCacheHint,
+  invalidateCodexCacheState,
+  noteCodexCacheOutcome,
+} from '../src/core/codex-cache-state.js';
+
+beforeEach(() => clearCodexCacheState());
+
+describe('Codex cache observation state', () => {
+  it('records explicit trustworthy provider cache usage', () => {
+    noteCodexCacheOutcome('s', {
+      inputTokens: 1_000,
+      cachedTokens: 900,
+      compressed: true,
+      historySegmentShas: ['a', 'b'],
+    }, 123);
+
+    expect(getCodexCacheHint('s')).toEqual({
+      inputTokens: 1_000,
+      cachedTokens: 900,
+      cacheShare: 0.9,
+      compressed: true,
+      historySegmentShas: ['a', 'b'],
+      lastSeenMs: 123,
+    });
+  });
+
+  it('does not turn missing or malformed cache telemetry into a cold signal', () => {
+    noteCodexCacheOutcome('s', {
+      inputTokens: 1_000,
+      cachedTokens: 900,
+      compressed: false,
+    }, 123);
+
+    const trusted = getCodexCacheHint('s');
+    expect(trusted).toBeDefined();
+
+    const malformed = [
+      {
+        inputTokens: 1_000,
+        cachedTokens: undefined,
+        compressed: false,
+      },
+      {
+        inputTokens: 1_000,
+        cachedTokens: Number.NaN,
+        compressed: false,
+      },
+      {
+        inputTokens: 1_000,
+        cachedTokens: -1,
+        compressed: false,
+      },
+      {
+        inputTokens: 1_000,
+        cachedTokens: 1.5,
+        compressed: false,
+      },
+      {
+        inputTokens: 1_000,
+        cachedTokens: Number.MAX_SAFE_INTEGER + 1,
+        compressed: false,
+      },
+      {
+        inputTokens: 1_000,
+        cachedTokens: 1_001,
+        compressed: false,
+      },
+      {
+        inputTokens: 1.5,
+        cachedTokens: 0,
+        compressed: false,
+      },
+      {
+        inputTokens: Number.MAX_SAFE_INTEGER + 1,
+        cachedTokens: 0,
+        compressed: false,
+      },
+    ];
+
+    for (const outcome of malformed) {
+      noteCodexCacheOutcome('s', outcome, 999);
+      expect(getCodexCacheHint('s')).toEqual(trusted);
+    }
+  });
+
+  it('accepts an explicit zero cached-token measurement as a cold signal', () => {
+    noteCodexCacheOutcome('s', {
+      inputTokens: 1_000,
+      cachedTokens: 0,
+      compressed: false,
+    });
+
+    expect(getCodexCacheHint('s')?.cacheShare).toBe(0);
+  });
+
+  it('does not retain page hashes for a native request', () => {
+    noteCodexCacheOutcome('s', {
+      inputTokens: 1_000,
+      cachedTokens: 900,
+      compressed: false,
+      historySegmentShas: ['must-not-survive'],
+    });
+
+    expect(getCodexCacheHint('s')?.historySegmentShas).toEqual([]);
+  });
+
+  it('invalidates only the requested trajectory', () => {
+    noteCodexCacheOutcome('a', {
+      inputTokens: 1_000,
+      cachedTokens: 900,
+      compressed: false,
+    });
+
+    noteCodexCacheOutcome('b', {
+      inputTokens: 2_000,
+      cachedTokens: 1_800,
+      compressed: false,
+    });
+
+    invalidateCodexCacheState('a');
+
+    expect(getCodexCacheHint('a')).toBeUndefined();
+    expect(getCodexCacheHint('b')).toBeDefined();
+  });
+});

--- a/tests/codex-native-routing.test.ts
+++ b/tests/codex-native-routing.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildCodexConfigArgs,
+  buildCodexEnvironment,
+  buildCodexProxyConfig,
+  codexProviderBaseUrl,
+  parseCodexInvocation,
+  resolveCodexPersistentProxy,
+} from '../src/core/codex.js';
+import { resolveCodexModelSelection } from '../src/core/codex-model.js';
+import { createProviderRouter } from '../src/core/provider-router.js';
+
+interface Call {
+  url: string;
+  auth: string | null;
+  gatewayAuth: string | null;
+  body: string;
+}
+
+function installFetch(calls: Call[], responseBody = '{}'): void {
+  vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (input, init) => {
+    const request = input instanceof Request
+      ? input
+      : new Request(String(input), { ...init, ...(init?.body ? { duplex: 'half' as const } : {}) });
+    calls.push({
+      url: request.url,
+      auth: request.headers.get('authorization'),
+      gatewayAuth: request.headers.get('cf-aig-authorization'),
+      body: request.method === 'GET' || request.method === 'HEAD' ? '' : await request.text(),
+    });
+    return new Response(responseBody, { status: 200, headers: { 'content-type': 'application/json' } });
+  }));
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('Codex launcher contract', () => {
+  it('uses the persistent provider route and native OpenAI provider identity', () => {
+    const base = codexProviderBaseUrl(47821);
+    expect(base).toBe('http://127.0.0.1:47821/providers/codex/backend-api/codex');
+    expect(buildCodexConfigArgs(base)).toEqual([
+      '-c', 'model_providers.pxpipe.name=OpenAI',
+      '-c', `model_providers.pxpipe.base_url=${base}`,
+      '-c', 'model_providers.pxpipe.wire_api=responses',
+      '-c', 'model_providers.pxpipe.requires_openai_auth=true',
+      '-c', 'model_providers.pxpipe.supports_websockets=false',
+      '-c', 'model_provider=pxpipe',
+    ]);
+  });
+
+  it('supports alternate Codex binaries without changing their home/auth state', () => {
+    expect(parseCodexInvocation(['codex', '--binary', 'codex-ar', '--', 'exec', 'hello'])).toEqual({
+      binary: 'codex-ar',
+      direct: false,
+      args: ['exec', 'hello'],
+    });
+    const env = buildCodexEnvironment({
+      CODEX_HOME: '/tmp/codex-alt',
+      OPENAI_BASE_URL: 'https://stale.example',
+      HTTPS_PROXY: 'http://127.0.0.1:9999',
+      NO_PROXY: 'example.test',
+    });
+    expect(env.CODEX_HOME).toBe('/tmp/codex-alt');
+    expect(env.OPENAI_BASE_URL).toBeUndefined();
+    expect(env.HTTPS_PROXY).toBeUndefined();
+    expect(env.NO_PROXY).toContain('127.0.0.1');
+    expect(env.NO_PROXY).toContain('localhost');
+  });
+
+  it('preserves the caller environment for direct launches', () => {
+    const source = {
+      CODEX_HOME: '/tmp/codex-alt',
+      OPENAI_BASE_URL: 'https://custom-openai.example/v1',
+      HTTPS_PROXY: 'http://127.0.0.1:9999',
+      NO_PROXY: 'example.test',
+    };
+
+    const env = buildCodexEnvironment(source, 'direct');
+
+    expect(env).toEqual(source);
+    expect(env).not.toBe(source);
+  });
+
+  it('resolves explicit model, profile model, then top-level config', () => {
+    const config = `
+model = "gpt-config"
+profile = "work"
+
+[profiles.work]
+model = "gpt-profile"
+`;
+    expect(resolveCodexModelSelection(['--model', 'gpt-cli'], config, 'gpt-ref')).toEqual({
+      model: 'gpt-cli', source: 'cli',
+    });
+    expect(resolveCodexModelSelection([], config, 'gpt-ref')).toEqual({
+      model: 'gpt-profile', source: 'profile', profile: 'work',
+    });
+    expect(resolveCodexModelSelection([], 'model = "gpt-config"', 'gpt-ref')).toEqual({
+      model: 'gpt-config', source: 'config',
+    });
+  });
+
+  it('health-checks the existing listener without starting another one', async () => {
+    const calls: Call[] = [];
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      calls.push({
+        url: String(input),
+        auth: null,
+        gatewayAuth: null,
+        body: '',
+      });
+      return new Response('{}', { status: 200 });
+    });
+    await expect(resolveCodexPersistentProxy({ PORT: '47821' }, fetchFn)).resolves.toEqual({
+      baseUrl: codexProviderBaseUrl(47821),
+      port: 47821,
+    });
+    expect(calls[0]!.url).toBe('http://127.0.0.1:47821/proxy-stats');
+  });
+});
+
+describe('Codex provider route', () => {
+  function router() {
+    return createProviderRouter({
+      defaultProxy: { upstream: 'https://api.anthropic.example' },
+      providers: [{
+        id: 'codex',
+        protocol: 'openai',
+        proxy: {
+          upstream: 'https://chatgpt.com',
+          openAIUpstream: 'https://chatgpt.com',
+          openAIModels: [],
+          cloudflareModels: [],
+        },
+      }],
+    });
+  }
+
+  it('forwards ChatGPT Responses to the exact native endpoint and preserves caller OAuth', async () => {
+    const calls: Call[] = [];
+    installFetch(calls, '{"id":"resp_test"}');
+    const jwt = 'Bearer eyJhbGciOiJub25lIn0.abc.def';
+    const response = await router()(new Request(
+      'http://127.0.0.1:47821/providers/codex/backend-api/codex/responses',
+      {
+        method: 'POST',
+        headers: { authorization: jwt, 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-unconfigured-test', input: 'hello', stream: false }),
+      },
+    ));
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://chatgpt.com/backend-api/codex/responses');
+    expect(calls[0]!.auth).toBe(jwt);
+  });
+
+  it('does not inherit gateway routing or credentials into the Codex route', async () => {
+    const calls: Call[] = [];
+    installFetch(calls);
+
+    const isolated = buildCodexProxyConfig({
+      provider: 'cloudflare-ai-gateway',
+      gatewayBaseUrl: 'https://gateway.example',
+      gatewayHeaders: {
+        'cf-aig-authorization': 'Bearer gateway-secret',
+      },
+      upstream: 'https://legacy-anthropic.example',
+      openAIUpstream: 'https://legacy-openai.example',
+      cloudflareUpstream: 'https://legacy-cloudflare.example',
+      cloudflareApiKey: 'cloudflare-secret',
+    });
+
+    const gatewayRouter = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy-anthropic.example',
+      },
+      providers: [{
+        id: 'codex',
+        protocol: 'openai',
+        proxy: isolated,
+      }],
+    });
+
+    const oauth = 'Bearer chatgpt-oauth-token';
+
+    const response = await gatewayRouter(new Request(
+      'http://127.0.0.1:47821/providers/codex/backend-api/codex/responses',
+      {
+        method: 'POST',
+        headers: {
+          authorization: oauth,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-unconfigured-test',
+          input: 'hello',
+          stream: false,
+        }),
+      },
+    ));
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url)
+      .toBe('https://chatgpt.com/backend-api/codex/responses');
+    expect(calls[0]!.auth).toBe(oauth);
+    expect(calls[0]!.gatewayAuth).toBeNull();
+  });
+
+  it('forwards native compact byte-for-byte on the same authenticated route', async () => {
+    const calls: Call[] = [];
+    installFetch(calls);
+    const body = '{"model":"gpt-test","input":[{"type":"opaque","value":"  exact  "}]}';
+    const jwt = 'Bearer eyJhbGciOiJub25lIn0.abc.def';
+    const response = await router()(new Request(
+      'http://127.0.0.1:47821/providers/codex/backend-api/codex/responses/compact',
+      {
+        method: 'POST',
+        headers: { authorization: jwt, 'content-type': 'application/json' },
+        body,
+      },
+    ));
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://chatgpt.com/backend-api/codex/responses/compact');
+    expect(calls[0]!.auth).toBe(jwt);
+    expect(calls[0]!.body).toBe(body);
+  });
+});

--- a/tests/openai-gpt5.test.ts
+++ b/tests/openai-gpt5.test.ts
@@ -1089,7 +1089,7 @@ describe('resolveGptProfile (Claude on Responses)', () => {
         keepRecentPairs: 1,
         minCollapseTokens: 1000,
         framing: 'compact',
-        factSheetScope: 'combined',
+        factSheetScope: 'per-segment',
       });
       expect(sol.factSheetFormat, model).toBe('full');
     }

--- a/tests/openai-history.test.ts
+++ b/tests/openai-history.test.ts
@@ -643,3 +643,94 @@ describe('planResponsesPairCollapse — native state classification', () => {
     expect(plan.selectedIndices).not.toContain(5);
   });
 });
+
+describe('planResponsesPairCollapse — Codex custom-tool protocol', () => {
+  const customPair = (id: string, outputWords = 1200): Array<Record<string, unknown>> => [
+    {
+      type: 'custom_tool_call', id: `ct_${id}`, call_id: id,
+      name: 'exec_command', input: `run ${id}`,
+    },
+    {
+      type: 'custom_tool_call_output', call_id: id,
+      output: `${id} ${'result '.repeat(outputWords)}`,
+    },
+  ];
+
+  it('pairs completed custom_tool_call/output state instead of treating it as a barrier', async () => {
+    const items: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < 8; i++) items.push(...customPair(`c${i}`));
+    const plan = await planResponsesPairCollapse(items, yes, {
+      responsesMode: 'mixed', keepRecentPairs: 2, minCollapseTokens: 1, maxImages: 100,
+    });
+    expect(plan.pairState).toMatchObject({
+      completedCustomToolPairs: 8,
+      recentCustomToolPairs: 2,
+      oldCustomToolPairs: 6,
+      openCustomToolCalls: 0,
+      orphanCustomToolOutputs: 0,
+      malformedCustomToolItems: 0,
+    });
+    expect(plan.pairState.collapsedCustomToolPairs).toBeGreaterThan(0);
+    // The newest protected native custom-tool round is a deliberate barrier;
+    // older completed rounds must no longer create one barrier per call.
+    expect(plan.barrierTypes?.get('custom_tool_call') ?? 0).toBeLessThanOrEqual(1);
+    expect(plan.barrierTypes?.has('custom_tool_call_output')).not.toBe(true);
+    const selected = new Set(plan.selectedIndices);
+    for (let i = 0; i < items.length; i += 2) {
+      expect(selected.has(i)).toBe(selected.has(i + 1));
+    }
+  });
+
+  it('keeps incomplete, orphaned and duplicate custom-tool state native', async () => {
+    const items: Array<Record<string, unknown>> = [
+      ...customPair('good'),
+      { type: 'custom_tool_call', call_id: 'open', name: 'shell', input: 'pwd' },
+      { type: 'custom_tool_call_output', call_id: 'orphan', output: 'x' },
+      { type: 'custom_tool_call', call_id: 'dup', name: 'shell', input: 'a' },
+      { type: 'custom_tool_call', call_id: 'dup', name: 'shell', input: 'b' },
+      { type: 'custom_tool_call_output', call_id: 'dup', output: 'x' },
+    ];
+    const plan = await planResponsesPairCollapse(items, yes, {
+      responsesMode: 'mixed', keepRecentPairs: 0, minCollapseTokens: 1, maxImages: 100,
+    });
+    expect(plan.pairState).toMatchObject({
+      completedCustomToolPairs: 1,
+      openCustomToolCalls: 1,
+      orphanCustomToolOutputs: 1,
+      malformedCustomToolItems: 3,
+    });
+    const selected = new Set(plan.selectedIndices);
+    expect(selected.has(0)).toBe(true);
+    expect(selected.has(1)).toBe(true);
+    for (let i = 2; i < items.length; i++) expect(selected.has(i)).toBe(false);
+  });
+
+  it('seals immutable token-sized Responses sections and leaves a partial tail native', async () => {
+    const makeMessage = (i: number): Record<string, unknown> => ({
+      role: i % 2 ? 'assistant' : 'user',
+      content: `turn-${i} ${'alpha beta gamma delta '.repeat(170)}`,
+    });
+    const first = Array.from({ length: 14 }, (_, i) => makeMessage(i));
+    const opts = {
+      responsesMode: 'mixed' as const,
+      keepTail: 1,
+      keepRecentPairs: 0,
+      minCollapseTokens: 1,
+      maxImages: 100,
+      responsesSectionTokens: 1_500,
+    };
+    const p1 = await planResponsesPairCollapse(first, yes, opts);
+    expect(p1.segments.length).toBeGreaterThan(0);
+    const p1Sources = p1.segments.map((s) => s.text);
+    const p1Bytes = p1.segments.flatMap((s) => s.images.map((img) => Buffer.from(img.png).toString('base64')));
+
+    const extended = [...first, makeMessage(14), makeMessage(15), makeMessage(16)];
+    const p2 = await planResponsesPairCollapse(extended, yes, opts);
+    expect(p2.segments.length).toBeGreaterThanOrEqual(p1.segments.length);
+    expect(p2.segments.slice(0, p1Sources.length).map((s) => s.text)).toEqual(p1Sources);
+    const p2Bytes = p2.segments.flatMap((s) => s.images.map((img) => Buffer.from(img.png).toString('base64')));
+    expect(p2Bytes.slice(0, p1Bytes.length)).toEqual(p1Bytes);
+    // Latest protected tail stays native and cannot be selected into a section.
+    expect(p2.selectedIndices).not.toContain(extended.length - 1);
+  });
+});

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -56,6 +56,7 @@ describe('provider route parsing', () => {
 
   it('does not treat incomplete or malformed paths as valid provider routes', () => {
     expect(parseProviderRoute('/v1/messages')).toBeNull();
+    expect(parseProviderRoute('/providers')).toBeNull();
     expect(parseProviderRoute('/providers/')).toBeNull();
     expect(parseProviderRoute('/providers/OpenAI/v1/chat/completions')).toBeNull();
     expect(parseProviderRoute('/providers/openai-alt')).toBeNull();
@@ -159,6 +160,7 @@ describe('provider router', () => {
   });
 
   it.each([
+    '/providers',
     '/providers/',
     '/providers/OpenAI/v1/chat/completions',
     '/providers/openai-alt',

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -186,7 +186,7 @@ describe('provider router', () => {
     ));
     expect(response.status).toBe(200);
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe('https://legacy.example/v1/messages');
+    expect(calls[0]!.url).toBe('https://legacy.example/v1/messages?provider=openai-alt');
   });
 
   it('exposes only credential-free provider metadata', () => {

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -54,7 +54,7 @@ describe('provider route parsing', () => {
     });
   });
 
-  it('does not treat incomplete or malformed paths as explicit provider routes', () => {
+  it('does not treat incomplete or malformed paths as valid provider routes', () => {
     expect(parseProviderRoute('/v1/messages')).toBeNull();
     expect(parseProviderRoute('/providers/')).toBeNull();
     expect(parseProviderRoute('/providers/OpenAI/v1/chat/completions')).toBeNull();
@@ -155,6 +155,33 @@ describe('provider router', () => {
       error: 'unknown_provider',
       provider: 'not-configured',
     });
+    expect(calls).toHaveLength(0);
+  });
+
+  it.each([
+    '/providers/',
+    '/providers/OpenAI/v1/chat/completions',
+    '/providers/openai-alt',
+    '/providers/openai-alt//v1/chat/completions',
+  ])('fails malformed reserved provider route %s closed', async (pathname) => {
+    const calls: FetchCall[] = [];
+    installEchoFetch(calls);
+    const router = createProviderRouter({
+      defaultProxy: { upstream: 'https://legacy.example' },
+      providers: [{
+        id: 'openai-alt',
+        protocol: 'openai',
+        proxy: { openAIUpstream: 'https://api.openai-alt.example' },
+      }],
+    });
+
+    const response = await router(new Request(`http://127.0.0.1:47821${pathname}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    }));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'invalid_provider_route' });
     expect(calls).toHaveLength(0);
   });
 

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  assertProviderId,
+  createProviderRouter,
+  parseProviderRoute,
+} from '../src/core/provider-router.js';
+
+function echoFetch(calls: Array<{ url: string; body: string; authorization: string | null }>): typeof fetch {
+  return vi.fn<typeof fetch>(async (input, init) => {
+    const request = input instanceof Request
+      ? input
+      : new Request(String(input), {
+          ...init,
+          ...(init?.body ? { duplex: 'half' as const } : {}),
+        });
+    const body = request.method === 'GET' || request.method === 'HEAD'
+      ? ''
+      : await request.text();
+    calls.push({
+      url: request.url,
+      body,
+      authorization: request.headers.get('authorization'),
+    });
+    return new Response(JSON.stringify({ url: request.url, body }), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'x-upstream': new URL(request.url).hostname,
+      },
+    });
+  });
+}
+
+describe('provider route parsing', () => {
+  it('accepts explicit provider paths and strips only the internal prefix', () => {
+    expect(parseProviderRoute('/providers/featherless/v1/chat/completions')).toEqual({
+      providerId: 'featherless',
+      upstreamPath: '/v1/chat/completions',
+    });
+    expect(parseProviderRoute('/providers/anthropic/v1/messages')).toEqual({
+      providerId: 'anthropic',
+      upstreamPath: '/v1/messages',
+    });
+  });
+
+  it('does not treat incomplete or malformed paths as explicit provider routes', () => {
+    expect(parseProviderRoute('/v1/messages')).toBeNull();
+    expect(parseProviderRoute('/providers/')).toBeNull();
+    expect(parseProviderRoute('/providers/Featherless/v1/chat/completions')).toBeNull();
+    expect(parseProviderRoute('/providers/featherless')).toBeNull();
+    expect(parseProviderRoute('/providers/featherless//v1/chat/completions')).toBeNull();
+  });
+
+  it('validates provider identifiers', () => {
+    expect(() => assertProviderId('featherless')).not.toThrow();
+    expect(() => assertProviderId('openai-compatible')).not.toThrow();
+    expect(() => assertProviderId('Bad_Id')).toThrow(/invalid provider id/);
+    expect(() => assertProviderId('')).toThrow(/invalid provider id/);
+  });
+});
+
+describe('provider router', () => {
+  it('routes explicit providers while preserving query, body and response headers', async () => {
+    const defaultCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const featherlessCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const observed: string[] = [];
+
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy.example',
+        customFetch: echoFetch(defaultCalls),
+      },
+      providers: [{
+        id: 'featherless',
+        protocol: 'openai',
+        proxy: {
+          provider: 'featherless',
+          openAIUpstream: 'https://api.featherless.example',
+          featherlessTransformMode: 'off',
+          customFetch: echoFetch(featherlessCalls),
+          onRequest: (event) => observed.push(`provider:${event.provider}`),
+        },
+      }],
+      onRequest: (providerId, event) => {
+        observed.push(`router:${providerId}:${event.provider}`);
+      },
+    });
+
+    const raw = '{"model":"moonshotai/Kimi-K3","messages":[],"spacing":"  preserved  "}';
+    const response = await router(new Request(
+      'http://127.0.0.1:47821/providers/featherless/v1/chat/completions?trace=one',
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer incoming-token',
+          'content-type': 'application/json',
+        },
+        body: raw,
+      },
+    ));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-upstream')).toBe('api.featherless.example');
+    expect(featherlessCalls).toHaveLength(1);
+    expect(featherlessCalls[0]!.url).toBe('https://api.featherless.example/v1/chat/completions?trace=one');
+    expect(featherlessCalls[0]!.authorization).toBe('Bearer incoming-token');
+    expect(featherlessCalls[0]!.body).toBe(raw);
+    await response.text();
+
+    await vi.waitFor(() => {
+      expect(observed).toEqual([
+        'provider:featherless',
+        'router:featherless:featherless',
+      ]);
+    });
+  });
+
+  it('keeps legacy unprefixed routes on the default proxy', async () => {
+    const calls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy-anthropic.example',
+        customFetch: echoFetch(calls),
+      },
+      providers: [],
+    });
+
+    const response = await router(new Request('http://127.0.0.1:47821/v1/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'unsupported-test-model',
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    }));
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://legacy-anthropic.example/v1/messages');
+  });
+
+  it('fails unknown explicit providers closed without contacting any upstream', async () => {
+    const calls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy.example',
+        customFetch: echoFetch(calls),
+      },
+      providers: [],
+    });
+
+    const response = await router(new Request(
+      'http://127.0.0.1:47821/providers/not-configured/v1/messages',
+      { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' },
+    ));
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: 'unknown_provider',
+      provider: 'not-configured',
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('does not let query/header/body provider hints change the selected route', async () => {
+    const defaultCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const explicitCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const router = createProviderRouter({
+      defaultProxy: {
+        upstream: 'https://legacy.example',
+        customFetch: echoFetch(defaultCalls),
+      },
+      providers: [{
+        id: 'featherless',
+        protocol: 'openai',
+        proxy: {
+          provider: 'featherless',
+          openAIUpstream: 'https://api.featherless.example',
+          featherlessTransformMode: 'off',
+          customFetch: echoFetch(explicitCalls),
+        },
+      }],
+    });
+
+    const response = await router(new Request(
+      'http://127.0.0.1:47821/v1/messages?provider=featherless',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-pxpipe-provider': 'featherless',
+        },
+        body: JSON.stringify({ provider: 'featherless', messages: [] }),
+      },
+    ));
+    expect(response.status).toBe(200);
+    expect(defaultCalls).toHaveLength(1);
+    expect(explicitCalls).toHaveLength(0);
+  });
+
+  it('exposes only credential-free provider metadata', () => {
+    const router = createProviderRouter({
+      defaultProxy: { upstream: 'https://legacy.example', apiKey: 'default-secret' },
+      providers: [{
+        id: 'featherless',
+        protocol: 'openai',
+        proxy: {
+          provider: 'featherless',
+          openAIUpstream: 'https://api.featherless.example',
+          openAIApiKey: 'provider-secret',
+        },
+      }],
+    });
+    expect(router.inspect()).toEqual({
+      defaultRoute: 'legacy',
+      providers: [{
+        id: 'featherless',
+        protocol: 'openai',
+        prefix: '/providers/featherless',
+      }],
+    });
+    expect(JSON.stringify(router.inspect())).not.toContain('secret');
+  });
+
+  it('rejects duplicate provider ids', () => {
+    expect(() => createProviderRouter({
+      defaultProxy: { upstream: 'https://legacy.example' },
+      providers: [
+        { id: 'same', protocol: 'anthropic', proxy: { upstream: 'https://a.example' } },
+        { id: 'same', protocol: 'openai', proxy: { openAIUpstream: 'https://b.example' } },
+      ],
+    })).toThrow(/duplicate provider id/);
+  });
+});

--- a/tests/provider-router.test.ts
+++ b/tests/provider-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   assertProviderId,
@@ -6,8 +6,14 @@ import {
   parseProviderRoute,
 } from '../src/core/provider-router.js';
 
-function echoFetch(calls: Array<{ url: string; body: string; authorization: string | null }>): typeof fetch {
-  return vi.fn<typeof fetch>(async (input, init) => {
+interface FetchCall {
+  url: string;
+  body: string;
+  authorization: string | null;
+}
+
+function installEchoFetch(calls: FetchCall[]): void {
+  vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (input, init) => {
     const request = input instanceof Request
       ? input
       : new Request(String(input), {
@@ -29,13 +35,17 @@ function echoFetch(calls: Array<{ url: string; body: string; authorization: stri
         'x-upstream': new URL(request.url).hostname,
       },
     });
-  });
+  }));
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('provider route parsing', () => {
   it('accepts explicit provider paths and strips only the internal prefix', () => {
-    expect(parseProviderRoute('/providers/featherless/v1/chat/completions')).toEqual({
-      providerId: 'featherless',
+    expect(parseProviderRoute('/providers/openai-alt/v1/chat/completions')).toEqual({
+      providerId: 'openai-alt',
       upstreamPath: '/v1/chat/completions',
     });
     expect(parseProviderRoute('/providers/anthropic/v1/messages')).toEqual({
@@ -47,13 +57,13 @@ describe('provider route parsing', () => {
   it('does not treat incomplete or malformed paths as explicit provider routes', () => {
     expect(parseProviderRoute('/v1/messages')).toBeNull();
     expect(parseProviderRoute('/providers/')).toBeNull();
-    expect(parseProviderRoute('/providers/Featherless/v1/chat/completions')).toBeNull();
-    expect(parseProviderRoute('/providers/featherless')).toBeNull();
-    expect(parseProviderRoute('/providers/featherless//v1/chat/completions')).toBeNull();
+    expect(parseProviderRoute('/providers/OpenAI/v1/chat/completions')).toBeNull();
+    expect(parseProviderRoute('/providers/openai-alt')).toBeNull();
+    expect(parseProviderRoute('/providers/openai-alt//v1/chat/completions')).toBeNull();
   });
 
   it('validates provider identifiers', () => {
-    expect(() => assertProviderId('featherless')).not.toThrow();
+    expect(() => assertProviderId('anthropic')).not.toThrow();
     expect(() => assertProviderId('openai-compatible')).not.toThrow();
     expect(() => assertProviderId('Bad_Id')).toThrow(/invalid provider id/);
     expect(() => assertProviderId('')).toThrow(/invalid provider id/);
@@ -61,35 +71,28 @@ describe('provider route parsing', () => {
 });
 
 describe('provider router', () => {
-  it('routes explicit providers while preserving query, body and response headers', async () => {
-    const defaultCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
-    const featherlessCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+  it('routes an explicit OpenAI provider while preserving query, body and auth', async () => {
+    const calls: FetchCall[] = [];
     const observed: string[] = [];
+    installEchoFetch(calls);
 
     const router = createProviderRouter({
-      defaultProxy: {
-        upstream: 'https://legacy.example',
-        customFetch: echoFetch(defaultCalls),
-      },
+      defaultProxy: { upstream: 'https://legacy.example' },
       providers: [{
-        id: 'featherless',
+        id: 'openai-alt',
         protocol: 'openai',
         proxy: {
-          provider: 'featherless',
-          openAIUpstream: 'https://api.featherless.example',
-          featherlessTransformMode: 'off',
-          customFetch: echoFetch(featherlessCalls),
-          onRequest: (event) => observed.push(`provider:${event.provider}`),
+          openAIUpstream: 'https://api.openai-alt.example',
+          openAIModels: ['gpt-test'],
+          onRequest: () => observed.push('provider-observer'),
         },
       }],
-      onRequest: (providerId, event) => {
-        observed.push(`router:${providerId}:${event.provider}`);
-      },
+      onRequest: (providerId) => observed.push(`router:${providerId}`),
     });
 
-    const raw = '{"model":"moonshotai/Kimi-K3","messages":[],"spacing":"  preserved  "}';
+    const raw = '{"model":"gpt-test","messages":[],"spacing":"  preserved  "}';
     const response = await router(new Request(
-      'http://127.0.0.1:47821/providers/featherless/v1/chat/completions?trace=one',
+      'http://127.0.0.1:47821/providers/openai-alt/v1/chat/completions?trace=one',
       {
         method: 'POST',
         headers: {
@@ -101,28 +104,23 @@ describe('provider router', () => {
     ));
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('x-upstream')).toBe('api.featherless.example');
-    expect(featherlessCalls).toHaveLength(1);
-    expect(featherlessCalls[0]!.url).toBe('https://api.featherless.example/v1/chat/completions?trace=one');
-    expect(featherlessCalls[0]!.authorization).toBe('Bearer incoming-token');
-    expect(featherlessCalls[0]!.body).toBe(raw);
+    expect(response.headers.get('x-upstream')).toBe('api.openai-alt.example');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://api.openai-alt.example/v1/chat/completions?trace=one');
+    expect(calls[0]!.authorization).toBe('Bearer incoming-token');
+    expect(calls[0]!.body).toBe(raw);
     await response.text();
 
     await vi.waitFor(() => {
-      expect(observed).toEqual([
-        'provider:featherless',
-        'router:featherless:featherless',
-      ]);
+      expect(observed).toEqual(['provider-observer', 'router:openai-alt']);
     });
   });
 
   it('keeps legacy unprefixed routes on the default proxy', async () => {
-    const calls: Array<{ url: string; body: string; authorization: string | null }> = [];
+    const calls: FetchCall[] = [];
+    installEchoFetch(calls);
     const router = createProviderRouter({
-      defaultProxy: {
-        upstream: 'https://legacy-anthropic.example',
-        customFetch: echoFetch(calls),
-      },
+      defaultProxy: { upstream: 'https://legacy-anthropic.example' },
       providers: [],
     });
 
@@ -140,13 +138,11 @@ describe('provider router', () => {
     expect(calls[0]!.url).toBe('https://legacy-anthropic.example/v1/messages');
   });
 
-  it('fails unknown explicit providers closed without contacting any upstream', async () => {
-    const calls: Array<{ url: string; body: string; authorization: string | null }> = [];
+  it('fails unknown explicit providers closed without contacting an upstream', async () => {
+    const calls: FetchCall[] = [];
+    installEchoFetch(calls);
     const router = createProviderRouter({
-      defaultProxy: {
-        upstream: 'https://legacy.example',
-        customFetch: echoFetch(calls),
-      },
+      defaultProxy: { upstream: 'https://legacy.example' },
       providers: [],
     });
 
@@ -162,51 +158,45 @@ describe('provider router', () => {
     expect(calls).toHaveLength(0);
   });
 
-  it('does not let query/header/body provider hints change the selected route', async () => {
-    const defaultCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
-    const explicitCalls: Array<{ url: string; body: string; authorization: string | null }> = [];
+  it('does not let query/header/body hints select an explicit provider', async () => {
+    const calls: FetchCall[] = [];
+    installEchoFetch(calls);
     const router = createProviderRouter({
-      defaultProxy: {
-        upstream: 'https://legacy.example',
-        customFetch: echoFetch(defaultCalls),
-      },
+      defaultProxy: { upstream: 'https://legacy.example' },
       providers: [{
-        id: 'featherless',
+        id: 'openai-alt',
         protocol: 'openai',
         proxy: {
-          provider: 'featherless',
-          openAIUpstream: 'https://api.featherless.example',
-          featherlessTransformMode: 'off',
-          customFetch: echoFetch(explicitCalls),
+          openAIUpstream: 'https://api.openai-alt.example',
+          openAIModels: ['gpt-test'],
         },
       }],
     });
 
     const response = await router(new Request(
-      'http://127.0.0.1:47821/v1/messages?provider=featherless',
+      'http://127.0.0.1:47821/v1/messages?provider=openai-alt',
       {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
-          'x-pxpipe-provider': 'featherless',
+          'x-pxpipe-provider': 'openai-alt',
         },
-        body: JSON.stringify({ provider: 'featherless', messages: [] }),
+        body: JSON.stringify({ provider: 'openai-alt', messages: [] }),
       },
     ));
     expect(response.status).toBe(200);
-    expect(defaultCalls).toHaveLength(1);
-    expect(explicitCalls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://legacy.example/v1/messages');
   });
 
   it('exposes only credential-free provider metadata', () => {
     const router = createProviderRouter({
       defaultProxy: { upstream: 'https://legacy.example', apiKey: 'default-secret' },
       providers: [{
-        id: 'featherless',
+        id: 'openai-alt',
         protocol: 'openai',
         proxy: {
-          provider: 'featherless',
-          openAIUpstream: 'https://api.featherless.example',
+          openAIUpstream: 'https://api.openai-alt.example',
           openAIApiKey: 'provider-secret',
         },
       }],
@@ -214,9 +204,9 @@ describe('provider router', () => {
     expect(router.inspect()).toEqual({
       defaultRoute: 'legacy',
       providers: [{
-        id: 'featherless',
+        id: 'openai-alt',
         protocol: 'openai',
-        prefix: '/providers/featherless',
+        prefix: '/providers/openai-alt',
       }],
     });
     expect(JSON.stringify(router.inspect())).not.toContain('secret');


### PR DESCRIPTION
> **Stacked on the preceding Codex native-routing draft, which is itself stacked on #223.**
>
> Please review in dependency order. This draft will be rebased/reconstructed after its dependencies merge and revalidated before being marked Ready.

## Problem

Codex benefits from provider-side prompt caching, while modern Responses trajectories can contain completed `function_call` and `custom_tool_call` rounds.

Rebuilding compressed history on every newly-cold turn can mutate an already-warm prefix. Treating custom-tool items as opaque barriers can also fragment history that PXPipe can safely collapse.

A transform that saves raw tokens can therefore still be operationally worse than leaving native Codex history untouched.

## Changes

- pair completed `function_call` and `custom_tool_call` rounds with their outputs by `call_id`;
- keep open, orphaned, malformed, and referenced protocol state native;
- split eligible cold history into deterministic sealed token-sized sections;
- leave the newest partial section native;
- require absolute, relative, and per-image materiality floors;
- observe a native request before creating the first image epoch;
- use provider-reported usage for cache feedback;
- scope cache observations to an opaque SHA-256 fingerprint of Codex `thread-id`;
- never retain the raw thread identifier;
- conservatively disable adaptive cache admission when no stable thread key exists;
- preserve a warm native prefix;
- permit cold/low-cache transitions only after materiality passes;
- allow warm compressed prefixes to grow only through exact append-only extensions;
- use per-segment Sol fact sheets so new sections cannot mutate older synthetic segments;
- retain only bounded token counts and short segment hashes in the cache observer;
- apply the policy only to the dedicated Codex provider route;
- leave generic OpenAI-compatible routing unchanged;
- leave native `/responses/compact` untouched.

## Scope

No Codex launcher/router changes are introduced here; those belong to the preceding draft.

No dashboard redesign, subscription-pricing claim, model promotion, AGY work, or generic OpenAI policy change is included.

## Validation

The isolated export is one commit on top of the clean Codex-routing slice.

Fresh exact-head CI passed:

- production dependency audit;
- TypeScript typecheck;
- focused cache/custom-tool/materiality regressions;
- full test suite;
- build.

The reviewable contract here is protocol/cache correctness and deterministic behavior; this PR makes no new model-readability claim.

Because this is temporarily stacked against upstream `main`, GitHub will initially include changes from its prerequisite PRs in the displayed diff.
