### PR TITLE
fix(history): tolerate non-array message content in blocksToText

### DIFF
--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -279,6 +279,10 @@ export function staleFreshnessHints(text: string): string {
  */
 export function blocksToText(content: string | ContentBlock[]): string {
   if (typeof content === 'string') return content;
+  // Untrusted bodies can carry a non-array content (e.g. `content: null`).
+  // Tolerate it like every sibling serializer/scanner here rather than letting
+  // `for...of` throw and 502 the whole request.
+  if (!Array.isArray(content)) return '';
   const parts: string[] = [];
   for (const blk of content) {
     if (!blk || typeof blk !== 'object') continue;

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -134,6 +134,13 @@ describe('blocksToText', () => {
     expect(blocksToText('hello world')).toBe('hello world');
   });
 
+  it('tolerates non-array content (null/undefined) instead of throwing', () => {
+    // Untrusted bodies can send `content: null`; blocksToText must pass it
+    // through as empty like its sibling serializers, not 502 the request.
+    expect(blocksToText(null as unknown as string)).toBe('');
+    expect(blocksToText(undefined as unknown as string)).toBe('');
+  });
+
   it('joins text blocks with double newline', () => {
     expect(
       blocksToText([


### PR DESCRIPTION
### Problem
`blocksToText` (`src/core/history.ts`) handles the `string` case, then does:

```ts
for (const blk of content) {
```

assuming an array. An untrusted request body can carry a non-array `content` (e.g. `{"role":"assistant","content":null}`), and `for...of null` throws `TypeError: content is not iterable`.

The collapse path reaches this with raw, unvalidated content: `messagesToHistorySegments` calls `blocksToText(m.content)` for assistant turns (and via `withoutTypedUserText`, which returns `null` unchanged, for user turns), and `req.messages` is only checked with an outer `Array.isArray` — individual `content` fields are never validated. The throw propagates out of `transformRequest` and is turned into a **502 "pxpipe transform failed"** at the proxy, so one malformed turn fails the whole request.

Every sibling in the module already guards exactly this shape and passes it through: `findClosedPrefixBoundary`, `withoutTypedUserText`, `splitUserTyped`, `messageCacheControl` (and the OpenAI-path twin `chatContentToText`). `blocksToText` was the lone exception.

### Fix
Add the same `!Array.isArray(content)` guard, returning `''` — a malformed turn serializes to empty and passes through instead of 502ing.

Added a unit test (`blocksToText(null)` / `undefined`), verified it throws on the old code and passes with the fix.

Full suite green (1207/1207); `typecheck` clean.
