### PR TITLE
fix(google): guard null parts in planGoogleHistory user-turn scan

### DIFF
--- a/src/core/google.ts
+++ b/src/core/google.ts
@@ -492,7 +492,7 @@ async function planGoogleHistory(
   const userTurns: number[] = [];
   for (let i = 0; i < contents.length; i++) {
     const c = contents[i];
-    if (c?.role === 'user' && Array.isArray(c.parts) && c.parts.some((p) => typeof p.text === 'string' && p.text.trim())) {
+    if (c?.role === 'user' && Array.isArray(c.parts) && c.parts.some((p) => p && typeof p.text === 'string' && p.text.trim())) {
       userTurns.push(i);
     }
   }

--- a/tests/google.test.ts
+++ b/tests/google.test.ts
@@ -485,6 +485,10 @@ describe('transformGoogleGenerateContent', () => {
     '42',
     JSON.stringify({ systemInstruction: { parts: 'bad' } }),
     JSON.stringify({ systemInstruction: { parts: [null] } }),
+    // A null element inside a contents turn's parts must not throw in
+    // planGoogleHistory's user-turn scan — it passes through like any other
+    // malformed shape rather than 502-ing the request.
+    JSON.stringify({ contents: [{ role: 'user', parts: [null] }] }),
     JSON.stringify({ systemInstruction: { parts: [{ text: 'x'.repeat(10000) }] }, contents: 'bad' }),
   ])('passes unsupported request shape through unchanged: %s', async (raw) => {
     const bytes = new TextEncoder().encode(raw);


### PR DESCRIPTION
### Problem
`planGoogleHistory` (`src/core/google.ts`) scans `contents` for user turns:

```ts
c.parts.some((p) => typeof p.text === 'string' && p.text.trim())
```

`p.text` is dereferenced without guarding `p`. A `null` element inside a `contents` turn's `parts` throws `TypeError: Cannot read properties of null (reading 'text')`. The proxy catches it and returns a **502 "pxpipe transform failed"**, so the whole Gemini request fails instead of being forwarded.

This violates the module's own contract: every other part-iterating function guards null (`googleHistoryUnit`: `if (!part) { … continue }`), and malformed request shapes are supposed to pass through unchanged. The existing test already pins `systemInstruction: { parts: [null] }` as pass-through, but the `contents` path — the one that reaches this scan — was untested.

### Fix
Add the missing `p &&` guard, matching the module's existing null-tolerance:

```ts
c.parts.some((p) => p && typeof p.text === 'string' && p.text.trim())
```

Extended the existing malformed-passthrough test with `{ contents: [{ role: 'user', parts: [null] }] }`. Verified it fails on the old code (`TypeError`) and passes with the fix.

Full suite green (1204/1204); `typecheck` clean.
