### PR TITLE
fix(pin): guard null content block in isPinReply

### DIFF
--- a/src/core/pin.ts
+++ b/src/core/pin.ts
@@ -378,8 +378,9 @@ function isPinReply(m: Message | undefined): boolean {
   const blocks = Array.isArray(m.content) ? m.content : [];
   if (typeof m.content === 'string') return m.content.startsWith(PIN_REPLY_MARK);
   if (blocks.length !== 1) return false;
-  const blk = blocks[0]!;
-  return (blk as { type?: string }).type === 'text'
+  const blk = blocks[0];
+  return !!blk && typeof blk === 'object'
+    && (blk as { type?: string }).type === 'text'
     && typeof (blk as TextBlock).text === 'string'
     && (blk as TextBlock).text.startsWith(PIN_REPLY_MARK);
 }

--- a/tests/pin.test.ts
+++ b/tests/pin.test.ts
@@ -206,6 +206,19 @@ describe('Claude Code path is unaffected', () => {
   });
 });
 
+describe('stripPinCommands: malformed input', () => {
+  it('does not throw on a null assistant content block after a pin command', () => {
+    // A null block passes isPinReply's length check; without the element guard
+    // (that every sibling has) blocks[0].type throws, silently disabling pinning
+    // for the whole request instead of passing the malformed turn through.
+    const messages: Message[] = [
+      { role: 'user', content: '@pxpipe pin be concise' },
+      { role: 'assistant', content: [null as unknown as TextBlock] },
+    ];
+    expect(() => stripPinCommands(messages)).not.toThrow();
+  });
+});
+
 describe('emission', () => {
   it('renders file pins unbulleted, preserving the user’s own markdown', () => {
     // Pinning is per line and opt-in: unmarked prose stays in the file, and a


### PR DESCRIPTION
### Problem
`isPinReply` (`src/core/pin.ts`) took the sole content block after a length check and read `.type` without guarding it:

```ts
const blk = blocks[0]!;
return (blk as { type?: string }).type === 'text' && ...
```

A `null` content block (e.g. `{"role":"assistant","content":[null]}` following a `@pxpipe pin …` command turn — the only path that evaluates `isPinReply`) passes the `length !== 1` check, and `blocks[0]!.type` throws `TypeError: Cannot read properties of null (reading 'type')`.

The throw is caught at the pin call site, so it doesn't 500 — instead the whole pin feature **silently no-ops** for that request: the raw `@pxpipe pin …` command lines stay in the outbound body (forwarded to the model) and the user's pinned rules are not re-emitted at the tail.

Every sibling that walks content blocks in this module guards this first (`isCommandOnlyTurn`, `pinLines`, `systemPinLines`, `stripFromMessage` all do `if (!blk || typeof blk !== 'object')`). `isPinReply` was the exception.

### Fix
Add the same `!!blk && typeof blk === 'object'` guard, so a malformed turn is simply not treated as a pin reply.

Added a regression test (`stripPinCommands` with a null assistant block after a pin command) — it throws on the old code and passes with the fix.

Full suite green (1207/1207); `typecheck` clean.
