### PR TITLE
fix(transform): route cc_automode_*/severity/category into dynamic tail

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -902,6 +902,15 @@ const DYNAMIC_BLOCK_TAGS = [
   // paid for as a create and never read. It was showing up in
   // `unknownStaticTags`, which is exactly the canary that list exists to be.
   'total_tokens',
+  // Newer Claude Code identity/automode block (#234). Left in the static slab
+  // it gets imaged along with the rest of the prefix, and the provider's
+  // subscription-quota recognition on that block breaks -> spurious 429s on
+  // every compressed request. Route it to the dynamic tail instead, same as
+  // total_tokens above.
+  'cc_automode_session_rules',
+  'cc_automode_permissions',
+  'severity',
+  'category',
 ] as const;
 
 // Known-static slab tags — suppresses first-sighting `unknownStaticTags` noise

--- a/tests/dynamic-cc-automode-tags.test.ts
+++ b/tests/dynamic-cc-automode-tags.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `<cc_automode_session_rules>`, `<cc_automode_permissions>`, `<severity>`, and
+ * `<category>` are per-turn blocks emitted by newer Claude Code builds. Left
+ * out of DYNAMIC_BLOCK_TAGS they fall into the static slab and get imaged
+ * along with the rest of the identity block (see #234).
+ *
+ * Same shape as dynamic-total-tokens.test.ts: an unrecognized per-turn tag
+ * re-keys (or, per #234, corrupts the provider's read of) the cacheable
+ * image every turn instead of being routed to the dynamic tail.
+ *
+ * Run just this file:  pnpm vitest run tests/dynamic-cc-automode-tags.test.ts
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { transformRequest } from '../src/core/transform.js';
+import { resetSessionState } from '../src/core/session-state.js';
+
+const big = (n: number) => 'x'.repeat(n);
+const enc = (obj: unknown) => new TextEncoder().encode(JSON.stringify(obj));
+
+/** Claude-Code-shaped system content carrying the newer automode block. */
+function systemWithAutomodeBlock(rulesId: string, severity: string): string {
+  return [
+    'You are a helpful assistant.',
+    big(40_000),
+    `<cc_automode_session_rules>${rulesId}</cc_automode_session_rules>`,
+    '<cc_automode_permissions>allow-all</cc_automode_permissions>',
+    `<severity>${severity}</severity>`,
+    '<category>automode</category>',
+  ].join('\n');
+}
+
+function bodyWithAutomodeBlock(rulesId: string, severity: string) {
+  return enc({
+    model: 'claude-sonnet-5',
+    system: [{ type: 'text', text: systemWithAutomodeBlock(rulesId, severity) }],
+    messages: [{ role: 'user', content: 'go' }],
+  });
+}
+
+describe('cc_automode_* / severity / category are classified as dynamic', () => {
+  beforeEach(() => resetSessionState());
+
+  it('does not report any of the four tags as unknown static blocks', async () => {
+    const { info } = await transformRequest(bodyWithAutomodeBlock('turn-1', 'info'));
+    const unknown = info.unknownStaticTags ?? [];
+    expect(unknown).not.toContain('cc_automode_session_rules');
+    expect(unknown).not.toContain('cc_automode_permissions');
+    expect(unknown).not.toContain('severity');
+    expect(unknown).not.toContain('category');
+  });
+
+  it('keeps the static slab byte-identical when only the block content moves', async () => {
+    const first = await transformRequest(bodyWithAutomodeBlock('turn-1', 'info'));
+    resetSessionState();
+    const second = await transformRequest(bodyWithAutomodeBlock('turn-2', 'warning'));
+
+    // Precondition: this request really did produce an imaged slab.
+    expect(first.info.imageCount).toBeGreaterThan(0);
+    expect(first.info.systemSha8).toBeDefined();
+
+    // The headline: the cacheable image is unchanged across the two turns.
+    expect(second.info.systemSha8).toBe(first.info.systemSha8);
+  });
+
+  it('routes the block into the dynamic text, not the imaged slab', async () => {
+    const first = await transformRequest(bodyWithAutomodeBlock('turn-1', 'info'));
+    resetSessionState();
+    const second = await transformRequest(bodyWithAutomodeBlock('turn-2', 'warning'));
+
+    expect(first.info.dynamicChars ?? 0).toBeGreaterThan(0);
+    expect(second.info.dynamicChars).not.toBe(first.info.dynamicChars);
+  });
+});


### PR DESCRIPTION
<!-- What breaks without this, then the fix. One root cause per PR.
     A before/after example beats prose. -->

`cc_automode_session_rules`, `cc_automode_permissions`, `severity`, and `category` are per-turn
tag-shaped blocks that newer Claude Code builds inject into the system prompt (visible as
`unknownStaticTags` in `pxpipe stats`, which itself suggests adding entries here). None of the
four was in `DYNAMIC_BLOCK_TAGS`, so they fell into the static slab and got imaged along with the
rest of the identity block.

Related to #234: with `claude-sonnet-5` and compression on, requests started failing with 429 out
of nowhere, and the reported `stats`/`DEBUG` output showed these same unknown tags. This PR routes
the four tags into the dynamic tail — same mechanism `total_tokens` already uses, added above for
an analogous reason (see the comment on that entry).

I can't verify *why* the provider's subscription-quota recognition breaks when this block is
imaged — that's on the provider's side, not observable from here. This PR only fixes the
classification bug pxpipe's own telemetry already flagged, and reports what happened before/after
in my environment as real-world evidence, not just the unit test below:

- Model: `claude-sonnet-5`, Claude Code client `2.1.229`. `claude-fable-5,gemini-3.6-flash` are
  the built-in defaults; `claude-sonnet-5` added via `PXPIPE_MODELS` (opt-in, as documented).
- Render geometry: `CLAUDE_LEGIBLE_PROFILE` (172-col history strip, `jetbrains-mono-14`) — the
  default non-Fable Claude profile.
- Before this fix: 10/10 real requests through the proxy with `claude-sonnet-5` compression on
  failed with 429, all within a ~30s window — matches the shape reported in #234.
- After this fix: 9/9 real requests through the proxy (same model, same opt-in config) came back
  `200`, and `unknownStaticTags` no longer listed any of the four tags for those requests.
- Sample size is small (single machine, single session, one date: 2026-08-16/17). This is not a
  claim that it's the only cause of every 429 in #234 — only that it reproduces and resolves this
  specific mechanism. Leaving the broader call to the maintainer per CONTRIBUTING.md.

## Verify

```text
$ pnpm vitest run tests/dynamic-cc-automode-tags.test.ts
# before this diff (revert src/core/transform.ts to see it fail):
 ❯ tests/dynamic-cc-automode-tags.test.ts (3 tests | 3 failed)
     × does not report any of the four tags as unknown static blocks
     × keeps the static slab byte-identical when only the block content moves
     × routes the block into the dynamic text, not the imaged slab

# with this diff:
 ✓ tests/dynamic-cc-automode-tags.test.ts (3 tests | 3 passed)

$ pnpm test
 Test Files  1 failed | 72 passed (73)
      Tests  2 failed | 1154 passed (1156)
# The 2 failures are in tests/image-byte-budget.test.ts, unrelated to this change, and
# pre-exist on a clean `main` checkout — confirmed by stashing this diff and re-running the
# same file against unmodified main (same 2 failures, same assertions).

$ pnpm typecheck
# clean, no output
```

- [x] Rebased on current `main`
- [x] `pnpm test` and `pnpm typecheck` pass (the 2 pre-existing `image-byte-budget.test.ts`
      failures are unrelated to this change and reproduce on a clean `main` checkout — see Verify)
- [x] No raw prompts, credentials, session files, or machine identifiers