### PR TITLE
feat: add OrcaRouter as a first-class provider

### DIFF
--- a/docs/CLAUDE_CODE_PROVIDER_ROUTING.md
+++ b/docs/CLAUDE_CODE_PROVIDER_ROUTING.md
@@ -68,6 +68,32 @@ than 404, confirming the routes exist); the actual model reply was not
 exercised end to end, so treat the routing as reachable but unverified, same
 disclaimer as everything past Kimi K3 above.
 
+### OrcaRouter (Anthropic- and OpenAI-compatible gateway)
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway that
+exposes both Anthropic Messages and OpenAI Responses/Chat Completions on one
+`https://api.orcarouter.ai/v1` namespace, so pxpipe can route either wire shape
+through it without translation. It is a first-class named provider: set
+`PXPIPE_PROVIDER=orcarouter` and both API families resolve to the same base.
+
+```bash
+PXPIPE_PROVIDER=orcarouter \
+ANTHROPIC_API_KEY=your-orcarouter-key \
+npx pxpipe-proxy
+```
+
+The provider default is `https://api.orcarouter.ai`; override it with
+`PXPIPE_GATEWAY_BASE_URL` if you self-host a gateway. With Claude Code, point
+`ANTHROPIC_BASE_URL` at the proxy and use an `anthropic/...` model ID from the
+OrcaRouter catalog (for example `anthropic/claude-fable-5`) so pxpipe applies
+its image compression, or an `orcarouter/...` model ID to pass through:
+
+```bash
+ANTHROPIC_BASE_URL=http://127.0.0.1:47821 \
+ANTHROPIC_AUTH_TOKEN=local-pxpipe \
+claude --model anthropic/claude-fable-5
+```
+
 ## Connect Claude Code
 
 ```bash

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -28,8 +28,10 @@ import { resolveGptProfile } from './gpt-model-profiles.js';
 
 export interface ProxyConfig {
   /** 'cloudflare-ai-gateway': routes both families through gatewayBaseUrl;
-   *  OpenAI paths drop the `/v1` prefix to match gateway shape. */
-  provider?: 'cloudflare-ai-gateway';
+   *  OpenAI paths drop the `/v1` prefix to match gateway shape.
+   *  'orcarouter': routes both families through OrcaRouter's OpenAI/Anthropic-
+   *  compatible gateway at https://api.orcarouter.ai (or gatewayBaseUrl). */
+  provider?: 'cloudflare-ai-gateway' | 'orcarouter';
   /** Gateway base URL (account/gateway-scoped). Required when provider is set. */
   gatewayBaseUrl?: string;
   /** Extra headers injected on every upstream request (e.g. gateway auth). */
@@ -1054,6 +1056,7 @@ function teeForUsage(
 
 const DEFAULT_UPSTREAM = 'https://api.anthropic.com';
 const DEFAULT_OPENAI_UPSTREAM = 'https://api.openai.com';
+const DEFAULT_ORCAROUTER_UPSTREAM = 'https://api.orcarouter.ai';
 
 /** Headers we strip on the way out — they're hop-by-hop or proxy-injected. */
 const STRIP_REQ_HEADERS = new Set([
@@ -1341,6 +1344,13 @@ export function resolveUpstreams(config: ProxyConfig): {
     }
     return { anthropic: `${base}/anthropic`, openai: `${base}/openai`, stripOpenAIV1: true };
   }
+  if (config.provider === 'orcarouter') {
+    // OrcaRouter exposes every wire protocol under one standard `/v1` namespace
+    // (Anthropic Messages, OpenAI Responses and Chat Completions), so both
+    // families resolve to the same base and keep their `/v1` path segments.
+    const base = (config.gatewayBaseUrl ?? DEFAULT_ORCAROUTER_UPSTREAM).trim().replace(/\/+$/, '');
+    return { anthropic: base, openai: base, stripOpenAIV1: false };
+  }
   return {
     anthropic: (config.upstream ?? DEFAULT_UPSTREAM).trim().replace(/\/+$/, ''),
     openai: (config.openAIUpstream ?? DEFAULT_OPENAI_UPSTREAM).trim().replace(/\/+$/, ''),
@@ -1400,7 +1410,8 @@ export function createProxy(config: ProxyConfig = {}) {
   // (e.g. /openai/*, /google-ai-studio/*) safe from env whitespace — see the
   // JSDoc on resolveUpstreams for the full rationale.
   const passthroughUpstream = config.provider === 'cloudflare-ai-gateway'
-    ? (config.gatewayBaseUrl ?? '').trim().replace(/\/+$/, '')
+    || config.provider === 'orcarouter'
+    ? (config.gatewayBaseUrl ?? DEFAULT_ORCAROUTER_UPSTREAM).trim().replace(/\/+$/, '')
     : upstream;
   const gatewayHeaders = config.gatewayHeaders ?? {};
   const applyGatewayHeaders = (h: Headers): Headers => {

--- a/src/node.ts
+++ b/src/node.ts
@@ -54,7 +54,7 @@ interface RuntimeConfig {
   cloudflareApiKey?: string;
   openAIModels?: string[];
   cloudflareModels?: string[];
-  provider?: 'cloudflare-ai-gateway';
+  provider?: 'cloudflare-ai-gateway' | 'orcarouter';
   gatewayBaseUrl?: string;
   gatewayHeaders?: Record<string, string>;
   eventsFile: string;
@@ -210,9 +210,9 @@ function parseMaxRequestBytes(value: string | undefined): number | undefined {
   return bytes;
 }
 
-function parseProvider(v: string | undefined): 'cloudflare-ai-gateway' | undefined {
+function parseProvider(v: string | undefined): 'cloudflare-ai-gateway' | 'orcarouter' | undefined {
   if (v === undefined || v === '') return undefined;
-  if (v === 'cloudflare-ai-gateway') return v;
+  if (v === 'cloudflare-ai-gateway' || v === 'orcarouter') return v;
   console.error(`[pxpipe] unknown PXPIPE_PROVIDER: ${v}`);
   process.exit(2);
 }
@@ -263,9 +263,10 @@ Environment:
   CLOUDFLARE_MODELS       comma-separated exact model ids routed to Cloudflare
   CLOUDFLARE_ACCOUNT_ID   with CLOUDFLARE_API_TOKEN, zero-config Cloudflare
   CLOUDFLARE_API_TOKEN    Workers AI endpoint and bearer token
-  PXPIPE_PROVIDER         optional: 'cloudflare-ai-gateway' — route both API
-                          families through one gateway base URL
-  PXPIPE_GATEWAY_BASE_URL gateway base URL (required with PXPIPE_PROVIDER)
+  PXPIPE_PROVIDER         optional: 'cloudflare-ai-gateway' or 'orcarouter' — route
+                          both API families through one gateway base URL
+  PXPIPE_GATEWAY_BASE_URL gateway base URL (optional with PXPIPE_PROVIDER;
+                          orcarouter defaults to https://api.orcarouter.ai)
   PXPIPE_GATEWAY_HEADERS  extra upstream headers: JSON object or k=v;k2=v2
   PXPIPE_MODELS           comma-separated model bases to image (Claude/Gemini/GPT/Grok);
                           default claude-fable-5,gemini-3.6-flash,gemini-3.7-flash (Sol/Opus/GPT-5.5/Grok opt-in);

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -1,6 +1,6 @@
 /**
- * Cloudflare AI Gateway provider mode. All URLs and tokens here are fake —
- * the suite never touches the network (global fetch is stubbed).
+ * Cloudflare AI Gateway and OrcaRouter provider modes. All URLs and tokens
+ * here are fake — the suite never touches the network (global fetch is stubbed).
  */
 import { afterEach, describe, expect, it } from 'vitest';
 import { createProxy, parseGatewayHeaders, resolveUpstreams } from '../src/core/proxy.js';
@@ -35,6 +35,23 @@ describe('resolveUpstreams', () => {
     expect(() => resolveUpstreams({ provider: 'cloudflare-ai-gateway' })).toThrow(
       /gatewayBaseUrl/,
     );
+  });
+
+  it('routes orcarouter through the default OrcaRouter base with /v1 kept', () => {
+    expect(resolveUpstreams({ provider: 'orcarouter' })).toEqual({
+      anthropic: 'https://api.orcarouter.ai',
+      openai: 'https://api.orcarouter.ai',
+      stripOpenAIV1: false,
+    });
+  });
+
+  it('honors a gatewayBaseUrl override for orcarouter', () => {
+    expect(resolveUpstreams({ provider: 'orcarouter', gatewayBaseUrl: 'https://orca.example.test' }))
+      .toEqual({
+        anthropic: 'https://orca.example.test',
+        openai: 'https://orca.example.test',
+        stripOpenAIV1: false,
+      });
   });
 });
 
@@ -168,6 +185,57 @@ describe('gateway end-to-end routing (stubbed fetch)', () => {
     );
     expect(await res.text()).toBe(sse);
     expect(res.headers.get('content-type')).toBe('text/event-stream');
+  });
+});
+
+describe('orcarouter end-to-end routing (stubbed fetch)', () => {
+  const proxy = () =>
+    createProxy({
+      provider: 'orcarouter',
+      gatewayHeaders: { 'x-orca-extra': '1' },
+    });
+
+  it('routes Anthropic /v1/messages to the orcarouter /v1 namespace', async () => {
+    const cap: { url?: string; headers?: Headers } = {};
+    stubFetch(cap);
+    const res = await proxy()(
+      new Request('http://localhost/v1/messages', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': 'fake-anthropic-key' },
+        body: JSON.stringify({ model: 'claude-fable-5', max_tokens: 1, messages: [{ role: 'user', content: 'hi' }] }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(cap.url).toBe('https://api.orcarouter.ai/v1/messages');
+    expect(cap.headers?.get('x-orca-extra')).toBe('1');
+    expect(cap.headers?.get('x-api-key')).toBe('fake-anthropic-key');
+  });
+
+  it('routes OpenAI /v1/responses to the orcarouter /v1 namespace keeping /v1', async () => {
+    const cap: { url?: string; headers?: Headers } = {};
+    stubFetch(cap);
+    await proxy()(
+      new Request('http://localhost/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer fake-openai-key' },
+        body: JSON.stringify({ model: 'gpt-fake', input: 'hi' }),
+      }),
+    );
+    expect(cap.url).toBe('https://api.orcarouter.ai/v1/responses');
+    expect(cap.headers?.get('x-orca-extra')).toBe('1');
+  });
+
+  it('routes OpenAI /v1/chat/completions to the orcarouter /v1 namespace keeping /v1', async () => {
+    const cap: { url?: string; headers?: Headers } = {};
+    stubFetch(cap);
+    await proxy()(
+      new Request('http://localhost/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer fake-openai-key' },
+        body: JSON.stringify({ model: 'gpt-fake', messages: [{ role: 'user', content: 'hi' }] }),
+      }),
+    );
+    expect(cap.url).toBe('https://api.orcarouter.ai/v1/chat/completions');
   });
 });
 


### PR DESCRIPTION
## What breaks without this

pxpipe's token-saving proxy already ships a named-provider slot (`PXPIPE_PROVIDER=cloudflare-ai-gateway`) for routing both API families through one OpenAI-compatible gateway, but there is no first-class entry for [OrcaRouter](https://www.orcarouter.ai). OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents: like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Users who point pxpipe at OrcaRouter today have to treat it as an anonymous custom base URL; this PR makes it a named provider so the whole stack is reachable without hand-rolled `OPENAI_UPSTREAM`/`ANTHROPIC_UPSTREAM` overrides.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## The change

`PXPIPE_PROVIDER=orcarouter` routes both API families to OrcaRouter's single `https://api.orcarouter.ai` namespace, fully parallel to how `cloudflare-ai-gateway` is wired today. OrcaRouter speaks Anthropic Messages, OpenAI Responses, and OpenAI Chat Completions under one `/v1` root (unlike Cloudflare's split `/anthropic` + `/openai` gateway shape), so the only real difference from the Cloudflare branch is that `/v1` is kept rather than stripped.

File-by-file correspondence:

| file | what changed |
| --- | --- |
| `src/core/proxy.ts` | `ProxyConfig.provider` union gains `'orcarouter'`; `resolveUpstreams()` gains the OrcaRouter branch (both families → same base, `stripOpenAIV1: false`); `passthroughUpstream` falls back to the new `DEFAULT_ORCAROUTER_UPSTREAM` (`https://api.orcarouter.ai`) when no `PXPIPE_GATEWAY_BASE_URL` is set. |
| `src/node.ts` | `RuntimeConfig.provider` and `parseProvider()` accept `'orcarouter'`; help text documents it, noting `PXPIPE_GATEWAY_BASE_URL` is now optional (OrcaRouter has a default base). |
| `tests/gateway.test.ts` | Mirrors the existing Cloudflare `resolveUpstreams` + end-to-end routing tests for `orcarouter` (default base, base override, `/v1` kept on Anthropic Messages / OpenAI Responses / Chat Completions). |
| `docs/CLAUDE_CODE_PROVIDER_ROUTING.md` | New "OrcaRouter" subsection beside the Cloudflare/Novita examples, with the env-var setup and Claude Code usage. |

## Verify

```text
pnpm run typecheck   # passes
pnpm run audit       # No known vulnerabilities found
pnpm exec vitest run tests/gateway.test.ts  # 18 passed (5 new orcarouter tests)

# L3 live test — real request through the proxy to api.orcarouter.ai:
#   PXPIPE_PROVIDER=orcarouter ANTHROPIC_API_KEY=… node bin/cli.js
#   POST /v1/messages      → 200 (model: claude-fable-5)
#   POST /v1/chat/completions → 200
#   proxy log: anthropic upstream → https://api.orcarouter.ai
#              openai upstream    → https://api.orcarouter.ai
```

- [ ] Rebased on current `main`
- [ ] `pnpm test` and `pnpm typecheck` pass (the one local failure — `restart.test.ts`, "reads the real process table" — is an environment artifact: this container has no `ps`, so `listProcesses()` returns `[]`; it passes on CI's ubuntu-24.04)
- [ ] No raw prompts, credentials, session files, or machine identifiers

---

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
