### PR TITLE
feat(google): support Cloud Code /v1internal:*generateContent (Antigravity, Gemini CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to pxpipe are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) (pre-1.0: minor = features /
 behavioral changes, patch = fixes).
 
+## Unreleased
+
+### Added
+- Cloud Code internal API route: `POST /v1internal:generateContent` and
+  `:streamGenerateContent` (Antigravity, Gemini CLI, Gemini Code Assist) are
+  now transformed like Google AI Studio requests. The body is a
+  `{ model, project, request: {...} }` envelope (`generateContentRequest` is
+  also accepted); the inner request is compressed and the envelope is kept
+  byte-for-byte. Forwards to `https://cloudcode-pa.googleapis.com` by default,
+  override with `GOOGLE_UPSTREAM` (or `googleUpstream` in `ProxyConfig`). The
+  client's own OAuth bearer is forwarded; the Anthropic key is never injected
+  on this route. No upstream countTokens probe: the local profitability gate
+  decides.
+
 ## 0.13.2 — 2026-08-18
 
 ### Added

--- a/src/core/google.ts
+++ b/src/core/google.ts
@@ -68,10 +68,52 @@ export interface GoogleGenerateContentRequest {
 }
 
 const GOOGLE_ROUTE = /^\/google-ai-studio\/(?:v1|v1beta)\/models\/([^/:]+):(generateContent|streamGenerateContent)$/;
+/** Cloud Code internal API (Antigravity, Gemini CLI, Gemini Code Assist):
+ *  `POST /v1internal:streamGenerateContent` on cloudcode-pa.googleapis.com. The
+ *  model is not in the path; it lives in the body next to a wrapped request. */
+const GOOGLE_INTERNAL_ROUTE = /^(?:\/[a-z0-9][a-z0-9._-]*)?\/v1internal:(generateContent|streamGenerateContent)$/;
+
+/** Wrapper keys the Cloud Code API and countTokens use around a generateContent body. */
+const GOOGLE_WRAPPER_KEYS = ['request', 'generateContentRequest'] as const;
 
 export function parseGoogleModelFromPath(pathname: string): string | null {
   const match = GOOGLE_ROUTE.exec(pathname);
   return match && match[1] ? match[1] : null;
+}
+
+export function isGoogleInternalPath(pathname: string): boolean {
+  return GOOGLE_INTERNAL_ROUTE.test(pathname);
+}
+
+/** Unwrap a Cloud Code envelope: `{ model, project, request: {...} }`. Returns the
+ *  wrapper key and inner request, or null when the body is a bare request. */
+export function unwrapGoogleRequest(
+  body: Record<string, unknown>,
+): { key: string; inner: Record<string, unknown> } | null {
+  if (Array.isArray(body.contents)) return null;
+  for (const key of GOOGLE_WRAPPER_KEYS) {
+    const inner = body[key];
+    if (inner && typeof inner === 'object' && !Array.isArray(inner)) {
+      return { key, inner: inner as Record<string, unknown> };
+    }
+  }
+  return null;
+}
+
+/** Model id for an internal-route body: top-level `model`, else the wrapped one. */
+export function readGoogleInternalModel(bodyBytes: Uint8Array): string | null {
+  let body: Record<string, unknown> | null;
+  try {
+    body = record(JSON.parse(new TextDecoder().decode(bodyBytes)));
+  } catch {
+    return null;
+  }
+  if (!body) return null;
+  const wrapped = unwrapGoogleRequest(body);
+  for (const candidate of [body.model, wrapped?.inner.model]) {
+    if (typeof candidate === 'string' && candidate.length <= 200) return candidate;
+  }
+  return null;
 }
 
 const SYSTEM_POINTER =
@@ -654,6 +696,18 @@ export async function transformGoogleGenerateContent(
   const reqRecord = record(parsed);
   if (!reqRecord) {
     return { body: bodyBytes, info: createDefaultInfo(modelName) };
+  }
+  const wrapped = unwrapGoogleRequest(reqRecord);
+  if (wrapped) {
+    // Cloud Code envelope: transform the inner request, put it back in place.
+    const innerBytes = new TextEncoder().encode(JSON.stringify(wrapped.inner));
+    const result = await transformGoogleGenerateContent(innerBytes, modelName, options);
+    if (result.body === innerBytes) return { body: bodyBytes, info: result.info };
+    const innerOut: unknown = JSON.parse(new TextDecoder().decode(result.body));
+    return {
+      body: new TextEncoder().encode(JSON.stringify({ ...reqRecord, [wrapped.key]: innerOut })),
+      info: result.info,
+    };
   }
   const req = reqRecord as GoogleGenerateContentRequest;
 

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -22,7 +22,12 @@ import {
   openAIChatToAnthropicResponse,
 } from './messages-chat-bridge.js';
 import { pinCommandResponse, pinCommandResponseOpenAI } from './pin.js';
-import { parseGoogleModelFromPath, transformGoogleGenerateContent } from './google.js';
+import {
+  isGoogleInternalPath,
+  parseGoogleModelFromPath,
+  readGoogleInternalModel,
+  transformGoogleGenerateContent,
+} from './google.js';
 import { isGeminiModel } from './gemini-model-profiles.js';
 import { resolveGptProfile } from './gpt-model-profiles.js';
 
@@ -45,6 +50,9 @@ export interface ProxyConfig {
   authToken?: string | (() => string | undefined);
   /** OpenAI API base for GPT chat completions, no trailing slash. */
   openAIUpstream?: string;
+  /** Cloud Code internal API base for `/v1internal:*generateContent` (Antigravity,
+   *  Gemini CLI), no trailing slash. Defaults to cloudcode-pa.googleapis.com. */
+  googleUpstream?: string;
   /** Override or supply an OpenAI API key. If unset, we forward Authorization. */
   openAIApiKey?: string;
   /** Cloudflare's OpenAI-compatible Chat Completions endpoint and bearer key. */
@@ -1054,6 +1062,7 @@ function teeForUsage(
 
 const DEFAULT_UPSTREAM = 'https://api.anthropic.com';
 const DEFAULT_OPENAI_UPSTREAM = 'https://api.openai.com';
+const DEFAULT_GOOGLE_INTERNAL_UPSTREAM = 'https://cloudcode-pa.googleapis.com';
 
 /** Headers we strip on the way out — they're hop-by-hop or proxy-injected. */
 const STRIP_REQ_HEADERS = new Set([
@@ -1402,6 +1411,8 @@ export function createProxy(config: ProxyConfig = {}) {
   const passthroughUpstream = config.provider === 'cloudflare-ai-gateway'
     ? (config.gatewayBaseUrl ?? '').trim().replace(/\/+$/, '')
     : upstream;
+  const googleInternalUpstream = (config.googleUpstream ?? DEFAULT_GOOGLE_INTERNAL_UPSTREAM)
+    .trim().replace(/\/+$/, '');
   const gatewayHeaders = config.gatewayHeaders ?? {};
   const applyGatewayHeaders = (h: Headers): Headers => {
     for (const [k, v] of Object.entries(gatewayHeaders)) h.set(k, v);
@@ -1559,16 +1570,19 @@ let responseContentType: string | undefined;
     const googleModel = req.method === 'POST'
       ? parseGoogleModelFromPath(url.pathname)
       : null;
-    const isGoogleRoute = googleModel !== null;
+    const isGoogleInternal = req.method === 'POST' && isGoogleInternalPath(url.pathname);
+    const isGoogleRoute = googleModel !== null || isGoogleInternal;
     const isGoogle = isGoogleRoute && !bypass;
     const isOpenAIPath = isCanonicalOpenAIPath(
       url.pathname,
       req.headers,
       config.openAIApiKey !== undefined,
     );
-    const upstreamBase = isGoogleRoute || providerPrefixed
-      ? passthroughUpstream
-      : isOpenAIPath ? openAIUpstream : upstream;
+    const upstreamBase = isGoogleInternal
+      ? googleInternalUpstream
+      : isGoogleRoute || providerPrefixed
+        ? passthroughUpstream
+        : isOpenAIPath ? openAIUpstream : upstream;
 
     let bodyOut: BodyInit | null = null;
     let info: TransformInfo | undefined;
@@ -1619,7 +1633,8 @@ let responseContentType: string | undefined;
         const transformOpts =
           typeof config.transform === 'function' ? config.transform() : config.transform;
         // Fail-closed: unreadable model → no compression, not a risky guess.
-const model = googleModel ?? readModelField(bodyIn);
+        const model = googleModel
+          ?? (isGoogleInternal ? readGoogleInternalModel(bodyIn) : readModelField(bodyIn));
         if (isOpenAIResponses) responsesStreaming = readStreamField(bodyIn);
         requestModel = model ?? undefined;
         // A turn whose only content is `@pxpipe pin` / `@pxpipe unpin` is
@@ -1706,7 +1721,9 @@ const model = googleModel ?? readModelField(bodyIn);
               ? await transformOpenAIChatCompletions(bodyIn, effectiveOpts)
               : await transformOpenAIResponses(bodyIn, effectiveOpts);
         transformMs = Date.now() - tTransform;
-        if (isGoogle && r.info.compressed) {
+        // The Cloud Code internal API has no public countTokens shape worth
+        // probing; keep the local profitability decision there.
+        if (isGoogle && !isGoogleInternal && r.info.compressed) {
           const countHeaders = applyGatewayHeaders(filterHeaders(req.headers, STRIP_REQ_HEADERS));
           countHeaders.set('content-type', 'application/json');
           const countUrl = new URL(
@@ -1880,6 +1897,9 @@ const model = googleModel ?? readModelField(bodyIn);
         else if (decision.action === 'replace') outHeaders.set('authorization', `Bearer ${bridgeKey}`);
         // 'keep-inbound' leaves the header filterHeaders already copied.
       }
+    } else if (isGoogleInternal) {
+      // Cloud Code takes the client's own OAuth bearer; never an Anthropic key.
+      outHeaders.delete('x-api-key');
     } else if (!providerPrefixed || url.pathname.startsWith('/anthropic/')) {
       if (config.apiKey) outHeaders.set('x-api-key', config.apiKey);
       const bearer = resolveAuthToken(config);

--- a/src/node.ts
+++ b/src/node.ts
@@ -48,6 +48,7 @@ interface RuntimeConfig {
   host: string;
   upstream: string;
   openAIUpstream: string;
+  googleUpstream?: string;
   openAIApiKey?: string;
   /** Independent Cloudflare OpenAI-compatible endpoint. */
   cloudflareUpstream?: string;
@@ -178,6 +179,7 @@ function parseCli(argv: string[]): RuntimeConfig {
     host: process.env.HOST?.trim() || '127.0.0.1',
     upstream: process.env.ANTHROPIC_UPSTREAM ?? sharedUpstream ?? 'https://api.anthropic.com',
     openAIUpstream: process.env.OPENAI_UPSTREAM ?? sharedUpstream ?? 'https://api.openai.com',
+    googleUpstream: process.env.GOOGLE_UPSTREAM ?? sharedUpstream,
     openAIApiKey: process.env.OPENAI_API_KEY,
     cloudflareUpstream,
     cloudflareApiKey: cfToken,
@@ -257,6 +259,9 @@ Environment:
                            (default https://api.anthropic.com)
   OPENAI_UPSTREAM         OpenAI API base; overrides PXPIPE_UPSTREAM
                            (default https://api.openai.com)
+  GOOGLE_UPSTREAM         Cloud Code API base for /v1internal:*generateContent
+                           (Antigravity, Gemini CLI); overrides PXPIPE_UPSTREAM
+                           (default https://cloudcode-pa.googleapis.com)
   OPENAI_API_KEY          optional OpenAI key override; otherwise forwarded
   OPENAI_MODELS           comma-separated exact model ids routed to OpenAI
                           Responses
@@ -1210,6 +1215,7 @@ async function main(): Promise<void> {
     gatewayHeaders: opts.gatewayHeaders,
     upstream: opts.upstream,
     openAIUpstream: opts.openAIUpstream,
+    googleUpstream: opts.googleUpstream,
     openAIApiKey: opts.openAIApiKey,
     cloudflareUpstream: opts.cloudflareUpstream,
     cloudflareApiKey: opts.cloudflareApiKey,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -25,6 +25,7 @@ export interface Env {
   /** Optional override — if set, replaces whatever x-api-key the client sent. */
   ANTHROPIC_API_KEY?: string;
   OPENAI_UPSTREAM?: string;
+  GOOGLE_UPSTREAM?: string;
   /** Optional override — if set, replaces whatever Authorization the client sent. */
   OPENAI_API_KEY?: string;
   OPENAI_MODELS?: string;
@@ -175,6 +176,7 @@ export default {
       upstream: env.ANTHROPIC_UPSTREAM ?? sharedUpstream ?? 'https://api.anthropic.com',
       apiKey: env.ANTHROPIC_API_KEY,
       openAIUpstream: env.OPENAI_UPSTREAM ?? sharedUpstream ?? 'https://api.openai.com',
+      googleUpstream: env.GOOGLE_UPSTREAM ?? sharedUpstream,
       openAIApiKey: env.OPENAI_API_KEY,
       cloudflareUpstream,
       cloudflareApiKey: cfToken,

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -190,6 +190,35 @@ describe('provider-prefixed passthrough routing', () => {
     expect(cap.headers?.get('authorization')).toBe('Bearer local-token');
   });
 
+  it('routes /v1internal:streamGenerateContent to the Cloud Code upstream with the client bearer', async () => {
+    const cap: { url?: string; headers?: Headers } = {};
+    stubFetch(cap);
+    const body = {
+      model: 'gemini-3.6-flash',
+      project: 'p',
+      request: { contents: [{ role: 'user', parts: [{ text: 'hi' }] }] },
+    };
+    await createProxy({ upstream: 'http://gateway.test', apiKey: 'sk-anthropic-test' })(
+      new Request('http://localhost/v1internal:streamGenerateContent?alt=sse', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer oauth-token' },
+        body: JSON.stringify(body),
+      }),
+    );
+    expect(cap.url).toBe('https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse');
+    expect(cap.headers?.get('authorization')).toBe('Bearer oauth-token');
+    expect(cap.headers?.get('x-api-key')).toBeNull();
+
+    await createProxy({ googleUpstream: 'http://cloudcode.test/' })(
+      new Request('http://localhost/v1internal:generateContent', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+    );
+    expect(cap.url).toBe('http://cloudcode.test/v1internal:generateContent');
+  });
+
   it('does not inject the Anthropic API key into non-Anthropic provider prefixes', async () => {
     const cap: { url?: string; headers?: Headers } = {};
     stubFetch(cap);

--- a/tests/google.test.ts
+++ b/tests/google.test.ts
@@ -7,6 +7,8 @@ import {
   transformGoogleGenerateContent,
   parseGoogleModelFromPath,
   normalizeGoogleTurnRoles,
+  isGoogleInternalPath,
+  readGoogleInternalModel,
 } from '../src/core/google.js';
 import { geminiVisionTokens } from '../src/core/gemini-model-profiles.js';
 
@@ -18,6 +20,58 @@ describe('parseGoogleModelFromPath', () => {
     expect(parseGoogleModelFromPath('/foo/google-ai-studio/v1beta/models/gemini-3.6-flash:generateContent')).toBeNull();
     expect(parseGoogleModelFromPath('/google-ai-studio/v1beta/models/gemini-3.6-flash:countTokens')).toBeNull();
     expect(parseGoogleModelFromPath('/v1/messages')).toBeNull();
+  });
+});
+
+describe('Cloud Code internal route (Antigravity / Gemini CLI)', () => {
+  it('matches /v1internal:*generateContent with or without a provider prefix', () => {
+    expect(isGoogleInternalPath('/v1internal:streamGenerateContent')).toBe(true);
+    expect(isGoogleInternalPath('/v1internal:generateContent')).toBe(true);
+    expect(isGoogleInternalPath('/google/v1internal:streamGenerateContent')).toBe(true);
+    expect(isGoogleInternalPath('/v1internal:countTokens')).toBe(false);
+    expect(isGoogleInternalPath('/v1internal:loadCodeAssist')).toBe(false);
+    expect(isGoogleInternalPath('/v1beta/models/gemini-3.6-flash:streamGenerateContent')).toBe(false);
+  });
+
+  it('reads the model from the envelope, then from the wrapped request', () => {
+    const enc = (v: unknown) => new TextEncoder().encode(JSON.stringify(v));
+    expect(readGoogleInternalModel(enc({ model: 'gemini-3.6-flash', project: 'p', request: {} }))).toBe('gemini-3.6-flash');
+    expect(readGoogleInternalModel(enc({ request: { model: 'models/gemini-3.6-flash' } }))).toBe('models/gemini-3.6-flash');
+    expect(readGoogleInternalModel(enc({ contents: [] }))).toBeNull();
+    expect(readGoogleInternalModel(new TextEncoder().encode('nope'))).toBeNull();
+  });
+
+  it('compresses the wrapped request and keeps the envelope intact', async () => {
+    const envelope = {
+      model: 'gemini-3.6-flash',
+      project: 'antigravity-project',
+      user_prompt_id: 'abc',
+      request: {
+        systemInstruction: {
+          parts: [{ text: 'System instruction text testing Google transformer. '.repeat(300) }],
+        },
+        contents: [{ role: 'user', parts: [{ text: 'User question' }] }],
+      },
+    };
+    const result = await transformGoogleGenerateContent(
+      new TextEncoder().encode(JSON.stringify(envelope)),
+      'gemini-3.6-flash',
+      { compress: true },
+    );
+    expect(result.info.compressed).toBe(true);
+    const out = JSON.parse(new TextDecoder().decode(result.body));
+    expect(out.model).toBe('gemini-3.6-flash');
+    expect(out.project).toBe('antigravity-project');
+    expect(out.user_prompt_id).toBe('abc');
+    expect(out.request.systemInstruction.parts[0].text).toContain('same authority');
+    expect(out.request.contents[0].parts[0].inlineData.mimeType).toBe('image/png');
+  });
+
+  it('returns the envelope bytes unchanged when the wrapped request is not transformed', async () => {
+    const raw = JSON.stringify({ model: 'gemini-3.6-flash', request: { contents: [{ role: 'user', parts: [{ text: 'hi' }] }] } });
+    const result = await transformGoogleGenerateContent(new TextEncoder().encode(raw), 'gemini-3.6-flash', { compress: true });
+    expect(result.info.compressed).toBe(false);
+    expect(new TextDecoder().decode(result.body)).toBe(raw);
   });
 });
 


### PR DESCRIPTION
## Summary

Support native Google inference requests rerouted through pxpipe from clients and providers using the Google wire format:

- `/v1/models/{model}:generateContent` and `/v1beta/models/{model}:streamGenerateContent` (both methods on both versions), alongside existing Google AI Studio gateway paths.
- Cloud Code `/v1internal:generateContent` and `:streamGenerateContent`, including `request` and `generateContentRequest` envelopes.
- Preserve Google OAuth/API credentials without injecting Anthropic credentials. Skip Cloud Code countTokens probes.
- `GOOGLE_UPSTREAM` overrides the shared upstream for Google inference; retain explicit Cloudflare gateway routing and daily Cloud Code host detection.
- Merge current main, retaining model opt-out, thought signatures, and Cloud Code response accounting.
- Fix Windows TypeScript build entry resolution using Node path utilities.

This routes Google-format requests; it does not translate OpenAI Responses or Chat Completions payloads into Google payloads.

## Validation

- TypeScript typecheck passed.
- Full Vitest suite: 1,224 tests passed.
- After final upstream-precedence adjustment: 23 routing tests passed.
- Build and bundled CLI version smoke check passed on Windows / Node 24.
- GitHub reports MERGEABLE with no conflicts at e342aeba67531c6c1bbbd49f3546a1cb323796e1.
- GitHub CI requires maintainer approval for this fork: https://github.com/teamchong/pxpipe/actions/runs/34201881084
- Live Google/OAuth requests were not exercised; routing tests use stubbed fetch.
