### PR TITLE
fix(warp): attach CONNECT proxy to main server and reuse running instance

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -8,6 +8,9 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createWarpRuntime } from './warp/index.js';
+import { CertificateAuthority } from './warp/ca.js';
+import { createWarpHandlers } from './warp/connect.js';
+import { parseRoute } from './warp/route.js';
 import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -1333,7 +1336,24 @@ async function main(): Promise<void> {
   };
   const handle = createProxy(config);
 
+  const defaultWarpRoutes = [
+    parseRoute(`api.anthropic.com/v1/messages*=http://127.0.0.1:${opts.port}`),
+  ];
+  const warpCa = CertificateAuthority.loadOrCreate(path.join(os.homedir(), '.pxpipe'));
+  const warpHandlers = createWarpHandlers({
+    routes: defaultWarpRoutes,
+    ca: warpCa,
+    onDivert: (host, path, target) => {
+      if (!process.stdout.isTTY) console.error(`[pxpipe] warp: ${host}${path} → ${target}`);
+    },
+  });
+
   const server = createServer((req, res) => {
+    // Forward proxy requests (absolute URL form: GET http://...)
+    if (req.url && (req.url.startsWith('http://') || req.url.startsWith('https://'))) {
+      warpHandlers.handleAbsoluteForm(req, res);
+      return;
+    }
     Promise.resolve()
       .then(async () => {
         // Local dashboard routes — handled BEFORE the proxy so they never hit
@@ -1368,6 +1388,8 @@ async function main(): Promise<void> {
       });
   });
 
+  server.on('connect', warpHandlers.handleConnect);
+
   // IPv6 literals need bracket notation to form a valid URL (http://[::1]:47821).
   const displayHost = opts.host.includes(':') ? `[${opts.host}]` : opts.host;
   const isLoopbackHost =
@@ -1376,6 +1398,7 @@ async function main(): Promise<void> {
     const routes = resolveUpstreams(config);
     console.log(`[pxpipe] anthropic upstream → ${routes.anthropic}`);
     console.log(`[pxpipe] openai upstream → ${routes.openai}`);
+    console.log(`[pxpipe] CONNECT proxy enabled → CA: ${warpCa.certPath}`);
     if (opts.cloudflareUpstream !== undefined) {
       console.log(
         `[pxpipe] cloudflare upstream → ${chatCompletionsUrl(opts.cloudflareUpstream)} ` +

--- a/src/warp/index.ts
+++ b/src/warp/index.ts
@@ -17,6 +17,7 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { accessSync, constants, existsSync } from 'node:fs';
 import { createServer } from 'node:http';
+import { connect as netConnect } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -278,15 +279,22 @@ export function createWarpRuntime(options: WarpRuntimeOptions): WarpRuntime {
     }
     console.error(`[pxpipe] warp exec → ${command.join(' ')}`);
 
-    proxy.on('error', (err) => {
-      console.error(`[pxpipe] warp: proxy listener failed: ${err.message}`);
-      process.exit(1);
+    const testSocket = netConnect({ host: '127.0.0.1', port }, () => {
+      testSocket.destroy();
+      console.error(`[pxpipe] warp → reusing running proxy at http://127.0.0.1:${port}`);
+      spawnChild(command, `http://127.0.0.1:${port}`);
     });
-    proxy.listen(0, '127.0.0.1', () => {
-      const address = proxy.address();
-      const proxyUrl = `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}`;
-      console.error(`[pxpipe] warp proxy → ${proxyUrl} (child only)`);
-      spawnChild(command, proxyUrl);
+    testSocket.on('error', () => {
+      proxy.on('error', (err) => {
+        console.error(`[pxpipe] warp: proxy listener failed: ${err.message}`);
+        process.exit(1);
+      });
+      proxy.listen(0, '127.0.0.1', () => {
+        const address = proxy.address();
+        const proxyUrl = `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}`;
+        console.error(`[pxpipe] warp proxy → ${proxyUrl} (child only)`);
+        spawnChild(command, proxyUrl);
+      });
     });
   };
 

--- a/tests/warp-connect.test.ts
+++ b/tests/warp-connect.test.ts
@@ -1,0 +1,75 @@
+import { createServer } from 'node:http';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+import { CertificateAuthority } from '../src/warp/ca.js';
+import { createWarpHandlers } from '../src/warp/connect.js';
+import { parseRoute } from '../src/warp/route.js';
+
+describe('CONNECT proxy and warp integration', () => {
+  it('diverts matching HTTPS requests to the local handler and establishes CONNECT tunnel', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'pxpipe-test-ca-'));
+    const ca = CertificateAuthority.loadOrCreate(tmpDir);
+    let divertCount = 0;
+
+    const testServer = createServer();
+    const port = await new Promise<number>((resolve) => {
+      testServer.listen(0, '127.0.0.1', () => {
+        const addr = testServer.address();
+        resolve(typeof addr === 'object' && addr ? addr.port : 0);
+      });
+    });
+
+    const routes = [parseRoute(`api.anthropic.com/v1/messages*=http://127.0.0.1:${port}`)];
+    const warpHandlers = createWarpHandlers({
+      routes,
+      ca,
+      onDivert: () => {
+        divertCount++;
+      },
+    });
+
+    testServer.on('request', (req, res) => {
+      if (req.url && (req.url.startsWith('http://') || req.url.startsWith('https://'))) {
+        warpHandlers.handleAbsoluteForm(req, res);
+        return;
+      }
+      if (req.url?.startsWith('/v1/messages')) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, diverted: true }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    testServer.on('connect', warpHandlers.handleConnect);
+
+    try {
+      const curl = spawn('curl', [
+        '-x',
+        `http://127.0.0.1:${port}`,
+        '--cacert',
+        ca.certPath,
+        '-s',
+        'https://api.anthropic.com/v1/messages',
+      ]);
+
+      let stdout = '';
+      curl.stdout.on('data', (d) => (stdout += d));
+      const code = await new Promise<number>((resolve) => {
+        curl.on('close', (c) => resolve(c ?? 0));
+      });
+
+      expect(code).toBe(0);
+      expect(stdout).toContain('"diverted":true');
+      expect(divertCount).toBeGreaterThanOrEqual(1);
+    } finally {
+      await new Promise<void>((resolve) => testServer.close(() => resolve()));
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### Summary
This PR enables the `CONNECT` forward proxy and absolute-form HTTP handlers directly on pxpipe-proxy's main server (default port 47821) and updates `pxpipe warp` to reuse an already-running pxpipe instance on `127.0.0.1:<port>` when available.

### Problem
1. When running tools with persistent background daemons (such as Claude Code's background supervisor daemon and agents), running `pxpipe warp` spawns a temporary CONNECT proxy on an ephemeral port (`port 0`).
2. The background daemon inherits `HTTP_PROXY=http://127.0.0.1:<ephemeral_port>`.
3. When the foreground `warp` process exits, the ephemeral port stops listening. The long-running daemon and its spawned background workers remain pointing at the dead port, leading to `ECONNREFUSED` / "Connection refused — a firewall or proxy may be blocking it" on subsequent prompts.
4. Multiple concurrent agent sessions each allocated separate ephemeral ports, causing port contention and broken daemon routing.

### Fix
- Attach `handlers.handleConnect` (`server.on('connect', ...)`) and `handlers.handleAbsoluteForm` to the main `createServer` in `src/node.ts`.
- In `createWarpRuntime` (`src/warp/index.ts`), probe `127.0.0.1:${port}` before starting an ephemeral listener; if the proxy is already running on that port, reuse it directly.
- Added automated integration test (`tests/warp-connect.test.ts`) validating HTTPS CONNECT proxy tunneling and local route diversion.