### PR TITLE
fix(chat-bridge): keep index-less streamed tool-call fragments in one block

### DIFF
--- a/src/core/messages-chat-bridge.ts
+++ b/src/core/messages-chat-bridge.ts
@@ -361,6 +361,10 @@ interface StreamState {
   usage?: JsonObject;
   // OpenAI tool_calls stream by their own `index`; map it to our block state.
   calls: Map<number, StreamCall>;
+  // Key of the most recently seen tool call, so index-less continuation
+  // fragments (providers that don't repeat `index`) append to the open call
+  // instead of opening a spurious new block.
+  lastToolKey?: number;
 }
 
 function chatStreamEvent(chunk: JsonObject, state: StreamState): string {
@@ -411,8 +415,20 @@ function chatStreamEvent(chunk: JsonObject, state: StreamState): string {
     for (const raw of delta.tool_calls) {
       const tc = object(raw);
       if (!tc) continue;
-      const key = typeof tc.index === 'number' ? tc.index : state.calls.size;
       const fn = object(tc.function) ?? {};
+      // Some OpenAI-compatible providers omit `index` on tool-call deltas.
+      // A new call is signaled by an id/name; an args-only fragment continues
+      // the most recent call. Keying index-less continuations by calls.size
+      // would split them into spurious new tool_use blocks.
+      let key: number;
+      if (typeof tc.index === 'number') {
+        key = tc.index;
+      } else if (typeof tc.id === 'string' || typeof fn.name === 'string' || state.calls.size === 0) {
+        key = state.calls.size; // opens a new call
+      } else {
+        key = state.lastToolKey ?? 0; // args-only continuation
+      }
+      state.lastToolKey = key;
       let call = state.calls.get(key);
       if (!call) {
         closeText();

--- a/tests/chat-bridge.test.ts
+++ b/tests/chat-bridge.test.ts
@@ -489,6 +489,32 @@ describe('openAIChatStreamToAnthropic — SSE translation', () => {
     expect(text).toContain('event: error');
     expect(text).toContain('api_error');
   });
+
+  it('keeps index-less tool-call argument fragments in one tool_use block', async () => {
+    // Some OpenAI-compatible providers omit `index` on tool-call deltas and
+    // split arguments across chunks. A new call is signaled by id/name; the
+    // args-only continuation must append to the same block, not open a second.
+    const text = await collect([
+      'data: {"id":"chatcmpl-1","choices":[{"delta":{"tool_calls":[{"id":"call_1","function":{"name":"search","arguments":"{\\"q\\":"}}]}}]}\n\n',
+      'data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\\"cats\\"}"}}]}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+    const events = text.split('\n\n').filter(Boolean).map((block) => {
+      const line = block.split('\n').find((l) => l.startsWith('data: '))!;
+      return JSON.parse(line.slice(6)) as any;
+    });
+    const toolStarts = events.filter(
+      (e) => e.type === 'content_block_start' && e.content_block?.type === 'tool_use',
+    );
+    expect(toolStarts).toHaveLength(1); // one block, not split into two
+    expect(toolStarts[0].content_block.name).toBe('search');
+    const args = events
+      .filter((e) => e.type === 'content_block_delta' && e.delta?.type === 'input_json_delta')
+      .map((e) => e.delta.partial_json)
+      .join('');
+    expect(args).toBe('{"q":"cats"}'); // fragments concatenate to valid JSON
+  });
 });
 
 describe('anthropicMessagesToOpenAIChat — model override', () => {


### PR DESCRIPTION
### Problem
The Chat Completions SSE translator (`chatStreamEvent` in `messages-chat-bridge.ts`) keyed streamed tool-call deltas by:

```ts
const key = typeof tc.index === 'number' ? tc.index : state.calls.size;
```

Some OpenAI-compatible upstreams — the arbitrary providers this bridge exists to support (Cloudflare Workers AI, Kimi, etc.) — omit `index` on tool-call deltas and split a single call's `arguments` across chunks. With `index` absent, each continuation fragment was keyed by the growing `calls.size`, so `calls.get(key)` missed and a **new** `tool_use` block was opened per fragment.

Result for a two-chunk `{"q":` + `"cats"}` call: a first block with truncated, invalid JSON plus a spurious second block with an empty name and duplicate id — instead of one `tool_use` with `{"q":"cats"}`. The entire streamed-tool-call branch was untested.

### Fix
Disambiguate the way the OpenAI stream shape already signals it: a delta carrying an `id` or `name` opens a new call; an args-only delta continues the most recent call (tracked via a new `lastToolKey` on the stream state). Strictly-conformant streams that always send `index` take the unchanged path.

Added a streaming regression test (index-less, split-arguments) — it opens two blocks on the old code and one on the fix.

Full suite green (1207/1207); `typecheck` clean.
