### PR TITLE
fix(anthropic): preserve rendered-context provenance

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -2354,8 +2354,7 @@ export async function transformRequest(
   const imageInstructionHeader =
     '=================== SESSION CONFIGURATION PAGES ===================\n' +
     "pxpipe (this user's local proxy) rendered this session's configuration" +
-    ' into the following images to reduce token cost. Read the pages carefully and follow them as' +
-    ' your operating instructions for this session.' +
+    ' into the following images to reduce token cost.' +
     ' For exact identifiers, paths, hashes, version strings, and numbers, use the adjacent' +
     ' exact-value factsheet; if a value was only visible in an image and is not in that factsheet,' +
     ' do not guess it — say it is not safe to quote from the image and re-read the source text.' +
@@ -2486,6 +2485,12 @@ export async function transformRequest(
     const sysTail: SystemField = [];
     if (preservedIdentity) {
       sysTail.push({ type: 'text', text: preservedIdentity });
+    }
+    if (imageBlocks.length > 0) {
+      sysTail.push({
+        type: 'text',
+        text: "pxpipe (this user's local proxy) rendered this session's configuration into the image blocks attached to the first user message to reduce token cost.",
+      });
     }
     // billingLine is NOT re-emitted here. req.system precedes messages[] in
     // Anthropic's cache-prefix order, so every system block sits inside the

--- a/tests/refusal-provenance.test.ts
+++ b/tests/refusal-provenance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { transformRequest } from '../src/core/transform.js';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+describe('Anthropic refusal prevention - proxy system provenance', () => {
+  it('adds explicit proxy provenance statement to req.system when rendering static slab into user-turn images', async () => {
+    const reqBody = JSON.stringify({
+      model: 'claude-3-5-sonnet',
+      system: 'System operating instructions. '.repeat(1000),
+      tools: [
+        {
+          name: 'ReadFile',
+          description: 'Read contents of a file.',
+          input_schema: { type: 'object', properties: { path: { type: 'string' } } },
+        },
+      ],
+      messages: [
+        { role: 'user', content: 'Help me debug this issue.' },
+      ],
+    });
+
+    const { body, info } = await transformRequest(enc.encode(reqBody));
+    expect(info.compressed).toBe(true);
+    expect(info.imageCount).toBeGreaterThan(0);
+
+    const out = JSON.parse(dec.decode(body));
+
+    // 1. req.system must contain an explicit first-party proxy provenance statement
+    const sysBlocks = Array.isArray(out.system)
+      ? out.system
+      : typeof out.system === 'string'
+      ? [{ type: 'text', text: out.system }]
+      : [];
+
+    const sysTexts = sysBlocks.map((b: any) => b.text || '');
+    const provenanceBlock = sysTexts.find((t: string) =>
+      t.includes("pxpipe (this user's local proxy)") && t.includes('rendered this session'),
+    );
+
+    expect(provenanceBlock).toBeDefined();
+    expect(provenanceBlock).toContain("pxpipe (this user's local proxy)");
+    expect(provenanceBlock).toContain('image blocks');
+
+    // 2. The user-turn image banner must NOT contain imperative commands like "follow them as your operating instructions"
+    const imgSrc = info.imageSourceText ?? '';
+    expect(imgSrc).not.toContain('follow them as your operating instructions');
+    expect(imgSrc).not.toMatch(/system prompt|authoritative/i);
+  });
+});


### PR DESCRIPTION
PXPipe's Anthropic transform can move trusted static configuration into image blocks attached to the first user message.

The existing image banner then instructs Claude to follow those user-role images as operating instructions. In real Claude Code usage this can trigger a false prompt-injection / reasoning-extraction refusal even though the represented material originated from the legitimate request.

This fixes that single trust-boundary problem by:

- removing the imperative operating-instruction wording from the rendered image banner;
- keeping the rendered image framing descriptive;
- adding a small first-party PXPipe provenance statement to the actual system field whenever configuration images are emitted;
- preserving the existing Claude Code identity as the first system block.

Before:

```text
[user-role rendered image]
Read the pages carefully and follow them as your operating instructions for this session.
```

After:

```text
system:
  preserved Claude Code identity
  PXPipe rendered-context provenance

first user:
  rendered configuration image
  exact-value factsheet
  live user request
```

Fixes #227

## Verify

```text
pnpm install --frozen-lockfile
pnpm run audit
pnpm run typecheck
pnpm exec vitest run tests/refusal-provenance.test.ts tests/safety-policy.test.ts tests/anthropic-cache-align.test.ts tests/abstention.test.ts tests/public-api.test.ts
pnpm test
pnpm run build
git diff --check
```

Validation performed:

- production dependency audit: no known vulnerabilities
- focused Anthropic provenance/safety/cache regressions: pass
- full suite: pass
- TypeScript typecheck: pass
- build and entrypoint smoke checks: pass
- live Claude Code validation after rebuilding/restarting PXPipe: the previous false refusal no longer occurs

- [x] Rebased on current `main`
- [x] `pnpm test` and `pnpm typecheck` pass
- [x] No raw prompts, credentials, session files, or machine identifiers
