### PR TITLE
fix(transform): stop over-truncating reflowed text in truncateForBudget

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1626,13 +1626,25 @@ export function truncateForBudget(
   const originalLines = lines.length;
   const originalChars = text.length;
 
+  // Reflowed text joins logical lines with the ↵ sentinel, which the renderer
+  // treats as an inline glyph that never forces a row break (see countVisualRows
+  // / wrapLines). So many ↵-segments pack into one visual row — charging one row
+  // per segment (lineRows) overstates rows ~6x and over-truncates. Charge the
+  // packed-row DELTA instead: total rows telescope to ceil(keptChars/cols),
+  // matching the renderer, while still binding the row budget for narrow columns
+  // where the char budget alone would under-truncate.
+  const reflowed = nlChar === NL_SENTINEL;
+  const packedRows = (n: number): number => Math.ceil(n / Math.max(1, cols));
+  const rowCost = (seg: string, priorChars: number, addChars: number): number =>
+    reflowed ? packedRows(priorChars + addChars) - packedRows(priorChars) : lineRows(seg, cols);
+
   if (shape === 'structured') {
     let rows = 0;
     let chars = 0;
     let cut = 0;
     for (let i = 0; i < lines.length; i++) {
-      const r = lineRows(lines[i]!, cols);
       const c = lines[i]!.length + (i > 0 ? 1 : 0);
+      const r = rowCost(lines[i]!, chars, c);
       if (rows + r > totalRowBudget || chars + c > totalCharBudget) break;
       rows += r;
       chars += c;
@@ -1667,8 +1679,8 @@ export function truncateForBudget(
   let headChars = 0;
   let headCut = 0;
   for (let i = 0; i < lines.length; i++) {
-    const r = lineRows(lines[i]!, cols);
     const c = lines[i]!.length + (i > 0 ? 1 : 0);
+    const r = rowCost(lines[i]!, headChars, c);
     if (headRows + r > headRowBudget || headChars + c > headCharBudget) break;
     headRows += r;
     headChars += c;
@@ -1679,8 +1691,8 @@ export function truncateForBudget(
   let tailChars = 0;
   let tailStart = lines.length;
   for (let i = lines.length - 1; i >= headCut; i--) {
-    const r = lineRows(lines[i]!, cols);
     const c = lines[i]!.length + (i < lines.length - 1 ? 1 : 0);
+    const r = rowCost(lines[i]!, tailChars, c);
     if (tailRows + r > tailRowBudget || tailChars + c > tailCharBudget) break;
     tailRows += r;
     tailChars += c;

--- a/tests/paging.test.ts
+++ b/tests/paging.test.ts
@@ -28,6 +28,7 @@ import {
   DENSE_CONTENT_CHARS_PER_IMAGE,
   DENSE_CONTENT_COLS,
   DENSE_RENDER_STYLE,
+  NL_SENTINEL,
   READABLE_CHARS_PER_IMAGE,
   renderTextToPngsWithCharLimit,
 } from '../src/core/render.js';
@@ -315,6 +316,32 @@ describe('truncateForBudget', () => {
     expect(reportedOmittedLines).toBeLessThan(originalLines);
   });
 
+  it('does not over-truncate REFLOWED text (↵-joined segments pack into rows)', () => {
+    // Production feeds truncateForBudget reflowed text: logical lines joined by
+    // NL_SENTINEL, which the renderer packs many-per-visual-row. Charging one
+    // row per segment (the old lineRows path) overstated rows ~6x and kept only
+    // ~1/6 of what fits, wasting most of the image budget. The kept text must
+    // fill close to the char budget (~280k for a 10-image DENSE budget), not
+    // collapse to ~40k.
+    const cols = DENSE_CONTENT_COLS; // 312
+    const segments: string[] = [];
+    for (let i = 0; i < 10_000; i++) {
+      segments.push(`2026-05-18T12:00:00Z entry ${i} payload content here`); // ~48 chars
+    }
+    const reflowed = segments.join(NL_SENTINEL);
+    expect(reflowed.indexOf('\n')).toBe(-1); // genuinely reflowed: no hard newlines
+
+    const { text: out, truncated } = truncateForBudget(reflowed, 10, cols);
+    expect(truncated).toBe(true);
+    // Char budget for 10 DENSE images is ~280k; the fix keeps most of it.
+    // The old per-segment row charge capped this near ~44k — this bound fails there.
+    expect(out.length).toBeGreaterThan(150_000);
+    // Head + tail, both ends preserved.
+    expect(out).toMatch(/Showing first \d+ lines and last \d+ lines/);
+    expect(out).toContain('entry 0');
+    expect(out).toContain('entry 9999');
+  });
+
   it('always shows at least one head line even on degenerate input', () => {
     // Single huge line — bigger than budget. Should still render with marker.
     const text = 'x'.repeat(500_000);
@@ -457,10 +484,10 @@ describe('paging end-to-end (transformRequest)', () => {
     );
     const { info } = await transformRequest(req, { charsPerToken: 2 });
     expect(info.truncatedToolResults).toBe(2);
-    // Both should have been truncated → omittedChars roughly doubled. The
-    // Exact bound depends on renderer configuration: each image
-    // packs ~19.5k chars worst-case. Threshold below covers the single-col case.
-    expect(info.omittedChars).toBeGreaterThan(600_000);
+    // Both truncated → omittedChars is the sum across the two ~530k results.
+    // Each keeps ~one image budget of content (the reflowed row-cost fix stops
+    // the old ~6x over-truncation), so ~250k is omitted per result, ~500k total.
+    expect(info.omittedChars).toBeGreaterThan(400_000);
   });
 
   it('handles array-shaped tool_result content', async () => {


### PR DESCRIPTION
### Problem
`truncateForBudget` receives **reflowed** text in production (tool-result bodies are reflowed before truncation). Reflowed text has no `\n` — logical lines are joined by `NL_SENTINEL` (`↵`), which the renderer treats as an inline glyph that never forces a row break, so many segments pack into one continuous soft-wrapped row.

The head / tail / structured budget loops charged `lineRows(segment, cols)` (≥1 row) **per segment**. Since the renderer packs all segments into one stream, that overstates visual rows by roughly `cols / avgSegmentLen` (~6× for typical short log lines). The row budget is exhausted after ~1/6 of the content that actually fits, so a large tool_result keeps ~44k chars where ~280k fit — silently dropping ~486k and wasting ~8 of every 10 image slots.

### Fix
For reflowed text, charge the **packed-row delta** instead of one row per segment:

```
ceil((priorChars + addChars) / cols) - ceil(priorChars / cols)
```

This telescopes to `ceil(keptChars / cols)`, matching what the renderer actually produces, while still binding the row budget in the narrow-column case where the char budget alone would under-truncate. Genuine `\n` text keeps the existing `lineRows` path unchanged.

### Tests
- Added a reflowed-text regression test in `paging.test.ts`: on `↵`-joined input over budget the kept text must fill close to the ~280k char budget. It **fails on the old per-segment charge** (keeps only ~47k) and passes with the fix.
- Corrected one existing e2e assertion (`omittedChars > 600_000` → `> 400_000`) that was calibrated to the old over-truncation; the `truncatedToolResults === 2` check is unchanged.

Full suite green (1154/1154); `typecheck` clean.

Generated with [Claude Code](https://claude.com/claude-code)
